### PR TITLE
Fix pre-test bugs: dangling pointers, auth expiry, control server aut…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,24 @@ elseif(APPLE)
 endif()
 set_target_properties(obs-zoom-plugin PROPERTIES PREFIX "")
 
+# ── sdk.dll deployment (Windows only) ────────────────────────────────────────
+if(WIN32)
+    set(ZOOM_SDK_DLL "${ZOOM_SDK_BASE}/bin/sdk.dll")
+    if(EXISTS "${ZOOM_SDK_DLL}")
+        add_custom_command(TARGET obs-zoom-plugin POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${ZOOM_SDK_DLL}"
+                "$<TARGET_FILE_DIR:obs-zoom-plugin>/sdk.dll"
+            COMMENT "Copying sdk.dll to output directory"
+        )
+        install(FILES "${ZOOM_SDK_DLL}"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+        )
+    else()
+        message(WARNING "sdk.dll not found at ${ZOOM_SDK_DLL} — copy it manually before running")
+    endif()
+endif()
+
 # ── Out-of-process capture engine ─────────────────────────────────────────────
 set(ENGINE_SOURCES
     engine/src/main.cpp

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -26,9 +26,10 @@ bool obs_module_load(void)
     zoom_source_register();
     zoom_share_source_register();
     zoom_participant_audio_source_register();
-    ZoomControlServer::instance().start();
 
     ZoomPluginSettings s = ZoomPluginSettings::load();
+    ZoomControlServer::instance().set_token(s.control_token);
+    ZoomControlServer::instance().start(s.control_server_port);
     if (!s.sdk_key.empty() && !s.sdk_secret.empty()) {
         if (ZoomAuth::instance().init(s.sdk_key, s.sdk_secret) && !s.jwt_token.empty())
             ZoomAuth::instance().authenticate(s.jwt_token);

--- a/src/zoom-auth.cpp
+++ b/src/zoom-auth.cpp
@@ -31,16 +31,14 @@ bool ZoomAuth::init(const std::string &sdk_key, const std::string &sdk_secret)
     }
 
     ZOOMSDK::InitParam init_param;
-    init_param.strWebDomain      = L"https://zoom.us";
+    init_param.strWebDomain       = L"https://zoom.us";
     init_param.enableGenerateDump = true;
     init_param.enableLogByDefault = false;
 
-    // Required to receive raw video/audio data callbacks
-#if defined(WIN32)
+    // Required on all platforms to suppress the Zoom UI and receive raw-data callbacks.
     init_param.obConfigOpts.optionalFeatures = ENABLE_CUSTOMIZED_UI_FLAG;
-#endif
 
-    // Use heap memory for video raw data — stack frames can be 1080p+ (>3 MB each)
+    // Use heap memory for video raw data — stack frames can be 1080p+ (>3 MB each).
     init_param.rawdataOpts.videoRawdataMemoryMode = ZOOMSDK::ZoomSDKRawDataMemoryModeHeap;
     init_param.rawdataOpts.audioRawdataMemoryMode = ZOOMSDK::ZoomSDKRawDataMemoryModeHeap;
 
@@ -75,10 +73,14 @@ bool ZoomAuth::authenticate(const std::string &jwt_token)
         return false;
     }
 
-    auto wide_token = to_zstr(jwt_token);
+    // Store the converted token as a member so the pointer stays valid for the
+    // entire duration of the async SDKAuth call (SDKAuth copies the AuthContext
+    // struct by value but the jwt_token field is a raw pointer).
+    m_wide_jwt = to_zstr(jwt_token);
+    m_last_jwt  = jwt_token;
 
     ZOOMSDK::AuthContext ctx;
-    ctx.jwt_token = wide_token.c_str();
+    ctx.jwt_token = m_wide_jwt.c_str();
 
     ZOOMSDK::SDKError err = m_auth_service->SDKAuth(ctx);
     if (err != ZOOMSDK::SDKERR_SUCCESS) {
@@ -107,6 +109,7 @@ void ZoomAuth::shutdown()
     ZOOMSDK::CleanUPSDK();
     m_sdk_init = false;
     m_state    = ZoomAuthState::Unauthenticated;
+    m_last_jwt.clear();
     blog(LOG_INFO, "[obs-zoom-plugin] Zoom SDK shut down");
 }
 
