### PR TITLE
docs: add GitHub Pages documentation with architecture diagrams

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,986 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CoreVideo — OBS Plugin for Live Zoom Video</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --accent: #2f81f7;
+      --accent-dim: #1f6feb;
+      --text: #e6edf3;
+      --muted: #8b949e;
+      --green: #3fb950;
+      --orange: #d29922;
+      --red: #f85149;
+      --purple: #bc8cff;
+      --teal: #39d353;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.7;
+      font-size: 16px;
+    }
+
+    /* ── Layout ── */
+    .layout { display: flex; min-height: 100vh; }
+    nav {
+      position: fixed; top: 0; left: 0; bottom: 0; width: 260px;
+      background: var(--surface); border-right: 1px solid var(--border);
+      padding: 24px 0; overflow-y: auto; z-index: 100;
+    }
+    .nav-logo {
+      padding: 0 20px 20px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 12px;
+    }
+    .nav-logo h1 { font-size: 1.1rem; color: var(--accent); font-weight: 700; }
+    .nav-logo p  { font-size: 0.75rem; color: var(--muted); margin-top: 2px; }
+    nav a {
+      display: block; padding: 6px 20px;
+      color: var(--muted); text-decoration: none; font-size: 0.875rem;
+      border-left: 2px solid transparent; transition: all 0.15s;
+    }
+    nav a:hover, nav a.active { color: var(--text); border-left-color: var(--accent); background: rgba(47,129,247,.08); }
+    .nav-section { padding: 14px 20px 4px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); }
+    main { margin-left: 260px; max-width: 960px; padding: 48px 56px; }
+
+    /* ── Typography ── */
+    h1 { font-size: 2.2rem; font-weight: 800; margin-bottom: 12px; }
+    h2 { font-size: 1.5rem; font-weight: 700; margin: 48px 0 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+    h3 { font-size: 1.1rem; font-weight: 600; margin: 28px 0 10px; color: var(--accent); }
+    h4 { font-size: 0.95rem; font-weight: 600; margin: 20px 0 8px; }
+    p  { margin-bottom: 14px; color: #cdd9e5; }
+    ul, ol { padding-left: 24px; margin-bottom: 14px; color: #cdd9e5; }
+    li { margin-bottom: 6px; }
+    a  { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    strong { color: var(--text); }
+    code {
+      background: #1c2128; border: 1px solid var(--border);
+      border-radius: 4px; padding: 1px 6px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 0.85em; color: #e3b341;
+    }
+    pre {
+      background: #1c2128; border: 1px solid var(--border); border-radius: 8px;
+      padding: 20px; overflow-x: auto; margin: 16px 0;
+    }
+    pre code { background: none; border: none; padding: 0; color: #e6edf3; font-size: 0.875rem; }
+
+    /* ── Hero ── */
+    .hero {
+      background: linear-gradient(135deg, #161b22 0%, #0d1117 60%);
+      border: 1px solid var(--border); border-radius: 12px;
+      padding: 40px; margin-bottom: 40px;
+      position: relative; overflow: hidden;
+    }
+    .hero::before {
+      content: ''; position: absolute; top: -60px; right: -60px;
+      width: 300px; height: 300px; border-radius: 50%;
+      background: radial-gradient(circle, rgba(47,129,247,.15) 0%, transparent 70%);
+    }
+    .hero-badges { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 16px; }
+    .badge {
+      background: #1c2128; border: 1px solid var(--border);
+      border-radius: 20px; padding: 4px 12px;
+      font-size: 0.75rem; font-weight: 600; color: var(--muted);
+    }
+    .badge.blue   { border-color: #1f6feb; color: var(--accent); background: rgba(31,111,235,.12); }
+    .badge.green  { border-color: #238636; color: var(--green);  background: rgba(35,134,54,.12); }
+    .badge.purple { border-color: #6e40c9; color: var(--purple); background: rgba(110,64,201,.12); }
+    .badge.orange { border-color: #9e6a03; color: var(--orange); background: rgba(158,106,3,.12); }
+
+    /* ── Cards ── */
+    .card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin: 20px 0; }
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 10px; padding: 20px;
+      transition: border-color .15s, transform .15s;
+    }
+    .card:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .card-icon { font-size: 1.5rem; margin-bottom: 8px; }
+    .card h4 { margin: 0 0 6px; font-size: 0.9rem; }
+    .card p { font-size: 0.8rem; color: var(--muted); margin: 0; }
+
+    /* ── Diagrams ── */
+    .diagram-wrap {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 10px; padding: 28px; margin: 20px 0; overflow-x: auto;
+    }
+    .diagram-wrap .mermaid { display: flex; justify-content: center; }
+    .diagram-caption { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 12px; font-style: italic; }
+
+    /* ── Tables ── */
+    table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.875rem; }
+    th { background: #1c2128; border: 1px solid var(--border); padding: 10px 14px; text-align: left; font-weight: 600; color: var(--muted); }
+    td { border: 1px solid var(--border); padding: 9px 14px; }
+    tr:nth-child(even) td { background: rgba(255,255,255,.02); }
+
+    /* ── Callouts ── */
+    .callout {
+      border-radius: 8px; padding: 14px 18px; margin: 18px 0;
+      border-left: 4px solid; font-size: 0.9rem;
+    }
+    .callout.info    { background: rgba(47,129,247,.08); border-color: var(--accent); }
+    .callout.warning { background: rgba(210,153,34,.08); border-color: var(--orange); }
+    .callout.tip     { background: rgba(63,185,80,.08);  border-color: var(--green); }
+    .callout-title   { font-weight: 700; margin-bottom: 4px; }
+
+    /* ── Steps ── */
+    .steps { counter-reset: step; }
+    .step { display: flex; gap: 16px; margin-bottom: 20px; }
+    .step::before {
+      counter-increment: step; content: counter(step);
+      min-width: 28px; height: 28px; border-radius: 50%;
+      background: var(--accent); color: #fff;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.8rem; font-weight: 700; flex-shrink: 0; margin-top: 2px;
+    }
+    .step-body h4 { margin-top: 0; color: var(--text); }
+
+    /* ── Section anchor ── */
+    section { scroll-margin-top: 24px; }
+
+    @media (max-width: 768px) {
+      nav { display: none; }
+      main { margin-left: 0; padding: 24px 20px; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ─── Sidebar ─────────────────────────────────────────────────── -->
+<nav id="sidebar">
+  <div class="nav-logo">
+    <h1>📹 CoreVideo</h1>
+    <p>OBS Plugin for Live Zoom Video</p>
+  </div>
+
+  <div class="nav-section">Overview</div>
+  <a href="#overview">Introduction</a>
+  <a href="#features">Features</a>
+  <a href="#requirements">Requirements</a>
+
+  <div class="nav-section">Architecture</div>
+  <a href="#arch-system">System Overview</a>
+  <a href="#arch-components">Plugin Components</a>
+  <a href="#arch-windows">Windows IPC Engine</a>
+  <a href="#arch-video">Video Pipeline</a>
+  <a href="#arch-audio">Audio Pipeline</a>
+
+  <div class="nav-section">Flows</div>
+  <a href="#flow-auth">Authentication Flow</a>
+  <a href="#flow-meeting">Meeting Join Flow</a>
+
+  <div class="nav-section">Reference</div>
+  <a href="#ipc-protocol">IPC Protocol</a>
+  <a href="#installation">Installation</a>
+  <a href="#configuration">Configuration</a>
+  <a href="#build">Building from Source</a>
+</nav>
+
+<!-- ─── Main Content ─────────────────────────────────────────────── -->
+<main>
+
+  <!-- Hero -->
+  <div class="hero">
+    <h1>CoreVideo</h1>
+    <p style="font-size:1.1rem; color:#8b949e; max-width:620px;">
+      An OBS Studio plugin that captures live Zoom meeting video and audio,
+      letting you stream or record any participant directly on your OBS canvas.
+    </p>
+    <div class="hero-badges">
+      <span class="badge blue">C++17</span>
+      <span class="badge blue">CMake 3.16+</span>
+      <span class="badge green">OBS Studio</span>
+      <span class="badge green">Qt 6</span>
+      <span class="badge purple">Zoom Meeting SDK</span>
+      <span class="badge orange">Windows</span>
+      <span class="badge orange">macOS</span>
+    </div>
+  </div>
+
+  <!-- ── Overview ──────────────────────────────────────────────── -->
+  <section id="overview">
+    <h2>Introduction</h2>
+    <p>
+      <strong>CoreVideo</strong> is an OBS Studio plugin that integrates the
+      <strong>Zoom Meeting SDK</strong> to bring raw video and audio frames from
+      a live Zoom meeting directly into OBS. No screen capture or virtual camera is
+      involved — the plugin subscribes to raw I420 video frames and 48 kHz PCM audio
+      from specific meeting participants or the active speaker, then converts and pushes
+      those frames into OBS as a first-class source.
+    </p>
+    <p>
+      On <strong>Windows</strong> the Zoom SDK must run in its own process due to
+      COM apartment and UI-thread constraints. A companion executable
+      (<code>ZoomObsEngine.exe</code>) hosts the SDK and communicates back to the
+      plugin via JSON over named pipes and shared memory for frame data.
+      On <strong>macOS</strong> the SDK is loaded directly in-process.
+    </p>
+  </section>
+
+  <!-- ── Features ─────────────────────────────────────────────── -->
+  <section id="features">
+    <h2>Features</h2>
+    <div class="card-grid">
+      <div class="card">
+        <div class="card-icon">🎥</div>
+        <h4>Raw Video Capture</h4>
+        <p>I420 YUV frames from the Zoom SDK converted to BGRA for OBS textures.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">🎙️</div>
+        <h4>Raw Audio Capture</h4>
+        <p>48 kHz PCM audio with configurable mono/stereo mixing modes.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">👥</div>
+        <h4>Participant Roster</h4>
+        <p>Track all meeting participants with active-speaker detection.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">🔄</div>
+        <h4>Auto-Follow Speaker</h4>
+        <p>Optionally follow the active speaker instead of a fixed participant.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">🔒</div>
+        <h4>JWT Authentication</h4>
+        <p>Authenticates with the Zoom SDK using your SDK key, secret, and JWT token.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">⚙️</div>
+        <h4>Settings Dialog</h4>
+        <p>Qt GUI dialog for credential management, accessible from OBS Tools menu.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">🖥️</div>
+        <h4>Multi-Platform</h4>
+        <p>Windows (x64) and macOS (universal arm64 + x86_64) support.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">🔗</div>
+        <h4>IPC Engine (Windows)</h4>
+        <p>Separate engine process communicates via named pipes for SDK isolation.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Requirements ──────────────────────────────────────────── -->
+  <section id="requirements">
+    <h2>Requirements</h2>
+    <table>
+      <tr><th>Dependency</th><th>Version</th><th>Notes</th></tr>
+      <tr><td>OBS Studio</td><td>30+</td><td>Provides <code>libobs</code> and <code>obs-frontend-api</code></td></tr>
+      <tr><td>CMake</td><td>3.16+</td><td>Build system</td></tr>
+      <tr><td>Qt</td><td>6.x</td><td>Core + Widgets modules</td></tr>
+      <tr><td>Zoom Meeting SDK</td><td>5.x</td><td>Place in <code>third_party/zoom-sdk/</code></td></tr>
+      <tr><td>C++ Compiler</td><td>C++17</td><td>MSVC 2022 (Windows) / Clang 14+ (macOS)</td></tr>
+      <tr><td>Zoom Developer Account</td><td>—</td><td>Required for SDK key, secret &amp; JWT token</td></tr>
+    </table>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════════════════ -->
+  <!--  ARCHITECTURE DIAGRAMS                                         -->
+  <!-- ══════════════════════════════════════════════════════════════ -->
+
+  <!-- ── System Overview ──────────────────────────────────────── -->
+  <section id="arch-system">
+    <h2>Architecture: System Overview</h2>
+    <p>
+      At the highest level, CoreVideo bridges two independent systems —
+      <strong>OBS Studio</strong> and the <strong>Zoom Meeting SDK</strong> —
+      by acting as both an OBS source plugin and a Zoom SDK consumer.
+    </p>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+graph TB
+    subgraph UserSpace["User's Machine"]
+      direction TB
+      subgraph OBS["OBS Studio"]
+        direction LR
+        Canvas["OBS Canvas / Output"]
+        Source["Zoom Participant Source\n(obs_source_t)"]
+        Frontend["OBS Frontend API\nTools Menu · Events"]
+        Canvas --> |"renders"| Source
+      end
+
+      subgraph Plugin["obs-zoom-plugin.dll / .so"]
+        direction TB
+        PM["plugin-main\nModule Init"]
+        ZS["ZoomSource\nOBS Source Impl"]
+        ZAuth["ZoomAuth\nSDK Init · JWT Auth"]
+        ZMeet["ZoomMeeting\nJoin · Leave"]
+        ZPart["ZoomParticipants\nRoster · Active Speaker"]
+        ZVD["VideoDelegate\nI420 → BGRA"]
+        ZAD["AudioDelegate\n48kHz PCM"]
+        ZSet["ZoomSettings\nCredential Store"]
+        ZDlg["SettingsDialog\nQt UI"]
+      end
+
+      subgraph EngineProc["ZoomObsEngine.exe (Windows only)"]
+        EMain["Engine Main\nIPC Loop"]
+        EVid["EngineVideo\nParticipant Subscriptions"]
+        EAud["EngineAudio\nAudio Capture"]
+        ZSDK["Zoom Meeting SDK\n(in-process on macOS\nout-of-process on Windows)"]
+        EMain --> EVid & EAud --> ZSDK
+      end
+
+      subgraph Zoom["Zoom Cloud"]
+        Meeting["Live Meeting\nParticipants · Audio · Video"]
+      end
+    end
+
+    OBS --> |"loads"| Plugin
+    Frontend <--> PM
+    Source <--> ZS
+    ZS <--> ZAuth & ZMeet & ZPart & ZVD & ZAD
+    ZAuth & ZSet <--> ZDlg
+    Plugin <-->|"Named Pipes\nJSON IPC"| EMain
+    EVid & EAud <-->|"Shared Memory\nFrame Data"| ZVD & ZAD
+    ZSDK <-->|"HTTPS / WebSocket"| Meeting
+
+    style OBS fill:#0d2137,stroke:#2f81f7,color:#e6edf3
+    style Plugin fill:#1a2332,stroke:#388bfd,color:#e6edf3
+    style EngineProc fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
+    style Zoom fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
+      </div>
+      <div class="diagram-caption">Fig 1 — Full system view showing OBS, the plugin, the Windows engine process, and Zoom cloud.</div>
+    </div>
+  </section>
+
+  <!-- ── Plugin Components ─────────────────────────────────────── -->
+  <section id="arch-components">
+    <h2>Architecture: Plugin Components</h2>
+    <p>
+      The plugin is structured as a set of cooperating singletons and per-source objects.
+      <code>ZoomAuth</code> and <code>ZoomMeeting</code> are process-wide singletons;
+      <code>ZoomSource</code>, <code>VideoDelegate</code>, and <code>AudioDelegate</code>
+      are instantiated once per OBS source item.
+    </p>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+classDiagram
+    class plugin_main {
+        +obs_module_load() bool
+        +obs_module_unload() void
+        -register_source()
+        -add_tools_menu()
+        -handle_frontend_events()
+    }
+
+    class ZoomSource {
+        -obs_source_t* source
+        -std::string meeting_id
+        -uint32_t participant_id
+        -AudioMode audio_mode
+        +create(settings, source) void*
+        +destroy(data) void
+        +get_name() const char*
+        +update(data, settings) void
+        +video_tick(data, seconds) void
+        +get_properties(data) obs_properties_t*
+        +get_defaults(settings) void
+    }
+
+    class ZoomAuth {
+        &lt;&lt;Singleton&gt;&gt;
+        -IAuthService* auth_svc
+        -AuthState state
+        +instance() ZoomAuth&
+        +init(key, secret) bool
+        +authenticate(jwt) bool
+        +shutdown() void
+        +is_authenticated() bool
+    }
+
+    class ZoomMeeting {
+        &lt;&lt;Singleton&gt;&gt;
+        -IMeetingService* meeting_svc
+        -MeetingState state
+        -std::string current_meeting_id
+        +instance() ZoomMeeting&
+        +join(meeting_id, passcode) bool
+        +leave() void
+        +get_state() MeetingState
+    }
+
+    class ZoomParticipants {
+        &lt;&lt;Singleton&gt;&gt;
+        -std::map~uint32_t,ParticipantInfo~ roster
+        -uint32_t active_speaker_id
+        +instance() ZoomParticipants&
+        +get_roster() vector~ParticipantInfo~
+        +get_active_speaker() uint32_t
+        +on_user_join(user_id) void
+        +on_user_leave(user_id) void
+        +on_active_speaker(user_id) void
+    }
+
+    class ZoomVideoDelegate {
+        -obs_source_t* source
+        -uint32_t subscribed_pid
+        -obs_source_frame frame
+        +subscribe(participant_id) void
+        +unsubscribe() void
+        +onRawDataFrameReceived(data) void
+        -convert_i420_to_bgra(yuv, bgra) void
+        -push_frame_to_obs() void
+    }
+
+    class ZoomAudioDelegate {
+        -obs_source_t* source
+        -AudioMode mode
+        -obs_source_audio audio
+        +init(source, mode) void
+        +onMixedAudioRawDataReceived(data) void
+        -push_audio_to_obs() void
+    }
+
+    class ZoomSettings {
+        +sdk_key string
+        +sdk_secret string
+        +jwt_token string
+        +load() ZoomPluginSettings
+        +save(settings) void
+    }
+
+    class ZoomSettingsDialog {
+        -QLineEdit* key_edit
+        -QLineEdit* secret_edit
+        -QLineEdit* token_edit
+        +ZoomSettingsDialog(parent)
+        +accept() void
+    }
+
+    plugin_main --> ZoomAuth : init on load
+    plugin_main --> ZoomSettings : load credentials
+    plugin_main --> ZoomSettingsDialog : open from Tools menu
+    plugin_main --> ZoomSource : register source type
+    ZoomSource --> ZoomAuth : check auth state
+    ZoomSource --> ZoomMeeting : join / leave
+    ZoomSource --> ZoomParticipants : query roster
+    ZoomSource --> ZoomVideoDelegate : create / configure
+    ZoomSource --> ZoomAudioDelegate : create / configure
+    ZoomSettingsDialog --> ZoomSettings : persist
+    ZoomSettingsDialog --> ZoomAuth : re-init
+      </div>
+      <div class="diagram-caption">Fig 2 — Plugin class diagram showing singletons, per-source objects, and their relationships.</div>
+    </div>
+  </section>
+
+  <!-- ── Windows IPC Engine ─────────────────────────────────────── -->
+  <section id="arch-windows">
+    <h2>Architecture: Windows IPC Engine</h2>
+    <p>
+      On Windows, the Zoom SDK requires a dedicated UI-thread and COM STA context
+      that conflicts with OBS's rendering thread. CoreVideo solves this by spawning
+      <code>ZoomObsEngine.exe</code> — a separate process that owns the SDK — and
+      communicating with it via two named pipes carrying newline-delimited JSON.
+    </p>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+graph LR
+    subgraph Plugin["obs-zoom-plugin.dll\n(OBS process)"]
+        direction TB
+        ZS2["ZoomSource"]
+        ZVD2["VideoDelegate"]
+        ZAD2["AudioDelegate"]
+        SHM_R["Read Shared Memory\nFrames"]
+        ZS2 --> ZVD2 & ZAD2
+        ZVD2 & ZAD2 --> SHM_R
+    end
+
+    subgraph Pipes["IPC Channels"]
+        direction TB
+        P2E["\\\\.\\pipe\\ZoomObsPlugin_P2E\nPlugin → Engine\nCommands"]
+        E2P["\\\\.\\pipe\\ZoomObsPlugin_E2P\nEngine → Plugin\nEvents"]
+        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;\nVideo &amp; Audio Frames"]
+    end
+
+    subgraph Engine["ZoomObsEngine.exe\n(Separate process)"]
+        direction TB
+        EMain2["IPC Loop\nmain()"]
+        EVid2["EngineVideo\nParticipant Subscriptions"]
+        EAud2["EngineAudio\nAudio Capture"]
+        SDK2["Zoom SDK\nIMeetingService\nIAuthService"]
+        EMain2 --> EVid2 & EAud2 --> SDK2
+    end
+
+    Plugin -- "init · join · leave\nsubscribe · unsubscribe · quit" --> P2E --> EMain2
+    EMain2 -- "ready · auth_ok · auth_fail\njoined · left · frame · audio · error" --> E2P --> Plugin
+    EVid2 & EAud2 -- "write frames" --> SHM --> SHM_R
+
+    style Plugin fill:#0d2137,stroke:#2f81f7,color:#e6edf3
+    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
+    style Pipes fill:#2d1f00,stroke:#d29922,color:#e6edf3
+      </div>
+      <div class="diagram-caption">Fig 3 — Windows inter-process communication: two named pipes for JSON commands/events, shared memory for frame data.</div>
+    </div>
+
+    <h3>IPC Message Flow</h3>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+sequenceDiagram
+    participant P as Plugin (OBS process)
+    participant E as ZoomObsEngine.exe
+
+    Note over E: Creates named pipes
+    E-->>P: {"cmd":"ready"}
+
+    P->>E: {"cmd":"init","jwt":"&lt;token&gt;"}
+    E-->>P: {"cmd":"auth_ok"}  or  {"cmd":"auth_fail","code":N}
+
+    P->>E: {"cmd":"join","meeting_id":"123","passcode":"pw","display_name":"OBS"}
+    E-->>P: {"cmd":"joined"}
+
+    P->>E: {"cmd":"subscribe","source_uuid":"&lt;uuid&gt;","participant_id":456}
+    loop Every video frame
+        E-->>P: {"cmd":"frame","uuid":"&lt;uuid&gt;","shm":"ZoomObsPlugin_&lt;uuid&gt;","w":1280,"h":720}
+    end
+    loop Every audio chunk
+        E-->>P: {"cmd":"audio","uuid":"&lt;uuid&gt;","shm":"ZoomObsPlugin_audio_&lt;uuid&gt;"}
+    end
+
+    P->>E: {"cmd":"unsubscribe","source_uuid":"&lt;uuid&gt;"}
+    P->>E: {"cmd":"leave"}
+    E-->>P: {"cmd":"left"}
+
+    P->>E: {"cmd":"quit"}
+      </div>
+      <div class="diagram-caption">Fig 4 — Full IPC command/event sequence for the Windows engine process.</div>
+    </div>
+  </section>
+
+  <!-- ── Video Pipeline ─────────────────────────────────────────── -->
+  <section id="arch-video">
+    <h2>Architecture: Video Pipeline</h2>
+    <p>
+      Video travels from the Zoom meeting through the SDK's raw-data callback,
+      gets color-converted, then is pushed into OBS as a texture frame.
+    </p>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    ZP["Zoom\nParticipant\nCamera"] -->|"H.264 stream"| ZC["Zoom\nCloud"]
+    ZC -->|"decoded in SDK"| RV["Raw Video\nCallback\nI420 YUV"]
+    RV -->|"Windows:\nshared memory\nmacOS: heap ptr"| VD["VideoDelegate\nonRawDataFrameReceived()"]
+    VD -->|"convert_i420_to_bgra()"| CV["BGRA\nFrame Buffer\nobs_source_frame"]
+    CV -->|"obs_source_output_video()"| OT["OBS\nVideo Texture"]
+    OT -->|"rendered each frame"| Canvas["OBS Canvas\nScene / Output"]
+
+    style ZP fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
+    style ZC fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
+    style RV fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
+    style VD fill:#0d2137,stroke:#2f81f7,color:#e6edf3
+    style CV fill:#0d2137,stroke:#2f81f7,color:#e6edf3
+    style OT fill:#1a2137,stroke:#388bfd,color:#e6edf3
+    style Canvas fill:#1a2137,stroke:#388bfd,color:#e6edf3
+      </div>
+      <div class="diagram-caption">Fig 5 — Video data path from Zoom participant camera to OBS canvas.</div>
+    </div>
+
+    <h3>Color Space Conversion</h3>
+    <p>
+      The Zoom SDK delivers frames in <strong>I420 (YUV planar)</strong> format using
+      BT.709 full-range colorspace. OBS consumes <code>VIDEO_FORMAT_BGRA</code>.
+      The <code>VideoDelegate</code> performs this conversion on every received frame
+      before calling <code>obs_source_output_video()</code>.
+    </p>
+    <table>
+      <tr><th>Stage</th><th>Format</th><th>Notes</th></tr>
+      <tr><td>Zoom SDK output</td><td>I420 YUV planar</td><td>BT.709 full-range (<code>VideoRawdataColorspace_BT709_F</code>)</td></tr>
+      <tr><td>After conversion</td><td>BGRA 32-bit</td><td>OBS <code>VIDEO_FORMAT_BGRA</code></td></tr>
+      <tr><td>OBS texture</td><td>BGRA / GPU</td><td>Uploaded per frame via <code>obs_source_frame</code></td></tr>
+    </table>
+  </section>
+
+  <!-- ── Audio Pipeline ─────────────────────────────────────────── -->
+  <section id="arch-audio">
+    <h2>Architecture: Audio Pipeline</h2>
+    <p>
+      Audio is received as mixed 48 kHz PCM from the Zoom SDK and forwarded to
+      OBS with configurable channel layout.
+    </p>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+flowchart LR
+    ZA["Zoom\nMeeting\nAudio Mix"] -->|"48 kHz PCM"| RA["Raw Audio\nCallback\nonMixedAudioRawDataReceived()"]
+    RA -->|"Windows: shared mem\nmacOS: heap ptr"| AD["AudioDelegate"]
+    AD -->|"channel map\nmono / stereo"| AF["obs_source_audio\n48 kHz · S16LE"]
+    AF -->|"obs_source_output_audio()"| OA["OBS Audio\nTrack"]
+    OA --> Mix["OBS Audio\nMixer / Output"]
+
+    style ZA fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
+    style RA fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
+    style AD fill:#0d2137,stroke:#2f81f7,color:#e6edf3
+    style AF fill:#0d2137,stroke:#2f81f7,color:#e6edf3
+    style OA fill:#1a2137,stroke:#388bfd,color:#e6edf3
+    style Mix fill:#1a2137,stroke:#388bfd,color:#e6edf3
+      </div>
+      <div class="diagram-caption">Fig 6 — Audio data path from Zoom meeting mix to OBS audio track.</div>
+    </div>
+
+    <table>
+      <tr><th>Property</th><th>Value</th></tr>
+      <tr><td>Sample rate</td><td>48 000 Hz (<code>AudioRawdataSamplingRate_48K</code>)</td></tr>
+      <tr><td>Format</td><td>Signed 16-bit little-endian (S16LE)</td></tr>
+      <tr><td>Mono mode</td><td>Single channel — Zoom mixed audio downmixed</td></tr>
+      <tr><td>Stereo mode</td><td>Two channels — left/right separation preserved</td></tr>
+    </table>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════════════════ -->
+  <!--  FLOW DIAGRAMS                                                 -->
+  <!-- ══════════════════════════════════════════════════════════════ -->
+
+  <!-- ── Auth Flow ─────────────────────────────────────────────── -->
+  <section id="flow-auth">
+    <h2>Flow: Authentication</h2>
+    <p>
+      Authentication happens at plugin load time if saved credentials are present,
+      and can be re-triggered from the Settings dialog.
+    </p>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+sequenceDiagram
+    participant U as User
+    participant OBS as OBS Studio
+    participant PM as plugin-main
+    participant ZA as ZoomAuth
+    participant ZS2 as ZoomSettings
+    participant DLG as SettingsDialog
+    participant SDK as Zoom SDK
+
+    OBS->>PM: obs_module_load()
+    PM->>ZS2: ZoomPluginSettings::load()
+    ZS2-->>PM: {sdk_key, sdk_secret, jwt_token}
+    alt Credentials present
+        PM->>ZA: init(sdk_key, sdk_secret)
+        ZA->>SDK: InitSDK(domain, customUI flag)
+        ZA->>SDK: CreateAuthService()
+        PM->>ZA: authenticate(jwt_token)
+        ZA->>SDK: SDKAuth({jwt_token})
+        SDK-->>ZA: onAuthenticationReturn(AUTHRET_SUCCESS)
+        ZA-->>PM: authenticated = true
+    else No credentials
+        PM-->>OBS: plugin loaded (unauthenticated)
+    end
+
+    opt User opens Settings dialog
+        U->>OBS: Tools → Zoom Plugin Settings
+        OBS->>DLG: exec()
+        U->>DLG: Enter SDK key / secret / JWT
+        DLG->>ZS2: save(settings)
+        DLG->>ZA: init(key, secret)
+        DLG->>ZA: authenticate(jwt)
+        ZA->>SDK: SDKAuth({jwt})
+        SDK-->>ZA: onAuthenticationReturn(AUTHRET_SUCCESS)
+    end
+      </div>
+      <div class="diagram-caption">Fig 7 — SDK authentication sequence at load time and via the Settings dialog.</div>
+    </div>
+  </section>
+
+  <!-- ── Meeting Join Flow ──────────────────────────────────────── -->
+  <section id="flow-meeting">
+    <h2>Flow: Meeting Join &amp; Capture</h2>
+    <p>
+      When a Zoom Participant source is activated in OBS, the plugin joins the
+      configured meeting and begins streaming frames to OBS.
+    </p>
+    <div class="diagram-wrap">
+      <div class="mermaid">
+sequenceDiagram
+    participant U as User
+    participant OBS as OBS Studio
+    participant ZS3 as ZoomSource
+    participant ZM as ZoomMeeting
+    participant ZPart2 as ZoomParticipants
+    participant ZVD3 as VideoDelegate
+    participant ZAD3 as AudioDelegate
+    participant SDK3 as Zoom SDK / Engine
+
+    U->>OBS: Add / activate "Zoom Participant" source
+    OBS->>ZS3: zoom_source_create(settings)
+    ZS3->>ZM: join(meeting_id, passcode)
+    ZM->>SDK3: IMeetingService::Join(JoinParam)
+    SDK3-->>ZM: onMeetingStatusChanged(INMEETING)
+    ZM-->>ZS3: joined callback
+
+    ZS3->>ZPart2: query roster
+    ZPart2-->>ZS3: [{participant_id, display_name}, ...]
+
+    ZS3->>ZVD3: subscribe(participant_id)
+    ZS3->>ZAD3: init(source, audio_mode)
+
+    loop Live capture
+        SDK3-->>ZVD3: onRawDataFrameReceived(I420 frame)
+        ZVD3->>OBS: obs_source_output_video(BGRA frame)
+        SDK3-->>ZAD3: onMixedAudioRawDataReceived(PCM)
+        ZAD3->>OBS: obs_source_output_audio(48kHz S16)
+    end
+
+    U->>OBS: Deactivate / remove source
+    OBS->>ZS3: zoom_source_destroy()
+    ZS3->>ZVD3: unsubscribe()
+    ZS3->>ZM: leave()
+    ZM->>SDK3: IMeetingService::Leave()
+    SDK3-->>ZM: onMeetingStatusChanged(ENDED)
+      </div>
+      <div class="diagram-caption">Fig 8 — Full sequence from source activation to live capture and teardown.</div>
+    </div>
+  </section>
+
+  <!-- ══════════════════════════════════════════════════════════════ -->
+  <!--  REFERENCE                                                     -->
+  <!-- ══════════════════════════════════════════════════════════════ -->
+
+  <!-- ── IPC Protocol ──────────────────────────────────────────── -->
+  <section id="ipc-protocol">
+    <h2>IPC Protocol Reference</h2>
+    <p>
+      All messages are UTF-8 JSON terminated by <code>\n</code>, exchanged over
+      two Windows named pipes. The plugin writes to
+      <code>\\.\pipe\ZoomObsPlugin_P2E</code> (plugin-to-engine) and reads from
+      <code>\\.\pipe\ZoomObsPlugin_E2P</code> (engine-to-plugin).
+    </p>
+
+    <h3>Plugin → Engine Commands</h3>
+    <table>
+      <tr><th>Command</th><th>Payload</th><th>Description</th></tr>
+      <tr><td><code>init</code></td><td><code>{"cmd":"init","jwt":"&lt;token&gt;"}</code></td><td>Initialize Zoom SDK with JWT token</td></tr>
+      <tr><td><code>join</code></td><td><code>{"cmd":"join","meeting_id":"&lt;id&gt;","passcode":"&lt;pw&gt;","display_name":"OBS"}</code></td><td>Join a Zoom meeting</td></tr>
+      <tr><td><code>leave</code></td><td><code>{"cmd":"leave"}</code></td><td>Leave current meeting</td></tr>
+      <tr><td><code>subscribe</code></td><td><code>{"cmd":"subscribe","source_uuid":"&lt;uuid&gt;","participant_id":&lt;id&gt;}</code></td><td>Subscribe to a participant's video &amp; audio</td></tr>
+      <tr><td><code>unsubscribe</code></td><td><code>{"cmd":"unsubscribe","source_uuid":"&lt;uuid&gt;"}</code></td><td>Stop frame delivery for a source</td></tr>
+      <tr><td><code>quit</code></td><td><code>{"cmd":"quit"}</code></td><td>Shut down the engine process</td></tr>
+    </table>
+
+    <h3>Engine → Plugin Events</h3>
+    <table>
+      <tr><th>Event</th><th>Payload</th><th>Description</th></tr>
+      <tr><td><code>ready</code></td><td><code>{"cmd":"ready"}</code></td><td>Engine started, pipes connected</td></tr>
+      <tr><td><code>auth_ok</code></td><td><code>{"cmd":"auth_ok"}</code></td><td>SDK authenticated successfully</td></tr>
+      <tr><td><code>auth_fail</code></td><td><code>{"cmd":"auth_fail","code":&lt;N&gt;}</code></td><td>Authentication failed with error code</td></tr>
+      <tr><td><code>joined</code></td><td><code>{"cmd":"joined"}</code></td><td>Successfully joined the meeting</td></tr>
+      <tr><td><code>left</code></td><td><code>{"cmd":"left"}</code></td><td>Meeting ended or left</td></tr>
+      <tr><td><code>frame</code></td><td><code>{"cmd":"frame","uuid":"&lt;uuid&gt;","shm":"ZoomObsPlugin_&lt;uuid&gt;","w":W,"h":H}</code></td><td>New video frame in shared memory</td></tr>
+      <tr><td><code>audio</code></td><td><code>{"cmd":"audio","uuid":"&lt;uuid&gt;","shm":"ZoomObsPlugin_audio_&lt;uuid&gt;"}</code></td><td>New audio chunk in shared memory</td></tr>
+      <tr><td><code>error</code></td><td><code>{"cmd":"error","msg":"&lt;reason&gt;","code":&lt;N&gt;}</code></td><td>SDK or meeting error</td></tr>
+    </table>
+
+    <h3>Shared Memory Layout</h3>
+    <p>
+      Frame data is written to named shared memory segments prefixed with
+      <code>ZoomObsPlugin_</code> followed by the source UUID. Video frames are
+      raw BGRA pixels (<code>width × height × 4</code> bytes); audio chunks are
+      raw S16LE samples.
+    </p>
+  </section>
+
+  <!-- ── Installation ──────────────────────────────────────────── -->
+  <section id="installation">
+    <h2>Installation</h2>
+    <div class="callout info">
+      <div class="callout-title">ℹ️ Pre-built releases coming soon</div>
+      Pre-built binaries are not yet published. Install from source using the steps below.
+    </div>
+
+    <div class="steps">
+      <div class="step">
+        <div class="step-body">
+          <h4>Obtain the Zoom Meeting SDK</h4>
+          <p>Download the Zoom Meeting SDK for your platform from the
+          <a href="https://developers.zoom.us/docs/meeting-sdk/releases/" target="_blank">Zoom Developer Portal</a>
+          and place it at <code>third_party/zoom-sdk/</code> so that
+          <code>third_party/zoom-sdk/h/zoom_sdk.h</code> exists.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-body">
+          <h4>Configure CMake</h4>
+          <pre><code>cmake -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DZOOM_SDK_DIR=third_party/zoom-sdk \
+  -DCMAKE_PREFIX_PATH="/path/to/obs-studio;/path/to/Qt6"</code></pre>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-body">
+          <h4>Build</h4>
+          <pre><code>cmake --build build --config Release</code></pre>
+          <p>On Windows this also produces <code>ZoomObsEngine.exe</code>.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-body">
+          <h4>Install into OBS</h4>
+          <pre><code>cmake --install build --prefix "/path/to/obs-studio"</code></pre>
+          <p>This copies the plugin module and the engine executable to
+          <code>obs-plugins/64bit/</code> and locale files to
+          <code>data/obs-plugins/obs-zoom-plugin/</code>.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-body">
+          <h4>Launch OBS and configure credentials</h4>
+          <p>Open OBS → <strong>Tools → Zoom Plugin Settings</strong> and enter your
+          Zoom SDK Key, SDK Secret, and JWT token.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Configuration ─────────────────────────────────────────── -->
+  <section id="configuration">
+    <h2>Configuration</h2>
+
+    <h3>Credentials (Settings Dialog)</h3>
+    <p>
+      Open <strong>Tools → Zoom Plugin Settings</strong> in OBS to save your Zoom
+      developer credentials. These are persisted in the OBS global configuration
+      file via <code>obs_data_t</code>.
+    </p>
+    <table>
+      <tr><th>Field</th><th>Description</th></tr>
+      <tr><td>SDK Key</td><td>Your Zoom SDK App Key from the developer portal</td></tr>
+      <tr><td>SDK Secret</td><td>Your Zoom SDK App Secret</td></tr>
+      <tr><td>JWT Token</td><td>A signed JWT generated from your key/secret pair</td></tr>
+    </table>
+
+    <h3>Source Properties</h3>
+    <p>
+      Each <em>Zoom Participant</em> source exposes these properties in the OBS
+      source Properties dialog:
+    </p>
+    <table>
+      <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+      <tr><td>Meeting ID</td><td>String</td><td>Zoom meeting number to join</td></tr>
+      <tr><td>Meeting Passcode</td><td>String</td><td>Optional meeting password</td></tr>
+      <tr><td>Participant</td><td>List</td><td>Select participant from live roster, or "Active Speaker"</td></tr>
+      <tr><td>Audio Mode</td><td>List</td><td>None / Mono / Stereo</td></tr>
+    </table>
+
+    <div class="callout warning">
+      <div class="callout-title">⚠️ Display Name</div>
+      The plugin joins meetings as <strong>"OBS"</strong>. Ensure the Zoom meeting
+      host allows guests or has "waiting room" disabled, or pre-admit the OBS participant.
+    </div>
+  </section>
+
+  <!-- ── Build ─────────────────────────────────────────────────── -->
+  <section id="build">
+    <h2>Building from Source</h2>
+
+    <h3>Directory Layout</h3>
+    <pre><code>CoreVideo/
+├── CMakeLists.txt          # Top-level build config
+├── buildspec/
+│   ├── macos.cmake         # macOS universal binary settings
+│   └── windows.cmake       # Windows MSVC settings
+├── data/
+│   └── locale/en-US.ini    # UI string translations
+├── engine/src/             # Windows engine process
+│   ├── main.cpp            # IPC event loop
+│   ├── engine-video.cpp/h  # Video frame capture
+│   └── engine-audio.cpp/h  # Audio capture
+├── src/                    # Main plugin
+│   ├── plugin-main.cpp     # Module entry point
+│   ├── zoom-source.*       # OBS source implementation
+│   ├── zoom-auth.*         # SDK initialization & auth
+│   ├── zoom-meeting.*      # Meeting join/leave
+│   ├── zoom-participants.* # Participant roster
+│   ├── zoom-settings.*     # Credential persistence
+│   ├── zoom-settings-dialog.* # Qt settings UI
+│   ├── zoom-video-delegate.* # Video frame handler
+│   ├── zoom-audio-delegate.* # Audio frame handler
+│   ├── engine-ipc.h        # Shared IPC constants
+│   └── obs-utils.*         # OBS helper functions
+└── third_party/
+    └── zoom-sdk/           # Zoom SDK (not in repo)</code></pre>
+
+    <h3>Platform Notes</h3>
+    <table>
+      <tr><th>Platform</th><th>Compiler</th><th>Extra Outputs</th><th>SDK Loading</th></tr>
+      <tr><td>Windows</td><td>MSVC 2022</td><td><code>ZoomObsEngine.exe</code></td><td>Out-of-process via named pipes</td></tr>
+      <tr><td>macOS</td><td>Clang 14+</td><td>None</td><td>In-process (arm64 + x86_64 fat binary)</td></tr>
+    </table>
+
+    <div class="callout tip">
+      <div class="callout-title">✅ macOS Deployment Target</div>
+      The macOS build targets <strong>macOS 12.0 Monterey</strong> and above,
+      producing a universal binary for both Apple Silicon and Intel.
+    </div>
+  </section>
+
+  <footer style="margin-top:64px; padding-top:24px; border-top:1px solid var(--border); color:var(--muted); font-size:0.8rem;">
+    <p>CoreVideo — OBS Plugin for Live Zoom Video &nbsp;·&nbsp; Docs generated from source</p>
+  </footer>
+</main>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',
+    themeVariables: {
+      background: '#161b22',
+      primaryColor: '#1f6feb',
+      primaryTextColor: '#e6edf3',
+      primaryBorderColor: '#30363d',
+      lineColor: '#8b949e',
+      secondaryColor: '#1c2128',
+      tertiaryColor: '#1c2128',
+      edgeLabelBackground: '#161b22',
+      clusterBkg: '#1c2128',
+      clusterBorder: '#30363d',
+      titleColor: '#e6edf3',
+      nodeTextColor: '#e6edf3',
+      actorBkg: '#1f6feb',
+      actorBorder: '#388bfd',
+      actorTextColor: '#ffffff',
+      actorLineColor: '#8b949e',
+      signalColor: '#8b949e',
+      signalTextColor: '#e6edf3',
+      noteBkgColor: '#1c2128',
+      noteTextColor: '#e6edf3',
+      noteBorderColor: '#30363d',
+      activationBorderColor: '#388bfd',
+      activationBkgColor: '#0d2137',
+      sequenceNumberColor: '#ffffff',
+      labelBoxBkgColor: '#161b22',
+      labelBoxBorderColor: '#30363d',
+      labelTextColor: '#e6edf3',
+      loopTextColor: '#e6edf3',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    },
+    flowchart: { curve: 'basis', htmlLabels: true },
+    sequence: { actorMargin: 60, messageMargin: 30 },
+  });
+
+  // Highlight active nav link on scroll
+  const sections = document.querySelectorAll('section[id]');
+  const navLinks = document.querySelectorAll('nav a');
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        navLinks.forEach(a => a.classList.remove('active'));
+        const active = document.querySelector(`nav a[href="#${e.target.id}"]`);
+        if (active) active.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  sections.forEach(s => observer.observe(s));
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a full docs/ site at docs/index.html covering:
- System overview, plugin component class diagram
- Windows IPC engine architecture and named-pipe protocol
- Video pipeline (I420 → BGRA) and audio pipeline diagrams
- Authentication and meeting-join sequence diagrams
- Installation, configuration, and build reference

Uses Mermaid.js for all diagrams; .nojekyll disables Jekyll so GitHub Pages serves the plain HTML directly.

https://claude.ai/code/session_01JHSQMeGhWauhaDB3i7djLY