### PR TITLE
Security hardening: input validation, IPC safety, and auth token fixes

### DIFF
--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -132,8 +132,17 @@ static std::string json_str(const std::string &json, const std::string &key)
     auto pos = json.find(needle);
     if (pos == std::string::npos) return {};
     pos += needle.size();
-    auto end = json.find('"', pos);
-    return end == std::string::npos ? std::string{} : json.substr(pos, end - pos);
+    std::string result;
+    while (pos < json.size()) {
+        char c = json[pos++];
+        if (c == '\\') {
+            if (pos < json.size()) pos++; // skip escaped character
+            continue;
+        }
+        if (c == '"') break;
+        result += c;
+    }
+    return result;
 }
 
 static uint32_t json_uint(const std::string &json, const std::string &key)
@@ -142,7 +151,24 @@ static uint32_t json_uint(const std::string &json, const std::string &key)
     auto pos = json.find(needle);
     if (pos == std::string::npos) return 0;
     pos += needle.size();
-    return static_cast<uint32_t>(std::stoul(json.substr(pos)));
+    try {
+        return static_cast<uint32_t>(std::stoul(json.substr(pos)));
+    } catch (...) {
+        return 0;
+    }
+}
+
+// UUID may only contain alphanumerics, hyphens, and underscores to prevent
+// path traversal when used as a POSIX shared-memory name.
+static bool is_valid_source_uuid(const std::string &uuid)
+{
+    if (uuid.empty() || uuid.size() > 64) return false;
+    for (char c : uuid) {
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              (c >= '0' && c <= '9') || c == '-' || c == '_'))
+            return false;
+    }
+    return true;
 }
 
 // ── Auth event handler ────────────────────────────────────────────────────────
@@ -290,10 +316,18 @@ int main()
                 g_wide_name = to_zstr(display_name);
                 g_wide_psw  = to_zstr(passcode);
 
+                uint64_t meeting_number = 0;
+                try {
+                    meeting_number = std::stoull(meeting_id);
+                } catch (...) {
+                    ipc_write_line(e2p, R"({"cmd":"error","msg":"invalid_meeting_id"})");
+                    continue;
+                }
+
                 ZOOMSDK::JoinParam jp;
                 jp.userType = ZOOMSDK::SDK_UT_WITHOUT_LOGIN;
                 ZOOMSDK::JoinParam4WithoutLogin &p = jp.param.withoutloginuserJoin;
-                p.meetingNumber             = std::stoull(meeting_id);
+                p.meetingNumber             = meeting_number;
                 p.userName                  = g_wide_name.c_str();
                 p.psw                       = passcode.empty() ? nullptr : g_wide_psw.c_str();
                 p.isVideoOff                = true;
@@ -311,14 +345,14 @@ int main()
         } else if (line.find(IPC_CMD_SUBSCRIBE) != std::string::npos) {
             std::string uuid = json_str(line, "source_uuid");
             uint32_t    pid  = json_uint(line, "participant_id");
-            if (!uuid.empty()) {
+            if (is_valid_source_uuid(uuid)) {
                 video_engine.subscribe(pid, uuid, e2p);
                 EngineAudio::instance().init(e2p, uuid);
             }
 
         } else if (line.find(IPC_CMD_UNSUBSCRIBE) != std::string::npos) {
             std::string uuid = json_str(line, "source_uuid");
-            if (!uuid.empty())
+            if (is_valid_source_uuid(uuid))
                 video_engine.unsubscribe(uuid);
         }
     }

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -324,6 +324,7 @@ int main()
     }
 
     if (meeting_svc) meeting_svc->Leave(ZOOMSDK::LEAVE_MEETING);
+    EngineAudio::instance().shutdown();
     ZOOMSDK::CleanUPSDK();
     ipc_teardown(p2e, e2p);
     return 0;

--- a/src/engine-ipc.h
+++ b/src/engine-ipc.h
@@ -105,14 +105,16 @@
 #endif
 
 // ── Line-oriented I/O helpers ─────────────────────────────────────────────────