@@ -141,14 +144,20 @@ void ZoomAuth::onLogout()
 
 void ZoomAuth::onZoomIdentityExpired()
 {
-    blog(LOG_WARNING, "[obs-zoom-plugin] Zoom identity expired — re-authenticate");
-    m_state = ZoomAuthState::Failed;
-    if (m_callback) m_callback(m_state);
+    blog(LOG_WARNING, "[obs-zoom-plugin] Zoom identity expired — re-authenticating");
+    if (!m_last_jwt.empty()) {
+        authenticate(m_last_jwt);
+    } else {
+        m_state = ZoomAuthState::Failed;
+        if (m_callback) m_callback(m_state);
+    }
 }
 
 void ZoomAuth::onZoomAuthIdentityExpired()
 {
-    blog(LOG_WARNING, "[obs-zoom-plugin] Auth identity expiring — re-authenticate soon");
+    blog(LOG_WARNING, "[obs-zoom-plugin] Auth identity expiring — re-authenticating proactively");
+    if (!m_last_jwt.empty())
+        authenticate(m_last_jwt);
 }
 
 #if defined(WIN32)

--- a/src/zoom-auth.h
+++ b/src/zoom-auth.h
@@ -32,8 +32,15 @@ public:
 
 private:
     ZoomAuth() = default;
-    ZoomAuthState       m_state        = ZoomAuthState::Unauthenticated;
-    StateCallback       m_callback;
-    bool                m_sdk_init     = false;
+    ZoomAuthState          m_state        = ZoomAuthState::Unauthenticated;
+    StateCallback          m_callback;
+    bool                   m_sdk_init     = false;
     ZOOMSDK::IAuthService *m_auth_service = nullptr;
+    // Kept alive for the duration of the async SDKAuth call.
+#if defined(WIN32)
+    std::wstring           m_wide_jwt;
+#else
+    std::string            m_wide_jwt;
+#endif
+    std::string            m_last_jwt; // used for auto re-auth on identity expiry
 };

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -50,6 +50,11 @@ void ZoomControlServer::stop()
     m_server->close();
 }
 
+void ZoomControlServer::set_token(const std::string &token)
+{
+    m_token = token;
+}
+
 void ZoomControlServer::on_new_connection()
 {
     while (m_server->hasPendingConnections()) {
@@ -110,6 +115,15 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
     }
 
     const QJsonObject req = doc.object();
+
+    if (!m_token.empty()) {
+        const QString provided = req.value("token").toString();
+        if (provided.toStdString() != m_token) {
+            write_response(socket, {{"ok", false}, {"error", "unauthorized"}});
+            return;
+        }
+    }
+
     const QString cmd = req.value("cmd").toString();
 
     if (cmd == "help") {

--- a/src/zoom-control-server.h
+++ b/src/zoom-control-server.h
@@ -4,6 +4,7 @@
 #include <QJsonObject>
 #include <QObject>
 #include <QtGlobal>
+#include <string>
 
 class QTcpServer;
 class QTcpSocket;
@@ -14,6 +15,7 @@ public:
 
     bool start(quint16 port = 19870);
     void stop();
+    void set_token(const std::string &token);
 
 private:
     explicit ZoomControlServer(QObject *parent = nullptr);
@@ -22,5 +24,6 @@ private:
     void handle_line(QTcpSocket *socket, const QByteArray &line);
     void write_response(QTcpSocket *socket, const QJsonObject &response);
 
-    QTcpServer *m_server = nullptr;
+    QTcpServer  *m_server = nullptr;
+    std::string  m_token; // empty = no auth required
 };

--- a/src/zoom-meeting.cpp
+++ b/src/zoom-meeting.cpp
@@ -81,16 +81,18 @@ bool ZoomMeeting::join_impl(const std::string &meeting_id, const std::string &pa
     }
 
     const std::string name = display_name.empty() ? "OBS" : display_name;
-    auto wide_name     = to_zstr(name);
-    auto wide_passcode = to_zstr(passcode);
+    // Store as members so the raw pointers in JoinParam remain valid for the
+    // duration of the async Join() call.
+    m_wide_name     = to_zstr(name);
+    m_wide_passcode = to_zstr(passcode);
 
     ZOOMSDK::JoinParam join_param;
     join_param.userType = ZOOMSDK::SDK_UT_WITHOUT_LOGIN;
 
     ZOOMSDK::JoinParam4WithoutLogin &p = join_param.param.withoutloginuserJoin;
     p.meetingNumber             = std::stoull(meeting_id);
-    p.userName                  = wide_name.c_str();
-    p.psw                       = passcode.empty() ? nullptr : wide_passcode.c_str();
+    p.userName                  = m_wide_name.c_str();
+    p.psw                       = passcode.empty() ? nullptr : m_wide_passcode.c_str();
     p.isVideoOff                = true;
     p.isAudioOff                = true;
     p.isMyVoiceInMix            = false;

--- a/src/zoom-meeting.h
+++ b/src/zoom-meeting.h
@@ -61,4 +61,13 @@ private:
     std::string m_last_display_name;
     int         m_reconnect_attempts = 0;
     bool        m_user_leaving       = false;
+
+    // Kept alive across the async Join() call (JoinParam holds raw pointers).
+#if defined(WIN32)
+    std::wstring m_wide_name;
+    std::wstring m_wide_passcode;
+#else
+    std::string  m_wide_name;
+    std::string  m_wide_passcode;
+#endif
 };

--- a/src/zoom-settings-dialog.cpp
+++ b/src/zoom-settings-dialog.cpp
@@ -1,10 +1,13 @@
 #include "zoom-settings-dialog.h"
 #include "zoom-settings.h"
 #include "zoom-auth.h"
+#include "zoom-control-server.h"
 #include <QVBoxLayout>
 #include <QFormLayout>
 #include <QDialogButtonBox>
+#include <QGroupBox>
 #include <QLineEdit>
+#include <QSpinBox>
 #include <QLabel>
 #include <QMessageBox>
 
@@ -12,7 +15,7 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     : QDialog(parent)
 {
     setWindowTitle("Zoom Plugin Settings");
-    setMinimumWidth(420);
+    setMinimumWidth(460);
 
     ZoomPluginSettings s = ZoomPluginSettings::load();
 
@@ -23,10 +26,28 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     m_sdk_secret_edit->setEchoMode(QLineEdit::Password);
     m_jwt_token_edit->setEchoMode(QLineEdit::Password);
 
-    auto *form = new QFormLayout;
-    form->addRow(new QLabel("SDK Key:",    this), m_sdk_key_edit);
-    form->addRow(new QLabel("SDK Secret:", this), m_sdk_secret_edit);
-    form->addRow(new QLabel("JWT Token:",  this), m_jwt_token_edit);
+    m_control_port_spin = new QSpinBox(this);
+    m_control_port_spin->setRange(1024, 65535);
+    m_control_port_spin->setValue(s.control_server_port);
+
+    m_control_token_edit = new QLineEdit(QString::fromStdString(s.control_token), this);
+    m_control_token_edit->setEchoMode(QLineEdit::Password);
+    m_control_token_edit->setPlaceholderText("Leave blank to allow unauthenticated access");
+
+    auto *sdk_form = new QFormLayout;
+    sdk_form->addRow(new QLabel("SDK Key:",    this), m_sdk_key_edit);
+    sdk_form->addRow(new QLabel("SDK Secret:", this), m_sdk_secret_edit);
+    sdk_form->addRow(new QLabel("JWT Token:",  this), m_jwt_token_edit);
+
+    auto *sdk_group = new QGroupBox("Zoom SDK", this);
+    sdk_group->setLayout(sdk_form);
+
+    auto *ctrl_form = new QFormLayout;
+    ctrl_form->addRow(new QLabel("Port:",  this), m_control_port_spin);
+    ctrl_form->addRow(new QLabel("Token:", this), m_control_token_edit);
+
+    auto *ctrl_group = new QGroupBox("Control Server (127.0.0.1)", this);
+    ctrl_group->setLayout(ctrl_form);
 
     auto *buttons = new QDialogButtonBox(
         QDialogButtonBox::Save | QDialogButtonBox::Cancel, this);
@@ -34,16 +55,19 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
     auto *layout = new QVBoxLayout(this);
-    layout->addLayout(form);
+    layout->addWidget(sdk_group);
+    layout->addWidget(ctrl_group);
     layout->addWidget(buttons);
 }
 
 void ZoomSettingsDialog::onSave()
 {
     ZoomPluginSettings s;
-    s.sdk_key    = m_sdk_key_edit->text().toStdString();
-    s.sdk_secret = m_sdk_secret_edit->text().toStdString();
-    s.jwt_token  = m_jwt_token_edit->text().toStdString();
+    s.sdk_key             = m_sdk_key_edit->text().toStdString();
+    s.sdk_secret          = m_sdk_secret_edit->text().toStdString();
+    s.jwt_token           = m_jwt_token_edit->text().toStdString();
+    s.control_server_port = static_cast<uint16_t>(m_control_port_spin->value());
+    s.control_token       = m_control_token_edit->text().toStdString();
     s.save();
 
     ZoomAuth &auth = ZoomAuth::instance();
@@ -59,6 +83,8 @@ void ZoomSettingsDialog::onSave()
         auth.state() != ZoomAuthState::Authenticating) {
         auth.authenticate(s.jwt_token);
     }
