### PR TITLE
Fix build: correct SDK header paths and add missing stubs for Linux

### DIFF
--- a/engine/src/engine-audio.cpp
+++ b/engine/src/engine-audio.cpp
@@ -1,6 +1,6 @@
 #include "engine-audio.h"
 #include "../../src/engine-ipc.h"
-#include <rawdata/zoom_rawdata_api.h>
+#include <zoom_rawdata_api.h>
 #include <cstring>
 
 EngineAudio &EngineAudio::instance() { static EngineAudio inst; return inst; }

--- a/engine/src/engine-audio.h
+++ b/engine/src/engine-audio.h
@@ -2,8 +2,8 @@
 #include <cstdint>
 #include <string>
 #include "../../src/engine-ipc.h"
-#include <zoom_sdk_raw_data_def.h>
-#include <rawdata/rawdata_audio_helper_interface.h>
+#include <rawdata_def.h>
+#include <rawdata_audio_helper_interface.h>
 
 class EngineAudio : public ZOOMSDK::IZoomSDKAudioRawDataDelegate {
 public:

--- a/engine/src/engine-video.cpp
+++ b/engine/src/engine-video.cpp
@@ -1,6 +1,6 @@
 #include "engine-video.h"
 #include "../../src/engine-ipc.h"
-#include <rawdata/zoom_rawdata_api.h>
+#include <zoom_rawdata_api.h>
 #include <cstring>
 
 ParticipantSubscription::ParticipantSubscription(uint32_t participant_id,

--- a/engine/src/engine-video.h
+++ b/engine/src/engine-video.h
@@ -4,8 +4,8 @@
 #include <unordered_map>
 #include <memory>
 #include "../../src/engine-ipc.h"
-#include <zoom_sdk_raw_data_def.h>
-#include <rawdata/rawdata_renderer_interface.h>
+#include <rawdata_def.h>
+#include <rawdata_renderer_interface.h>
 
 class ParticipantSubscription : public ZOOMSDK::IZoomSDKRendererDelegate {
 public:

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -4,9 +4,9 @@
 #include <zoom_sdk.h>
 #include <auth_service_interface.h>
 #include <meeting_service_interface.h>
-#include <meeting_service_components/meeting_participants_ctrl_interface.h>
-#include <meeting_service_components/meeting_audio_interface.h>
-#include <meeting_service_components/meeting_video_interface.h>
+#include <meeting_participants_ctrl_interface.h>
+#include <meeting_audio_interface.h>
+#include <meeting_video_interface.h>
 #include <algorithm>
 #include <string>
 #include <atomic>
@@ -426,8 +426,10 @@ public:
         ipc_write_line(m_e2p, R"({"cmd":"error","msg":"identity_expired"})");
     }
     void onZoomAuthIdentityExpired() override {}
+#if defined(WIN32)
     void onNotificationServiceStatus(ZOOMSDK::SDKNotificationServiceStatus,
                                      ZOOMSDK::SDKNotificationServiceError) override {}
+#endif
 private:
     IpcFd m_e2p;
 };
@@ -532,7 +534,9 @@ int main()
             init_param.strWebDomain = "https://zoom.us";
 #endif
             init_param.enableGenerateDump = true;
+#if defined(WIN32)
             init_param.obConfigOpts.optionalFeatures = ENABLE_CUSTOMIZED_UI_FLAG;
+#endif
             init_param.rawdataOpts.videoRawdataMemoryMode = ZOOMSDK::ZoomSDKRawDataMemoryModeHeap;
             init_param.rawdataOpts.audioRawdataMemoryMode = ZOOMSDK::ZoomSDKRawDataMemoryModeHeap;
             ZOOMSDK::InitSDK(init_param);

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -47,7 +47,7 @@ bool obs_module_load(void)
             if (event == OBS_FRONTEND_EVENT_FINISHED_LOADING) {
                 auto *main_win = static_cast<QMainWindow *>(obs_frontend_get_main_window());
                 auto *dock = new ZoomDock(main_win);
-                obs_frontend_add_dock(dock);
+                obs_frontend_add_dock_by_id("ZoomControlDock", "Zoom Control", dock);
             }
             if (event == OBS_FRONTEND_EVENT_EXIT)
                 ZoomEngineClient::instance().stop();

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -61,19 +61,17 @@ static QString participant_label(const ParticipantInfo &p)
 
 // ── Constructor ───────────────────────────────────────────────────────────────
 ZoomDock::ZoomDock(QWidget *parent)
-    : QDockWidget("Zoom Control", parent)
+    : QWidget(parent)
 {
-    setObjectName("ZoomControlDock");
     setMinimumWidth(340);
 
-    auto *root    = new QWidget(this);
-    auto *vLayout = new QVBoxLayout(root);
+    auto *vLayout = new QVBoxLayout(this);
     vLayout->setContentsMargins(6, 6, 6, 6);
     vLayout->setSpacing(6);
 
     // ── Status row ────────────────────────────────────────────────────────────
-    m_state_dot   = new QLabel("●", root);
-    m_state_label = new QLabel("Not connected", root);
+    m_state_dot   = new QLabel("●", this);
+    m_state_label = new QLabel("Not connected", this);
     m_state_dot->setStyleSheet("color: #666666; font-size: 18px;");
 
     auto *status_row = new QHBoxLayout;
@@ -82,16 +80,16 @@ ZoomDock::ZoomDock(QWidget *parent)
     vLayout->addLayout(status_row);
 
     // ── Active speaker ────────────────────────────────────────────────────────
-    m_speaker_label = new QLabel("—", root);
+    m_speaker_label = new QLabel("—", this);
     m_speaker_label->setStyleSheet("color: #aaaaaa; font-style: italic;");
 
     auto *speaker_row = new QHBoxLayout;
-    speaker_row->addWidget(new QLabel("Active speaker:", root));
+    speaker_row->addWidget(new QLabel("Active speaker:", this));
     speaker_row->addWidget(m_speaker_label, 1);
     vLayout->addLayout(speaker_row);
 
     // ── Join controls ─────────────────────────────────────────────────────────
-    auto *join_group  = new QGroupBox("Join Meeting", root);
+    auto *join_group  = new QGroupBox("Join Meeting", this);
     auto *join_layout = new QVBoxLayout(join_group);
 
     m_meeting_id = new QLineEdit(join_group);
@@ -118,7 +116,7 @@ ZoomDock::ZoomDock(QWidget *parent)
     connect(m_leave_btn, &QPushButton::clicked, this, [this]() { on_leave_clicked(); });
 
     // ── Output table ──────────────────────────────────────────────────────────
-    auto *output_group  = new QGroupBox("Outputs", root);
+    auto *output_group  = new QGroupBox("Outputs", this);
     auto *output_layout = new QVBoxLayout(output_group);
 
     m_output_table = new QTableWidget(output_group);
@@ -139,7 +137,7 @@ ZoomDock::ZoomDock(QWidget *parent)
     output_layout->addWidget(m_apply_btn);
     vLayout->addWidget(output_group, 1);
 
-    setWidget(root);
+    
 
     // ── Subscribe to roster / state changes ──────────────────────────────────
     auto self  = this;

--- a/src/zoom-dock.h
+++ b/src/zoom-dock.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDockWidget>
+#include <QWidget>
 #include <atomic>
 #include <memory>
 
@@ -11,7 +11,7 @@ class QTableWidget;
 class QComboBox;
 class QCheckBox;
 
-class ZoomDock : public QDockWidget {
+class ZoomDock : public QWidget {
     Q_OBJECT
 public:
     explicit ZoomDock(QWidget *parent = nullptr);

--- a/src/zoom-settings.h
+++ b/src/zoom-settings.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 struct ZoomPluginSettings {
     std::string sdk_key, sdk_secret, jwt_token;

--- a/third_party/zoom-sdk/h/meeting_video_interface.h
+++ b/third_party/zoom-sdk/h/meeting_video_interface.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "zoom_sdk_def.h"
+
+namespace ZOOMSDK {
+
+enum VideoStatus { Video_ON = 0, Video_OFF = 1, Video_Failed = 2 };
+enum VideoConnectionQuality { VideoConnectionQuality_Unknown = 0, VideoConnectionQuality_Bad = 1, VideoConnectionQuality_Normal = 2, VideoConnectionQuality_Good = 3 };
+enum CameraControlRequestType { CameraControlRequestType_RequestControl = 0, CameraControlRequestType_GiveUpControl = 1 };
+enum CameraControlRequestResult { CameraControlRequestResult_Approve = 0, CameraControlRequestResult_Decline = 1 };
+
+class IRequestStartVideoHandler {
+public:
+    virtual ~IRequestStartVideoHandler() {}
+};
+
+class ICameraControlRequestHandler {
+public:
+    virtual ~ICameraControlRequestHandler() {}
+};
+
+class IMeetingVideoCtrlEvent {
+public:
+    virtual void onUserVideoStatusChange(unsigned int userId, VideoStatus status) = 0;
+    virtual void onActiveSpeakerVideoUserChanged(unsigned int userId) = 0;
+    virtual void onActiveVideoUserChanged(unsigned int userId) = 0;
+    virtual void onSpotlightedUserListChangeNotification(IList<unsigned int> *list) = 0;
+    virtual void onHostRequestStartVideo(IRequestStartVideoHandler *handler) = 0;
+    virtual void onUserVideoQualityChanged(VideoConnectionQuality quality, unsigned int userId) = 0;
+    virtual void onHostVideoOrderUpdated(IList<unsigned int> *list) = 0;
+    virtual void onLocalVideoOrderUpdated(IList<unsigned int> *list) = 0;
+    virtual void onFollowHostVideoOrderChanged(bool follow) = 0;
+    virtual void onVideoAlphaChannelStatusChanged(bool enabled) = 0;
+    virtual void onCameraControlRequestReceived(unsigned int userId, CameraControlRequestType type, ICameraControlRequestHandler *handler) = 0;
+    virtual void onCameraControlRequestResult(unsigned int userId, CameraControlRequestResult result) = 0;
+    virtual ~IMeetingVideoCtrlEvent() {}
+};
+
+class IMeetingVideoController {
+public:
+    virtual SDKError SetEvent(IMeetingVideoCtrlEvent *event) = 0;
+    virtual ~IMeetingVideoController() {}
+};
+
+} // namespace ZOOMSDK


### PR DESCRIPTION
- engine: change <rawdata/...> and <meeting_service_components/...>
  includes to flat paths matching the SDK stub layout (all headers
  live directly under h/, not in subdirectories)
- engine: change <zoom_sdk_raw_data_def.h> to <rawdata_def.h>
- Add missing meeting_video_interface.h stub with full IMeetingVideoCtrlEvent and IMeetingVideoController interfaces
- engine/main.cpp: guard onNotificationServiceStatus and optionalFeatures with #if defined(WIN32) — these fields don't exist in the Linux SDK headers
- ZoomDock: convert from QDockWidget to QWidget and use obs_frontend_add_dock_by_id (replaces deprecated obs_frontend_add_dock)
- zoom-settings.h: add missing #include <cstdint> for uint16_t

obs-zoom-plugin.so compiles cleanly. ZoomObsEngine link-fails only because the real libsdk.so is not present in this dev environment (expected — stub headers only).

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP