### PR TITLE
Fix Windows CI: bootstrap OBS dev environment when portable zip lacks cmake files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,54 +17,100 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install OBS Studio (for headers + libs)
+      # Puts dumpbin.exe and lib.exe on PATH — needed to synthesise import libs.
+      - name: Set up MSVC tools
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Install OBS Studio
+        shell: powershell
         run: |
           $ver = "30.2.2"
-          Invoke-WebRequest -Uri "https://github.com/obsproject/obs-studio/releases/download/$ver/OBS-Studio-$ver-Windows.zip" -OutFile obs.zip
-          Expand-Archive obs.zip -DestinationPath C:\obs-studio
-          # Show cmake layout so failures are diagnosable
-          Get-ChildItem C:\obs-studio -Recurse -Filter "*.cmake" | Select-Object -First 20 | ForEach-Object { $_.FullName }
-        shell: powershell
+          $obs = "C:\obs-runtime"
+          Invoke-WebRequest `
+            "https://github.com/obsproject/obs-studio/releases/download/$ver/OBS-Studio-$ver-Windows.zip" `
+            -OutFile obs.zip
+          Expand-Archive obs.zip $obs -Force
+
+          # ── Fast path: portable zip already contains cmake config files ──────
+          if (Test-Path "$obs\cmake\LibObs\LibObsConfig.cmake") {
+            Write-Host "cmake config files found in portable zip — nothing extra to do."
+            exit 0
+          }
+
+          Write-Host "Portable zip has no cmake dev files. Bootstrapping from OBS source + DLL exports."
+
+          # ── Headers: sparse-checkout only libobs + frontend-api ──────────────
+          git clone --depth 1 --branch $ver --filter=blob:none --sparse `
+            https://github.com/obsproject/obs-studio.git C:\obs-source
+          Push-Location C:\obs-source
+          git sparse-checkout set libobs UI/obs-frontend-api
+          Pop-Location
+
+          New-Item -Force -ItemType Directory "$obs\include\obs" | Out-Null
+          Copy-Item C:\obs-source\libobs\*.h                                    "$obs\include\obs\"
+          Copy-Item C:\obs-source\UI\obs-frontend-api\obs-frontend-api.h        "$obs\include\obs\"
+
+          # ── Import libs: generate from DLL export tables via dumpbin + lib ───
+          New-Item -Force -ItemType Directory "$obs\lib" | Out-Null
+          foreach ($name in @("obs", "obs-frontend-api")) {
+            $dll = "$obs\bin\64bit\$name.dll"
+            $def = "$obs\lib\$name.def"
+            $lib = "$obs\lib\$name.lib"
+            if (-not (Test-Path $dll)) { Write-Warning "$dll not found — skipping"; continue }
+
+            $exports = @("EXPORTS")
+            (dumpbin /nologo /exports $dll) | ForEach-Object {
+              # dumpbin lines: "  <ordinal>  <hint>  <RVA>  <name>"
+              if ($_ -match "^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)\s*$") {
+                $exports += "  $($Matches[1])"
+              }
+            }
+            $exports | Set-Content $def
+            lib /nologo /def:$def /out:$lib /machine:x64
+          }
+
+          # ── cmake config files: one per package ──────────────────────────────
+          $obsSlash = $obs -replace '\\', '/'
+          foreach ($pkg in @(
+            @{ name = "LibObs";          target = "OBS::libobs";            dll = "obs"              },
+            @{ name = "obs-frontend-api"; target = "OBS::obs-frontend-api"; dll = "obs-frontend-api" }
+          )) {
+            $dir = "$obs\cmake\$($pkg.name)"
+            New-Item -Force -ItemType Directory $dir | Out-Null
+            @"
+add_library($($pkg.target) SHARED IMPORTED GLOBAL)
+set_target_properties($($pkg.target) PROPERTIES
+  IMPORTED_IMPLIB   "$obsSlash/lib/$($pkg.dll).lib"
+  IMPORTED_LOCATION "$obsSlash/bin/64bit/$($pkg.dll).dll"
+  INTERFACE_INCLUDE_DIRECTORIES "$obsSlash/include"
+)
+set($($pkg.name)_FOUND TRUE)
+"@ | Set-Content "$dir\$($pkg.name)Config.cmake"
+          }
 
       - name: Download Zoom Windows SDK
         env:
           ZOOM_SDK_DOWNLOAD_URL: ${{ secrets.ZOOM_SDK_WINDOWS_URL }}
+        shell: powershell
         run: |
-          if ("$env:ZOOM_SDK_DOWNLOAD_URL" -ne "") {
-            Invoke-WebRequest -Uri $env:ZOOM_SDK_DOWNLOAD_URL -OutFile zoom-sdk.zip
-            Expand-Archive zoom-sdk.zip -DestinationPath third_party/zoom-sdk-extracted
-            # Move contents to expected path
+          if ($env:ZOOM_SDK_DOWNLOAD_URL) {
+            Invoke-WebRequest $env:ZOOM_SDK_DOWNLOAD_URL -OutFile zoom-sdk.zip
+            Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted
             $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
             Move-Item $inner.FullName third_party/zoom-sdk
           }
-        shell: powershell
 
       - name: Configure
         shell: powershell
         run: |
-          # OBS 30.x ships cmake config files at cmake\LibObs\ and cmake\obs-frontend-api\
-          # Probe both the flat zip root and the common nested layout.
-          $obsRoot   = "C:\obs-studio"
-          $cmakeRoot = "$obsRoot\cmake"
-
-          $libobsDir = if (Test-Path "$cmakeRoot\LibObs\LibObsConfig.cmake") {
-              "$cmakeRoot\LibObs"
-          } elseif (Test-Path "$obsRoot\lib\cmake\LibObs\LibObsConfig.cmake") {
-              "$obsRoot\lib\cmake\LibObs"
-          } else { $cmakeRoot }
-
-          $frontendDir = if (Test-Path "$cmakeRoot\obs-frontend-api\obs-frontend-apiConfig.cmake") {
-              "$cmakeRoot\obs-frontend-api"
-          } elseif (Test-Path "$obsRoot\lib\cmake\obs-frontend-api\obs-frontend-apiConfig.cmake") {
-              "$obsRoot\lib\cmake\obs-frontend-api"
-          } else { $cmakeRoot }
-
           cmake -B build -G "Visual Studio 17 2022" -A x64 `
             -DCMAKE_BUILD_TYPE=Release `
             -DZOOM_SDK_DIR=third_party/zoom-sdk `
