### PR TITLE
[codex] Improve SDK build compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.16)
 project(obs-zoom-plugin VERSION 0.1.0)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
 find_package(libobs REQUIRED)
 find_package(obs-frontend-api REQUIRED)
 find_package(Qt6 COMPONENTS Core Network Widgets REQUIRED)
-set(CMAKE_AUTOMOC ON)
 
 set(ZOOM_SDK_DIR "third_party/zoom-sdk" CACHE PATH "Zoom Meeting SDK directory")
 
@@ -26,13 +28,39 @@ if(WIN32 AND NOT EXISTS "${ZOOM_SDK_BASE}/h/zoom_sdk.h")
 endif()
 
 set(ZOOM_SDK_INCLUDE_DIR "${ZOOM_SDK_DIR}/h")
+set(ZOOM_SDK_LIBRARY "${ZOOM_SDK_DIR}/lib/sdk.lib")
+
+if(WIN32)
+    if(EXISTS "${ZOOM_SDK_DIR}/bin/sdk.dll")
+        set(ZOOM_SDK_RUNTIME_DIR "${ZOOM_SDK_DIR}/bin")
+    elseif(EXISTS "${ZOOM_SDK_BASE}/bin/sdk.dll")
+        set(ZOOM_SDK_RUNTIME_DIR "${ZOOM_SDK_BASE}/bin")
+    else()
+        set(ZOOM_SDK_RUNTIME_DIR "")
+    endif()
+
+    if(NOT EXISTS "${ZOOM_SDK_INCLUDE_DIR}/zoom_sdk.h")
+        message(FATAL_ERROR
+            "Zoom SDK headers not found at ${ZOOM_SDK_INCLUDE_DIR}. "
+            "Set ZOOM_SDK_DIR to the SDK folder that contains h/zoom_sdk.h.")
+    endif()
+    if(NOT EXISTS "${ZOOM_SDK_LIBRARY}")
+        message(FATAL_ERROR
+            "Zoom SDK import library not found at ${ZOOM_SDK_LIBRARY}. "
+            "Set ZOOM_SDK_DIR to the SDK folder that contains lib/sdk.lib.")
+    endif()
+    if(ZOOM_SDK_RUNTIME_DIR STREQUAL "")
+        message(FATAL_ERROR
+            "Zoom SDK runtime folder not found. Expected bin/sdk.dll under "
+            "${ZOOM_SDK_DIR} or ${ZOOM_SDK_BASE}.")
+    endif()
+endif()
 
 # macOS distributes the Zoom SDK as a .framework bundle.
 # Point ZOOM_SDK_FRAMEWORK at the ZoomSDK.framework directory if building on Apple.
 set(ZOOM_SDK_FRAMEWORK "${ZOOM_SDK_DIR}/ZoomSDK.framework" CACHE PATH
     "Zoom Meeting SDK framework path (macOS only)")
 
-# ── OBS plugin module ─────────────────────────────────────────────────────────
 add_library(obs-zoom-plugin MODULE
     src/plugin-main.cpp
     src/zoom-source.cpp
@@ -54,6 +82,7 @@ add_library(obs-zoom-plugin MODULE
     src/zoom-interpretation-audio-source.cpp
     src/obs-utils.cpp
 )
+
 target_include_directories(obs-zoom-plugin PRIVATE
     src
     ${ZOOM_SDK_INCLUDE_DIR}
@@ -65,8 +94,9 @@ target_link_libraries(obs-zoom-plugin PRIVATE
     Qt6::Network
     Qt6::Widgets
 )
+
 if(WIN32)
-    target_link_libraries(obs-zoom-plugin PRIVATE ${ZOOM_SDK_DIR}/lib/sdk.lib)
+    target_link_libraries(obs-zoom-plugin PRIVATE ${ZOOM_SDK_LIBRARY})
 elseif(APPLE)
     target_link_libraries(obs-zoom-plugin PRIVATE
         "-framework ${ZOOM_SDK_FRAMEWORK}"
@@ -74,27 +104,21 @@ elseif(APPLE)
         "-framework Foundation"
     )
 endif()
+
 set_target_properties(obs-zoom-plugin PROPERTIES PREFIX "")
 
-# ── sdk.dll deployment (Windows only) ────────────────────────────────────────
 if(WIN32)
-    set(ZOOM_SDK_DLL "${ZOOM_SDK_BASE}/bin/sdk.dll")
-    if(EXISTS "${ZOOM_SDK_DLL}")
-        add_custom_command(TARGET obs-zoom-plugin POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${ZOOM_SDK_DLL}"
-                "$<TARGET_FILE_DIR:obs-zoom-plugin>/sdk.dll"
-            COMMENT "Copying sdk.dll to output directory"
-        )
-        install(FILES "${ZOOM_SDK_DLL}"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
-        )
-    else()
-        message(WARNING "sdk.dll not found at ${ZOOM_SDK_DLL} — copy it manually before running")
-    endif()
+    add_custom_command(TARGET obs-zoom-plugin POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${ZOOM_SDK_RUNTIME_DIR}"
+            "$<TARGET_FILE_DIR:obs-zoom-plugin>"
+        COMMENT "Copying Zoom SDK runtime files to output directory"
+    )
+    install(DIRECTORY "${ZOOM_SDK_RUNTIME_DIR}/"
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+    )
 endif()
 
-# ── Out-of-process capture engine ─────────────────────────────────────────────
 set(ENGINE_SOURCES
     engine/src/main.cpp
     engine/src/engine-video.cpp
@@ -107,7 +131,7 @@ if(WIN32)
     target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
     target_link_libraries(ZoomObsEngine PRIVATE
         ws2_32 crypt32 winhttp shlwapi
-        ${ZOOM_SDK_DIR}/lib/sdk.lib
+        ${ZOOM_SDK_LIBRARY}
     )
     set_target_properties(ZoomObsEngine PROPERTIES WIN32_EXECUTABLE FALSE)
     install(TARGETS ZoomObsEngine
@@ -129,14 +153,13 @@ elseif(UNIX)
     target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
     target_link_libraries(ZoomObsEngine PRIVATE
         ${ZOOM_SDK_DIR}/lib/libsdk.so
-        rt  # shm_open / shm_unlink on Linux
+        rt
     )
     install(TARGETS ZoomObsEngine
         RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
     )
 endif()
 
-# ── Install ───────────────────────────────────────────────────────────────────
 install(TARGETS obs-zoom-plugin
     LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
 )

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,23 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+CoreVideo is currently pre-1.0 software. Security fixes are applied to the
+default branch until a stable release channel exists.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version | Supported |
+| ------- | --------- |
+| main    | Yes       |
+| < 0.1   | No        |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please do not open public issues for suspected vulnerabilities. Report security
+concerns privately to the project maintainer with:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+- A short description of the issue and affected component.
+- Steps to reproduce, proof-of-concept input, or logs when available.
+- The expected impact, especially if local control APIs, credentials, IPC, or
+  meeting media isolation are involved.
+
+The maintainer should acknowledge valid reports, investigate impact, and publish
+a fix or mitigation before public disclosure whenever possible.

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -10,16 +10,38 @@
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <obs-module.h>
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
+#include <limits>
 
 // Timing-safe string equality — prevents token leakage via timing side-channel.
 static bool ct_equal(const std::string &a, const std::string &b)
 {
-    if (a.size() != b.size()) return false;
-    volatile uint8_t diff = 0;
-    for (size_t i = 0; i < a.size(); ++i)
-        diff |= static_cast<uint8_t>(a[i]) ^ static_cast<uint8_t>(b[i]);
+    volatile size_t diff = a.size() ^ b.size();
+    const size_t max_len = std::max(a.size(), b.size());
+    for (size_t i = 0; i < max_len; ++i) {
+        const uint8_t ca = i < a.size() ? static_cast<uint8_t>(a[i]) : 0;
+        const uint8_t cb = i < b.size() ? static_cast<uint8_t>(b[i]) : 0;
+        diff |= static_cast<size_t>(ca ^ cb);
+    }
     return diff == 0;
+}
+
+static bool json_to_uint32(const QJsonObject &obj, const char *key, uint32_t &out)
+{
+    const QJsonValue value = obj.value(key);
+    if (!value.isDouble()) return false;
+
+    const double raw = value.toDouble(-1);
+    if (!std::isfinite(raw) || raw < 0 ||
+        raw > static_cast<double>(std::numeric_limits<uint32_t>::max()) ||
+        std::floor(raw) != raw) {
+        return false;
+    }
+
+    out = static_cast<uint32_t>(raw);
+    return true;
 }
 
 ZoomControlServer &ZoomControlServer::instance()
@@ -89,7 +111,7 @@ void ZoomControlServer::on_new_connection()
 static QJsonObject participant_to_json(const ParticipantInfo &p)
 {
     QJsonObject obj;
-    obj["id"] = static_cast<int>(p.user_id);
+    obj["id"] = static_cast<double>(p.user_id);
     obj["name"] = QString::fromStdString(p.display_name);
     obj["has_video"] = p.has_video;
     obj["is_talking"] = p.is_talking;
@@ -104,7 +126,7 @@ static QJsonObject output_to_json(const ZoomOutputInfo &o)
     obj["display_name"]   = o.display_name.empty()
                             ? QString::fromStdString(o.source_name)
                             : QString::fromStdString(o.display_name);
-    obj["participant_id"] = static_cast<int>(o.participant_id);
+    obj["participant_id"] = static_cast<double>(o.participant_id);
     obj["active_speaker"] = o.active_speaker;
     obj["isolate_audio"]  = o.isolate_audio;
     obj["audio_channels"] = o.audio_mode == AudioChannelMode::Stereo
@@ -168,7 +190,7 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
         write_response(socket, {
             {"ok", true},
             {"meeting_state", meeting_state_to_string(ZoomMeeting::instance().state())},
-            {"active_speaker_id", static_cast<int>(
+            {"active_speaker_id", static_cast<double>(
                 ZoomParticipants::instance().active_speaker_id())}
         });
         return;
@@ -192,12 +214,11 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
 
     if (cmd == "assign_output") {
         const QString source = req.value("source").toString();
-        const int raw_pid = req.value("participant_id").toInt(-1);
-        if (raw_pid < 0) {
+        uint32_t participant_id = 0;
+        if (!json_to_uint32(req, "participant_id", participant_id)) {
             write_response(socket, {{"ok", false}, {"error", "invalid_participant_id"}});
             return;
         }
-        const uint32_t participant_id = static_cast<uint32_t>(raw_pid);
         const bool active_speaker = req.value("active_speaker").toBool(false);
         const bool isolate_audio = req.value("isolate_audio").toBool(false);
         const QString audio_channels = req.value("audio_channels").toString("mono");

--- a/src/zoom-output-profile.cpp
+++ b/src/zoom-output-profile.cpp
@@ -7,6 +7,9 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <obs-module.h>
+#include <cmath>
+#include <cstdint>
+#include <limits>
 
 static QString profiles_dir()
 {
@@ -23,6 +26,22 @@ static QString profile_path(const std::string &name)
     const QString dir = profiles_dir();
     if (dir.isEmpty()) return {};
     return dir + "/" + QString::fromStdString(name) + ".json";
+}
+
+static bool json_to_uint32(const QJsonObject &obj, const char *key, uint32_t &out)
+{
+    const QJsonValue value = obj.value(key);
+    if (!value.isDouble()) return false;
+
+    const double raw = value.toDouble(-1);
+    if (!std::isfinite(raw) || raw < 0 ||
+        raw > static_cast<double>(std::numeric_limits<uint32_t>::max()) ||
+        std::floor(raw) != raw) {
+        return false;
+    }
+
+    out = static_cast<uint32_t>(raw);
+    return true;
 }
 
 namespace ZoomOutputProfile {
@@ -49,7 +68,7 @@ bool save(const std::string &name, const std::vector<ZoomOutputInfo> &outputs)
         QJsonObject obj;
         obj["source"]         = QString::fromStdString(o.source_name);
         obj["display_name"]   = QString::fromStdString(o.display_name);
-        obj["participant_id"] = static_cast<int>(o.participant_id);
+        obj["participant_id"] = static_cast<double>(o.participant_id);
         obj["active_speaker"] = o.active_speaker;
         obj["isolate_audio"]  = o.isolate_audio;
         obj["audio_channels"] = o.audio_mode == AudioChannelMode::Stereo
@@ -83,7 +102,7 @@ std::vector<ZoomOutputInfo> load(const std::string &name)
         ZoomOutputInfo o;
         o.source_name    = obj.value("source").toString().toStdString();
         o.display_name   = obj.value("display_name").toString().toStdString();
-        o.participant_id = static_cast<uint32_t>(obj.value("participant_id").toInt(0));
+        json_to_uint32(obj, "participant_id", o.participant_id);
         o.active_speaker = obj.value("active_speaker").toBool(false);
         o.isolate_audio  = obj.value("isolate_audio").toBool(false);
         o.audio_mode     = obj.value("audio_channels").toString() == "stereo"

--- a/src/zoom-participants.cpp
+++ b/src/zoom-participants.cpp
@@ -222,10 +222,8 @@ void ZoomParticipants::onBotAuthorizerRelationChanged(unsigned int) {}
 void ZoomParticipants::onVirtualNameTagStatusChanged(bool, unsigned int) {}
 void ZoomParticipants::onVirtualNameTagRosterInfoUpdated(unsigned int) {}
 void ZoomParticipants::onGrantCoOwnerPrivilegeChanged(bool) {}
-#if defined(WIN32)
 void ZoomParticipants::onCreateCompanionRelation(unsigned int, unsigned int) {}
 void ZoomParticipants::onRemoveCompanionRelation(unsigned int) {}
-#endif
 
 // ── IMeetingAudioCtrlEvent ────────────────────────────────────────────────────
 

--- a/src/zoom-participants.h
+++ b/src/zoom-participants.h
@@ -63,11 +63,9 @@ public:
     void onVirtualNameTagStatusChanged(bool bOn, unsigned int userID) override;
     void onVirtualNameTagRosterInfoUpdated(unsigned int userID) override;
     void onGrantCoOwnerPrivilegeChanged(bool canGrantOther) override;
-#if defined(WIN32)
     void onCreateCompanionRelation(unsigned int parentUserID,
                                    unsigned int childUserID) override;
     void onRemoveCompanionRelation(unsigned int childUserID) override;
-#endif
 
     // IMeetingVideoCtrlEvent — used to keep has_video flag current
     void onUserVideoStatusChange(unsigned int userId,
@@ -78,14 +76,17 @@ public:
         ZOOMSDK::IList<unsigned int> *) override {}
     void onHostRequestStartVideo(
         ZOOMSDK::IRequestStartVideoHandler *) override {}
-    void onUserVideoQualityChanged(ZOOMSDK::VideoQuality,
+    void onUserVideoQualityChanged(ZOOMSDK::VideoConnectionQuality,
                                    unsigned int) override {}
-    void onVideoOrderUpdated(
-        ZOOMSDK::IVideoOrderUpdatedHelper *) override {}
-    void onLocalVideoOrderUpdated(
-        ZOOMSDK::ILocalVideoOrderUpdatedHelper *) override {}
+    void onHostVideoOrderUpdated(ZOOMSDK::IList<unsigned int> *) override {}
+    void onLocalVideoOrderUpdated(ZOOMSDK::IList<unsigned int> *) override {}
     void onFollowHostVideoOrderChanged(bool) override {}
     void onVideoAlphaChannelStatusChanged(bool) override {}
+    void onCameraControlRequestReceived(
+        unsigned int, ZOOMSDK::CameraControlRequestType,
+        ZOOMSDK::ICameraControlRequestHandler *) override {}
+    void onCameraControlRequestResult(
+        unsigned int, ZOOMSDK::CameraControlRequestResult) override {}
 
     // IMeetingAudioCtrlEvent — used for reliable active-speaker tracking
     void onUserAudioStatusChange(


### PR DESCRIPTION
## Summary

- validate the uploaded Zoom SDK layout in CMake and reuse a single `ZOOM_SDK_LIBRARY` path
- copy/install the full Zoom SDK `bin` runtime payload on Windows instead of only `sdk.dll`
- update participant/video callback signatures for the newer Zoom Meeting SDK headers
- preserve full unsigned Zoom participant IDs in JSON control responses and output profiles
- replace the placeholder security policy with a pre-1.0 project policy

## Why

The local SDK upload exposed a newer Windows Zoom Meeting SDK layout and API surface. The previous build script only deployed `sdk.dll`, which is not enough for the SDK runtime folder, and several callback declarations no longer matched the installed headers.

## Validation

- `git diff --cached --check`
- attempted CMake configure with `C:\Program Files\CMake\bin\cmake.exe -S . -B build -DZOOM_SDK_DIR=third_party/zoom-sdk`

CMake configuration is still blocked on this machine because no C++ build toolchain is installed or active: `nmake`, `cl`, MSBuild, Ninja, and `gh` are not available, and `vswhere` reports no Visual Studio instances.