-// Returns false on EOF or I/O error; 'out' is empty in that case.
-static inline bool ipc_read_line(IpcFd fd, std::string &out)
+// Returns false on EOF, I/O error, or if the line exceeds max_len bytes.
+static inline bool ipc_read_line(IpcFd fd, std::string &out,
+                                 size_t max_len = 65536)
 {
     out.clear();
 #if defined(WIN32)
     char ch; DWORD n;
     while (ReadFile(fd, &ch, 1, &n, nullptr) && n == 1) {
         if (ch == '\n') return true;
+        if (out.size() >= max_len) return false; // line too long
         out += ch;
     }
     return false; // EOF or error
@@ -120,6 +122,7 @@ static inline bool ipc_read_line(IpcFd fd, std::string &out)
     char ch; ssize_t n;
     while ((n = read(fd, &ch, 1)) == 1) {
         if (ch == '\n') return true;
+        if (out.size() >= max_len) return false; // line too long
         out += ch;
     }
     return false; // EOF (n==0) or error (n==-1)

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -10,6 +10,17 @@
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <obs-module.h>
+#include <cstdint>
+
+// Timing-safe string equality — prevents token leakage via timing side-channel.
+static bool ct_equal(const std::string &a, const std::string &b)
+{
+    if (a.size() != b.size()) return false;
+    volatile uint8_t diff = 0;
+    for (size_t i = 0; i < a.size(); ++i)
+        diff |= static_cast<uint8_t>(a[i]) ^ static_cast<uint8_t>(b[i]);
+    return diff == 0;
+}
 
 ZoomControlServer &ZoomControlServer::instance()
 {
@@ -32,6 +43,8 @@ bool ZoomControlServer::start(quint16 port)
                 [this]() { on_new_connection(); });
     }
 
+    m_server->setMaxPendingConnections(10);
+
     if (!m_server->listen(QHostAddress::LocalHost, port)) {
         blog(LOG_ERROR,
              "[obs-zoom-plugin] Control server failed to bind on 127.0.0.1:%u: %s "
@@ -40,6 +53,10 @@ bool ZoomControlServer::start(quint16 port)
              m_server->errorString().toUtf8().constData());
         return false;
     }
+
+    if (m_token.empty())
+        blog(LOG_WARNING, "[obs-zoom-plugin] Control server started without an auth token "
+             "— any local process can issue commands. Set a token in Zoom Plugin Settings.");
 
     blog(LOG_INFO, "[obs-zoom-plugin] Control server listening on 127.0.0.1:%u",
          static_cast<unsigned>(port));
@@ -119,8 +136,8 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
     const QJsonObject req = doc.object();
 
     if (!m_token.empty()) {
-        const QString provided = req.value("token").toString();
-        if (provided.toStdString() != m_token) {
+        const std::string provided = req.value("token").toString().toStdString();
+        if (!ct_equal(provided, m_token)) {
             write_response(socket, {{"ok", false}, {"error", "unauthorized"}});
             return;
         }
@@ -172,8 +189,12 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
 
     if (cmd == "assign_output") {
         const QString source = req.value("source").toString();
-        const uint32_t participant_id =
-            static_cast<uint32_t>(req.value("participant_id").toInt(0));
+        const int raw_pid = req.value("participant_id").toInt(-1);
+        if (raw_pid < 0) {
+            write_response(socket, {{"ok", false}, {"error", "invalid_participant_id"}});
+            return;
+        }
+        const uint32_t participant_id = static_cast<uint32_t>(raw_pid);
         const bool active_speaker = req.value("active_speaker").toBool(false);
         const bool isolate_audio = req.value("isolate_audio").toBool(false);
         const QString audio_channels = req.value("audio_channels").toString("mono");

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -33,7 +33,9 @@ bool ZoomControlServer::start(quint16 port)
     }
 
     if (!m_server->listen(QHostAddress::LocalHost, port)) {
-        blog(LOG_WARNING, "[obs-zoom-plugin] Control server failed on 127.0.0.1:%u: %s",
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Control server failed to bind on 127.0.0.1:%u: %s "
+             "— TCP control API unavailable. Check that no other process owns this port.",
              static_cast<unsigned>(port),
              m_server->errorString().toUtf8().constData());
         return false;

--- a/src/zoom-meeting.cpp
+++ b/src/zoom-meeting.cpp
@@ -165,15 +165,12 @@ void ZoomMeeting::schedule_reconnect()
     blog(LOG_INFO, "[obs-zoom-plugin] Reconnect attempt %d/%d in %d ms",
          attempt, kMaxReconnectAttempts, delay_ms);
 
-    struct Task { ZoomMeeting *self; };
-    auto *task = new Task{this};
-    std::thread([task, delay_ms]() {
+    ZoomMeeting *self = this;
+    std::thread([self, delay_ms]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
         obs_queue_task(OBS_TASK_UI, [](void *p) {
-            auto *t = static_cast<Task *>(p);
-            t->self->do_reconnect();
-            delete t;
-        }, task, false);
+            static_cast<ZoomMeeting *>(p)->do_reconnect();
+        }, self, false);
     }).detach();
 }
 

--- a/src/zoom-meeting.cpp
+++ b/src/zoom-meeting.cpp
@@ -82,17 +82,29 @@ bool ZoomMeeting::join_impl(const std::string &meeting_id, const std::string &pa
         m_meeting_service->SetEvent(this);
     }
 
-    const std::string name = display_name.empty() ? "OBS" : display_name;
+    // Zoom SDK limits display names to 64 characters.
+    std::string name = display_name.empty() ? "OBS" : display_name;
+    if (name.size() > 64) name.resize(64);
+
     // Store as members so the raw pointers in JoinParam remain valid for the
     // duration of the async Join() call.
     m_wide_name     = to_zstr(name);
     m_wide_passcode = to_zstr(passcode);
 
+    uint64_t meeting_number = 0;
+    try {
+        meeting_number = std::stoull(meeting_id);
+    } catch (const std::exception &) {
+        blog(LOG_ERROR, "[obs-zoom-plugin] Invalid meeting ID '%s': not a number",
+             meeting_id.c_str());
+        return false;
+    }
+
     ZOOMSDK::JoinParam join_param;
     join_param.userType = ZOOMSDK::SDK_UT_WITHOUT_LOGIN;
 
     ZOOMSDK::JoinParam4WithoutLogin &p = join_param.param.withoutloginuserJoin;
-    p.meetingNumber             = std::stoull(meeting_id);
+    p.meetingNumber             = meeting_number;
     p.userName                  = m_wide_name.c_str();
     p.psw                       = passcode.empty() ? nullptr : m_wide_passcode.c_str();
     p.isVideoOff                = true;

--- a/src/zoom-participants.cpp
+++ b/src/zoom-participants.cpp
@@ -52,9 +52,10 @@ void ZoomParticipants::detach()
 ParticipantInfo ZoomParticipants::user_to_info(ZOOMSDK::IUserInfo *u)
 {
     ParticipantInfo info;
-    info.user_id   = u->GetUserID();
-    info.has_video = u->IsVideoOn();
+    info.user_id    = u->GetUserID();
+    info.has_video  = u->IsVideoOn();
     info.is_talking = u->IsTalking();
+    info.is_muted   = u->IsAudioMuted();
 
     const zchar_t *name = u->GetUserName();
 #if defined(WIN32)

--- a/src/zoom-share-delegate.cpp
+++ b/src/zoom-share-delegate.cpp
@@ -65,27 +65,43 @@ void ZoomShareDelegate::subscribe_to(uint32_t share_source_id)
     if (m_current_source_id == share_source_id) return;
     unsubscribe_renderer();
 
-    ZOOMSDK::SDKError err = ZOOMSDK::createRenderer(&m_renderer, this);
-    if (err != ZOOMSDK::SDKERR_SUCCESS || !m_renderer) return;
-
-    m_renderer->setRawDataResolution(ZOOMSDK::ZoomSDKResolution_1080P);
-    err = m_renderer->subscribe(share_source_id, ZOOMSDK::RAW_DATA_TYPE_SHARE);
-    if (err != ZOOMSDK::SDKERR_SUCCESS) {
-        ZOOMSDK::destroyRenderer(m_renderer);
-        m_renderer = nullptr;
+    ZOOMSDK::IZoomSDKRenderer *renderer = nullptr;
+    ZOOMSDK::SDKError err = ZOOMSDK::createRenderer(&renderer, this);
+    if (err != ZOOMSDK::SDKERR_SUCCESS || !renderer) {
+        blog(LOG_ERROR, "[obs-zoom-plugin] Share createRenderer failed: %d",
+             static_cast<int>(err));
         return;
     }
-    m_current_source_id = share_source_id;
+
+    renderer->setRawDataResolution(ZOOMSDK::ZoomSDKResolution_1080P);
+    err = renderer->subscribe(share_source_id, ZOOMSDK::RAW_DATA_TYPE_SHARE);
+    if (err != ZOOMSDK::SDKERR_SUCCESS) {
+        blog(LOG_ERROR, "[obs-zoom-plugin] Share renderer->subscribe failed: %d",
+             static_cast<int>(err));
+        ZOOMSDK::destroyRenderer(renderer);
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(m_renderer_mtx);
+        m_renderer = renderer;
+        m_current_source_id = share_source_id;
+    }
     blog(LOG_INFO, "[obs-zoom-plugin] Share subscribed (source_id=%u)", share_source_id);
 }
 
 void ZoomShareDelegate::unsubscribe_renderer()
 {
-    if (!m_renderer) return;
-    m_renderer->unSubscribe();
-    ZOOMSDK::destroyRenderer(m_renderer);
-    m_renderer = nullptr;
-    m_current_source_id = 0;
+    ZOOMSDK::IZoomSDKRenderer *r = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(m_renderer_mtx);
+        r = m_renderer;
+        m_renderer = nullptr;
+        m_current_source_id = 0;
+    }
+    if (!r) return;
+    r->unSubscribe();
+    ZOOMSDK::destroyRenderer(r);
 }
 
 // ── IZoomSDKRendererDelegate ─────────────────────────────────────────────────
@@ -119,6 +135,8 @@ void ZoomShareDelegate::onRawDataStatusChanged(RawDataStatus status)
 
 void ZoomShareDelegate::onRendererBeDestroyed()
 {
+    // SDK is destroying the renderer — null our pointer; don't call destroyRenderer().
+    std::lock_guard<std::mutex> lk(m_renderer_mtx);
     m_renderer = nullptr;
     m_current_source_id = 0;
 }

--- a/src/zoom-share-delegate.h
+++ b/src/zoom-share-delegate.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <mutex>
 #include <obs-module.h>
 #include <zoom_sdk_raw_data_def.h>
 #include <rawdata/rawdata_renderer_interface.h>
@@ -41,6 +42,9 @@ private:
     void unsubscribe_renderer();
 
     obs_source_t                    *m_source     = nullptr;
+    // m_renderer_mtx guards m_renderer against concurrent unsubscribe_renderer()
+    // and SDK-initiated onRendererBeDestroyed() on different threads.
+    std::mutex                       m_renderer_mtx;
     ZOOMSDK::IZoomSDKRenderer       *m_renderer   = nullptr;
     ZOOMSDK::IMeetingShareController *m_share_ctrl = nullptr;
     uint32_t                         m_current_source_id = 0;

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -227,8 +227,17 @@ static void zoom_source_update(void *data, obs_data_t *settings)
     static_cast<ZoomSource *>(data)->apply_settings(settings);
 }
 
-static uint32_t zoom_source_get_width(void *)  { return 0; }
-static uint32_t zoom_source_get_height(void *) { return 0; }
+static uint32_t zoom_source_get_width(void *data)
+{
+    auto *ctx = static_cast<ZoomSource *>(data);
+    return ctx->video_delegate ? ctx->video_delegate->width() : 0;
+}
+
+static uint32_t zoom_source_get_height(void *data)
+{
+    auto *ctx = static_cast<ZoomSource *>(data);
+    return ctx->video_delegate ? ctx->video_delegate->height() : 0;
+}
 
 static obs_properties_t *zoom_source_get_properties(void *data)
 {

--- a/src/zoom-video-delegate.cpp
+++ b/src/zoom-video-delegate.cpp
@@ -13,10 +13,11 @@ ZoomVideoDelegate::~ZoomVideoDelegate()
 
 bool ZoomVideoDelegate::subscribe(uint32_t participant_id, VideoResolution res)
 {
-    if (m_renderer) unsubscribe();
+    unsubscribe();
 
-    ZOOMSDK::SDKError err = ZOOMSDK::createRenderer(&m_renderer, this);
-    if (err != ZOOMSDK::SDKERR_SUCCESS || !m_renderer) {
+    ZOOMSDK::IZoomSDKRenderer *renderer = nullptr;
+    ZOOMSDK::SDKError err = ZOOMSDK::createRenderer(&renderer, this);
+    if (err != ZOOMSDK::SDKERR_SUCCESS || !renderer) {
         blog(LOG_ERROR, "[obs-zoom-plugin] createRenderer failed: %d", static_cast<int>(err));
         return false;
     }
@@ -27,16 +28,19 @@ bool ZoomVideoDelegate::subscribe(uint32_t participant_id, VideoResolution res)
     case VideoResolution::P720:  sdk_res = ZOOMSDK::ZoomSDKResolution_720P;  break;
     default:                     sdk_res = ZOOMSDK::ZoomSDKResolution_1080P; break;
     }
-    m_renderer->setRawDataResolution(sdk_res);
+    renderer->setRawDataResolution(sdk_res);
 
-    err = m_renderer->subscribe(participant_id, ZOOMSDK::RAW_DATA_TYPE_VIDEO);
+    err = renderer->subscribe(participant_id, ZOOMSDK::RAW_DATA_TYPE_VIDEO);
     if (err != ZOOMSDK::SDKERR_SUCCESS) {
         blog(LOG_ERROR, "[obs-zoom-plugin] renderer->subscribe failed: %d", static_cast<int>(err));
-        ZOOMSDK::destroyRenderer(m_renderer);
-        m_renderer = nullptr;
+        ZOOMSDK::destroyRenderer(renderer);
         return false;
     }
 
+    {
+        std::lock_guard<std::mutex> lk(m_renderer_mtx);
+        m_renderer = renderer;
+    }
     static const char *res_names[] = {"360P", "720P", "1080P"};
     blog(LOG_INFO, "[obs-zoom-plugin] Video subscribed for participant %u at %s",
          participant_id, res_names[static_cast<int>(res)]);
@@ -45,11 +49,18 @@ bool ZoomVideoDelegate::subscribe(uint32_t participant_id, VideoResolution res)
 
 void ZoomVideoDelegate::unsubscribe()
 {
-    if (!m_renderer) return;
-    m_renderer->unSubscribe();
-    ZOOMSDK::destroyRenderer(m_renderer);
-    m_renderer = nullptr;
+    ZOOMSDK::IZoomSDKRenderer *r = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(m_renderer_mtx);
+        r = m_renderer;
+        m_renderer = nullptr;
+    }
+    if (!r) return;
     m_active.store(false, std::memory_order_relaxed);
+    m_width.store(0, std::memory_order_relaxed);
+    m_height.store(0, std::memory_order_relaxed);
+    r->unSubscribe();
+    ZOOMSDK::destroyRenderer(r);
 }
 
 void ZoomVideoDelegate::onRawDataFrameReceived(YUVRawDataI420 *data)
@@ -59,6 +70,8 @@ void ZoomVideoDelegate::onRawDataFrameReceived(YUVRawDataI420 *data)
     const uint32_t w = data->GetStreamWidth();
     const uint32_t h = data->GetStreamHeight();
     if (w == 0 || h == 0) return;
+    m_width.store(w, std::memory_order_relaxed);
+    m_height.store(h, std::memory_order_relaxed);
 
     obs_source_frame frame = {};
     frame.format      = VIDEO_FORMAT_I420;
@@ -84,7 +97,14 @@ void ZoomVideoDelegate::onRawDataStatusChanged(RawDataStatus status)
 
 void ZoomVideoDelegate::onRendererBeDestroyed()
 {
+    // The SDK is destroying the renderer; null our pointer without calling
+    // destroyRenderer() ourselves (that would double-free).
+    {
+        std::lock_guard<std::mutex> lk(m_renderer_mtx);
+        m_renderer = nullptr;
+    }
     m_active.store(false, std::memory_order_relaxed);
-    m_renderer = nullptr;
+    m_width.store(0, std::memory_order_relaxed);
+    m_height.store(0, std::memory_order_relaxed);
     blog(LOG_INFO, "[obs-zoom-plugin] Video renderer destroyed by SDK");
 }

--- a/src/zoom-video-delegate.h
+++ b/src/zoom-video-delegate.h
@@ -2,6 +2,7 @@
 #include <obs-module.h>
 #include <cstdint>
 #include <atomic>
+#include <mutex>
 #include <zoom_sdk_raw_data_def.h>
 #include <rawdata/rawdata_renderer_interface.h>
 
@@ -14,7 +15,9 @@ public:
 
     bool subscribe(uint32_t participant_id, VideoResolution res = VideoResolution::P1080);
     void unsubscribe();
-    bool is_active() const { return m_active.load(std::memory_order_relaxed); }
+    bool     is_active() const { return m_active.load(std::memory_order_relaxed); }
+    uint32_t width()     const { return m_width.load(std::memory_order_relaxed); }
+    uint32_t height()    const { return m_height.load(std::memory_order_relaxed); }
 
     // IZoomSDKRendererDelegate
     void onRawDataFrameReceived(YUVRawDataI420 *data) override;
@@ -23,6 +26,11 @@ public:
 
 private:
     obs_source_t              *m_source;
+    // m_renderer_mtx guards m_renderer against concurrent unsubscribe() and
+    // SDK-initiated onRendererBeDestroyed() firing from different threads.
+    std::mutex                 m_renderer_mtx;
     ZOOMSDK::IZoomSDKRenderer *m_renderer = nullptr;
     std::atomic<bool>          m_active{false};
+    std::atomic<uint32_t>      m_width{0};
+    std::atomic<uint32_t>      m_height{0};
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR bundles the full set of stability and security fixes developed on this branch:

### Security fixes (commit `f214290`)
- **`engine/src/main.cpp`** — Fix `json_str()` to correctly skip `\"`-escaped quotes, preventing field-injection via crafted IPC messages; wrap `stoul`/`stoull` in try/catch to avoid crashes on non-numeric input; add `is_valid_source_uuid()` to reject path-traversal characters before a UUID is used as a POSIX shared-memory name
- **`src/engine-ipc.h`** — `ipc_read_line()` now enforces a 64 KiB line limit, preventing unbounded memory growth from a malformed IPC stream
- **`src/zoom-meeting.cpp`** — `std::stoull(meeting_id)` wrapped in try/catch (returns `false` instead of throwing); display name truncated to 64 characters per Zoom SDK limit
- **`src/zoom-control-server.cpp`** — Constant-time `ct_equal()` for auth token comparison (eliminates timing side-channel); `setMaxPendingConnections(10)`; warning logged when server starts without a token; `participant_id` validated non-negative before cast to `uint32_t`

### Stability fixes (commits `57844a4`, `cb3fe30`, `48faa94`)
- Renderer double-free prevention via mutex ownership pattern in video and share delegates
- Atomic meeting state, alive-flag guards, and main-thread dispatch for all SDK callbacks
- `EngineAudio::shutdown()` now called on exit to clean up stale SHM regions
- `is_muted` correctly populated from `IUserInfo::IsAudioMuted()` at join time
- Video source `get_width`/`get_height` callbacks wired to live frame dimensions
- Control server bind failure upgraded to `LOG_ERROR` with a descriptive message
- `schedule_reconnect()` no longer heap-allocates a `Task` struct (leak-free)

## Test plan
- [ ] Build on Linux and Windows — no new warnings
- [ ] Send a non-numeric meeting ID via the control API — plugin logs error, does not crash
- [ ] Send a `source_uuid` containing `../` via IPC — engine silently ignores the subscribe command
- [ ] Send an oversized line (>64 KiB) to the engine IPC — connection closes cleanly
- [ ] Start the plugin with no control token configured — `LOG_WARNING` appears in OBS log
- [ ] Verify auth token check rejects a wrong token and accepts the correct one

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP)_