-            -DCMAKE_PREFIX_PATH="$obsRoot" `
-            -DLibObs_DIR="$libobsDir" `
-            "-Dobs-frontend-api_DIR=$frontendDir" `
+            -DCMAKE_PREFIX_PATH="C:/obs-runtime" `
+            -DLibObs_DIR="C:/obs-runtime/cmake/LibObs" `
+            "-Dobs-frontend-api_DIR=C:/obs-runtime/cmake/obs-frontend-api" `
             "-DZOOM_EMBED_SDK_KEY=${{ secrets.ZOOM_EMBED_SDK_KEY }}" `
             "-DZOOM_EMBED_SDK_SECRET=${{ secrets.ZOOM_EMBED_SDK_SECRET }}" `
             "-DZOOM_EMBED_JWT_TOKEN=${{ secrets.ZOOM_EMBED_JWT_TOKEN }}"


### PR DESCRIPTION
## Problem

The OBS portable zip (`OBS-Studio-*.zip`) is an end-user package — it contains runtime DLLs but no cmake config files, headers, or import libraries. The previous probing logic searched `cmake\LibObs\` and `lib\cmake\LibObs\` but those paths don't exist in the zip, so `find_package(libobs)` always failed.

## Solution

The "Install OBS Studio" step now has two paths:

**Fast path** — if the zip already contains `cmake/LibObs/LibObsConfig.cmake` (e.g. a future OBS release ships dev files), it uses them directly and exits.

**Fallback** (current reality for OBS 30.x) — synthesises a complete dev environment in three substeps:

1. **Headers**: sparse-checkout of only `libobs/` and `UI/obs-frontend-api/` from the OBS source repo at the matching tag. Text files only — completes in seconds.
2. **Import libs**: `dumpbin /exports` parses each DLL's export table → `.def` file, then `lib.exe` generates a Windows import `.lib`. Both tools are provided by the new `ilammy/msvc-dev-cmd@v1` step.
3. **cmake configs**: writes minimal `LibObsConfig.cmake` and `obs-frontend-apiConfig.cmake` as `SHARED IMPORTED` targets pointing at the synthesised headers and libs.

The `Configure` step now passes explicit `LibObs_DIR` and `obs-frontend-api_DIR` variables instead of relying on `find_package` auto-discovery of OBS's non-standard `cmake/` layout.

## Test plan

- [ ] Trigger a CI run on this branch and confirm the Windows build reaches the `cmake --build` step without a `find_package` error
- [ ] Confirm the synthesised `obs.lib` and `obs-frontend-api.lib` allow the linker to resolve OBS symbols
- [ ] Confirm a tagged release produces a valid NSIS installer artifact

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP)_