+
+    ZoomControlServer::instance().set_token(s.control_token);
 
     accept();
 }

--- a/src/zoom-settings-dialog.h
+++ b/src/zoom-settings-dialog.h
@@ -2,6 +2,7 @@
 #include <QDialog>
 
 class QLineEdit;
+class QSpinBox;
 
 class ZoomSettingsDialog : public QDialog {
     Q_OBJECT
@@ -12,7 +13,9 @@ private slots:
     void onSave();
 
 private:
-    QLineEdit *m_sdk_key_edit    = nullptr;
-    QLineEdit *m_sdk_secret_edit = nullptr;
-    QLineEdit *m_jwt_token_edit  = nullptr;
+    QLineEdit *m_sdk_key_edit           = nullptr;
+    QLineEdit *m_sdk_secret_edit        = nullptr;
+    QLineEdit *m_jwt_token_edit         = nullptr;
+    QSpinBox  *m_control_port_spin      = nullptr;
+    QLineEdit *m_control_token_edit     = nullptr;
 };

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -6,16 +6,22 @@ ZoomPluginSettings ZoomPluginSettings::load()
 {
     config_t *cfg = obs_frontend_get_global_config();
     ZoomPluginSettings s;
-    s.sdk_key    = config_get_string(cfg, SECTION, "SdkKey")    ?: "";
-    s.sdk_secret = config_get_string(cfg, SECTION, "SdkSecret") ?: "";
-    s.jwt_token  = config_get_string(cfg, SECTION, "JwtToken")  ?: "";
+    s.sdk_key             = config_get_string(cfg, SECTION, "SdkKey")           ?: "";
+    s.sdk_secret          = config_get_string(cfg, SECTION, "SdkSecret")        ?: "";
+    s.jwt_token           = config_get_string(cfg, SECTION, "JwtToken")         ?: "";
+    s.control_server_port = static_cast<uint16_t>(
+        config_get_uint(cfg, SECTION, "ControlServerPort"));
+    if (s.control_server_port == 0) s.control_server_port = 19870;
+    s.control_token = config_get_string(cfg, SECTION, "ControlToken") ?: "";
     return s;
 }
 void ZoomPluginSettings::save() const
 {
     config_t *cfg = obs_frontend_get_global_config();
-    config_set_string(cfg, SECTION, "SdkKey",    sdk_key.c_str());
-    config_set_string(cfg, SECTION, "SdkSecret", sdk_secret.c_str());
-    config_set_string(cfg, SECTION, "JwtToken",  jwt_token.c_str());
+    config_set_string(cfg, SECTION, "SdkKey",             sdk_key.c_str());
+    config_set_string(cfg, SECTION, "SdkSecret",          sdk_secret.c_str());
+    config_set_string(cfg, SECTION, "JwtToken",           jwt_token.c_str());
+    config_set_uint  (cfg, SECTION, "ControlServerPort",  control_server_port);
+    config_set_string(cfg, SECTION, "ControlToken",       control_token.c_str());
     config_save_safe(cfg, "tmp", nullptr);
 }

--- a/src/zoom-settings.h
+++ b/src/zoom-settings.h
@@ -2,6 +2,8 @@
 #include <string>
 struct ZoomPluginSettings {
     std::string sdk_key, sdk_secret, jwt_token;
+    uint16_t    control_server_port  = 19870;
+    std::string control_token;
     static ZoomPluginSettings load();
     void save() const;
 };


### PR DESCRIPTION
…h, sdk.dll deploy

- zoom-auth: fix JWT dangling pointer by storing m_wide_jwt/m_last_jwt as members; remove WIN32 guard from ENABLE_CUSTOMIZED_UI_FLAG so raw-data callbacks work on all platforms; auto re-auth on onZoomIdentityExpired/onZoomAuthIdentityExpired
- zoom-meeting: fix JoinParam dangling pointer by storing m_wide_name/m_wide_passcode as members so the raw pointers in JoinParam remain valid across the async Join() call
- zoom-control-server: add set_token() and per-request token validation (if configured)
- zoom-settings: persist control_server_port and control_token; load them on startup
- zoom-settings-dialog: add port (QSpinBox) and token (QLineEdit) UI fields grouped under "Control Server (127.0.0.1)" section
- plugin-main: pass port and token from settings to control server on load
- CMakeLists: add sdk.dll post-build copy and install rule for Windows builds

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP