### PR TITLE
Fix critical bugs: error handling, resource leaks, threading races, crash recovery, licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # CoreVideo
 
+> **LICENSING REQUIREMENT — READ BEFORE USE**
+>
+> Capturing raw video and audio from Zoom meetings via the Meeting SDK requires
+> a **Zoom Enhanced Media license** (or equivalent raw-data-enabled license) on
+> the Zoom account that is hosting or joining the meeting. Operating without
+> this license violates the [Zoom Marketplace developer agreement](https://marketplace.zoom.us/docs/api-reference/developer-agreement)
+> and will cause the SDK to return a raw-data permission error at runtime.
+>
+> Contact your Zoom account representative or visit
+> [Zoom Plans](https://zoom.us/pricing) to verify your entitlements before
+> deploying this plugin in a production environment.
+
 **OBS Studio plugin for live Zoom meeting video, audio, screen share, and language interpretation.**
 
 CoreVideo integrates the Zoom Meeting SDK directly into OBS — no screen capture or virtual camera required. It receives raw I420 video and 48 kHz PCM audio from any meeting participant, converts the frames, and pushes them into OBS as native sources. Two external control interfaces (TCP JSON + UDP OSC) and named output profiles enable full broadcast automation.
@@ -33,7 +45,7 @@ CoreVideo integrates the Zoom Meeting SDK directly into OBS — no screen captur
 | OBS Studio | 30+ | `libobs` + `obs-frontend-api` |
 | CMake | 3.16+ | Build system |
 | Qt | 6.x | Core + Network + Widgets |
-| Zoom Meeting SDK | 5.x | Place in `third_party/zoom-sdk/` |
+| Zoom Meeting SDK | **5.17.x** (tested) | Place in `third_party/zoom-sdk/`. Raw data API surface changes between minor versions; pin to 5.17.x unless you have tested a newer release. |
 | C++ compiler | C++17 | MSVC 2022 / Clang 14+ / GCC 11+ |
 | Zoom Developer Account | — | SDK key, secret & JWT token |
 

--- a/engine/src/engine-audio.cpp
+++ b/engine/src/engine-audio.cpp
@@ -1,5 +1,5 @@
 #include "engine-audio.h"
-#include "../../src/engine-ipc.h"
+#include "engine-writer.h"
 #include <zoom_rawdata_api.h>
 #include <cstring>
 
@@ -54,7 +54,7 @@ void EngineAudio::onMixedAudioRawDataReceived(AudioRawData *data)
     std::memcpy(static_cast<char *>(m_shm.ptr) + sizeof(ShmAudioHeader),
                 data->GetBuffer(), byte_len);
 
-    ipc_write_line(m_e2p_fd,
+    EngineIpc::write(
         R"({"cmd":"audio","source_uuid":")" + m_source_uuid +
         R"(","byte_len":)" + std::to_string(byte_len) + "}");
 }

--- a/engine/src/engine-video.cpp
+++ b/engine/src/engine-video.cpp
@@ -1,5 +1,5 @@
 #include "engine-video.h"
-#include "../../src/engine-ipc.h"
+#include "engine-writer.h"
 #include <zoom_rawdata_api.h>
 #include <cstring>
 
@@ -55,7 +55,7 @@ void ParticipantSubscription::onRawDataFrameReceived(YUVRawDataI420 *data)
     std::memcpy(pixels + y_len,           data->GetUBuffer(), y_len / 4);
     std::memcpy(pixels + y_len + y_len/4, data->GetVBuffer(), y_len / 4);
 
-    ipc_write_line(m_e2p_fd,
+    EngineIpc::write(
         R"({"cmd":"frame","source_uuid":")" + m_source_uuid +
         R"(","w":)" + std::to_string(w) + R"(,"h":)" + std::to_string(h) + "}");
 }

--- a/engine/src/engine-writer.h
+++ b/engine/src/engine-writer.h
@@ -1,0 +1,34 @@
+#pragma once
+// Thread-safe IPC write for the engine process.
+// The Zoom SDK fires auth, meeting, participant, video, and audio callbacks on
+// its own internal threads concurrently with the main IPC read loop.  All of
+// them write to the same e2p fd — serialise those writes here.
+#include "../../src/engine-ipc.h"
+#include <mutex>
+#include <string>
+
+namespace EngineIpc {
+
+inline IpcFd &fd()
+{
+    static IpcFd instance = kIpcInvalidFd;
+    return instance;
+}
+
+inline std::mutex &mtx()
+{
+    static std::mutex instance;
+    return instance;
+}
+
+// Call once from main() after e2p is established, before SDK callbacks start.
+inline void init(IpcFd e2p) { fd() = e2p; }
+
+// Serialised write — safe to call from any thread.
+inline void write(const std::string &msg)
+{
+    std::lock_guard<std::mutex> lk(mtx());
+    ipc_write_line(fd(), msg);
+}
+
+} // namespace EngineIpc

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -1,4 +1,5 @@
 #include "../../src/engine-ipc.h"
+#include "engine-writer.h"
 #include "engine-video.h"
 #include "engine-audio.h"
 #include <zoom_sdk.h>
@@ -287,7 +288,7 @@ public:
                 }
             }
         }
-        ipc_write_line(m_e2p, R"({"cmd":"active_speaker","participant_id":)" +
+        EngineIpc::write( R"({"cmd":"active_speaker","participant_id":)" +
                        std::to_string(active) + "}");
         send_roster();
     }
@@ -299,7 +300,7 @@ public:
             std::lock_guard<std::mutex> lk(m_mtx);
             if (m_active_speaker == 0) m_active_speaker = userId;
         }
-        ipc_write_line(m_e2p, R"({"cmd":"active_speaker","participant_id":)" +
+        EngineIpc::write( R"({"cmd":"active_speaker","participant_id":)" +
                        std::to_string(userId) + "}");
     }
 
@@ -393,7 +394,7 @@ private:
                 R"(,"is_muted":)" + (p.is_muted ? "true" : "false") + "}";
         }
         msg += "]}";
-        ipc_write_line(m_e2p, msg);
+        EngineIpc::write( msg);
     }
 
     IpcFd m_e2p;
@@ -413,9 +414,9 @@ public:
 
     void onAuthenticationReturn(ZOOMSDK::AuthResult ret) override {
         if (ret == ZOOMSDK::AUTHRET_SUCCESS)
-            ipc_write_line(m_e2p, R"({"cmd":"auth_ok"})");
+            EngineIpc::write( R"({"cmd":"auth_ok"})");
         else
-            ipc_write_line(m_e2p, R"({"cmd":"auth_fail","code":)" +
+            EngineIpc::write( R"({"cmd":"auth_fail","code":)" +
                            std::to_string(static_cast<int>(ret)) + "}");
     }
     void onLoginReturnWithReason(ZOOMSDK::LOGINSTATUS,
@@ -423,7 +424,7 @@ public:
                                  ZOOMSDK::LoginFailReason) override {}
     void onLogout() override {}
     void onZoomIdentityExpired() override {
-        ipc_write_line(m_e2p, R"({"cmd":"error","msg":"identity_expired"})");
+        EngineIpc::write( R"({"cmd":"error","msg":"identity_expired"})");
     }
     void onZoomAuthIdentityExpired() override {}
 #if defined(WIN32)
@@ -446,7 +447,7 @@ public:
     void onMeetingStatusChanged(ZOOMSDK::MeetingStatus status, int iResult) override {
         switch (status) {
         case ZOOMSDK::MEETING_STATUS_INMEETING:
-            ipc_write_line(m_e2p, R"({"cmd":"joined"})");
+            EngineIpc::write( R"({"cmd":"joined"})");
             if (m_participants && m_meeting_svc && *m_meeting_svc) {
                 m_participants->attach(
                     (*m_meeting_svc)->GetMeetingParticipantsController(),
@@ -457,11 +458,11 @@ public:
         case ZOOMSDK::MEETING_STATUS_DISCONNECTING:
         case ZOOMSDK::MEETING_STATUS_ENDED:
             if (m_participants) m_participants->detach();
-            ipc_write_line(m_e2p, R"({"cmd":"left"})");
+            EngineIpc::write( R"({"cmd":"left"})");
             break;
         case ZOOMSDK::MEETING_STATUS_FAILED:
             if (m_participants) m_participants->detach();
-            ipc_write_line(m_e2p, R"({"cmd":"error","msg":"meeting_failed","code":)" +
+            EngineIpc::write( R"({"cmd":"error","msg":"meeting_failed","code":)" +
                            std::to_string(iResult) + "}");
             break;
         default: break;
@@ -492,8 +493,9 @@ int main()
     IpcFd p2e = kIpcInvalidFd;
     IpcFd e2p = kIpcInvalidFd;
     if (!ipc_setup(p2e, e2p)) return 1;
+    EngineIpc::init(e2p); // must be called before any SDK callbacks can fire
 
-    ipc_write_line(e2p, R"({"cmd":"ready"})");
+    EngineIpc::write(R"({"cmd":"ready"})");
 
     ZOOMSDK::IAuthService    *auth_svc    = nullptr;
     ZOOMSDK::IMeetingService *meeting_svc = nullptr;
@@ -549,7 +551,7 @@ int main()
                 ctx.jwt_token = g_wide_jwt.c_str();
                 auth_svc->SDKAuth(ctx);
             } else {
-                ipc_write_line(e2p, R"({"cmd":"auth_fail","code":-1})");
+                EngineIpc::write( R"({"cmd":"auth_fail","code":-1})");
             }
 
         } else if (line.find(IPC_CMD_JOIN) != std::string::npos) {
@@ -572,7 +574,7 @@ int main()
                 try {
                     meeting_number = std::stoull(meeting_id);
                 } catch (...) {
-                    ipc_write_line(e2p, R"({"cmd":"error","msg":"invalid_meeting_id"})");
+                    EngineIpc::write( R"({"cmd":"error","msg":"invalid_meeting_id"})");
                     continue;
                 }
 

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -10,6 +10,9 @@
 #include "zoom-control-server.h"
 #include "zoom-osc-server.h"
 #include <QMainWindow>
+#include <QPointer>
+
+static QPointer<ZoomDock> g_dock;
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-zoom-plugin", "en-US")
@@ -27,8 +30,10 @@ bool obs_module_load(void)
 
     ZoomPluginSettings s = ZoomPluginSettings::load();
     ZoomControlServer::instance().set_token(s.control_token);
-    ZoomControlServer::instance().start(s.control_server_port);
-    ZoomOscServer::instance().start(s.osc_server_port);
+    if (!ZoomControlServer::instance().start(s.control_server_port))
+        blog(LOG_WARNING, "[obs-zoom-plugin] TCP control server unavailable — continuing without it");
+    if (!ZoomOscServer::instance().start(s.osc_server_port))
+        blog(LOG_WARNING, "[obs-zoom-plugin] OSC server unavailable — continuing without it");
 
     obs_frontend_add_tools_menu_item("Zoom Plugin Settings", [](void *) {
         auto *main_win = static_cast<QMainWindow *>(obs_frontend_get_main_window());
@@ -46,8 +51,12 @@ bool obs_module_load(void)
         [](enum obs_frontend_event event, void *) {
             if (event == OBS_FRONTEND_EVENT_FINISHED_LOADING) {
                 auto *main_win = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-                auto *dock = new ZoomDock(main_win);
-                obs_frontend_add_dock_by_id("ZoomControlDock", "Zoom Control", dock);
+                if (!main_win) {
+                    blog(LOG_WARNING, "[obs-zoom-plugin] obs_frontend_get_main_window() returned null — dock not created");
+                } else {
+                    g_dock = new ZoomDock(main_win);
+                    obs_frontend_add_dock_by_id("ZoomControlDock", "Zoom Control", g_dock);
+                }
             }
             if (event == OBS_FRONTEND_EVENT_EXIT)
                 ZoomEngineClient::instance().stop();

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -11,8 +11,10 @@
 #if defined(WIN32)
 #include <windows.h>
 #else
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #endif
 
@@ -84,6 +86,21 @@ bool ZoomEngineClient::start(const std::string &jwt_token)
 
     if (!launch_engine() || !connect_ipc()) {
         disconnect_ipc();
+        // Engine may have been launched before IPC connection failed — kill it.
+#if defined(WIN32)
+        if (m_process) {
+            TerminateProcess(static_cast<HANDLE>(m_process), 1);
+            WaitForSingleObject(static_cast<HANDLE>(m_process), 3000);
+            CloseHandle(static_cast<HANDLE>(m_process));
+            m_process = nullptr;
+        }
+#else
+        if (m_pid > 0) {
+            kill(m_pid, SIGTERM);
+            waitpid(m_pid, nullptr, 0);
+            m_pid = -1;
+        }
+#endif
         return false;
     }
 
@@ -105,6 +122,11 @@ void ZoomEngineClient::stop()
     if (m_process) {
         CloseHandle(static_cast<HANDLE>(m_process));
         m_process = nullptr;
+    }
+#else
+    if (m_pid > 0) {
+        waitpid(m_pid, nullptr, 0);
+        m_pid = -1;
     }
 #endif
 }

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -84,6 +84,10 @@ bool ZoomEngineClient::start(const std::string &jwt_token)
         return false;
     }
 
+    // Join threads from any previous session (e.g. after a crash).
+    if (m_reader.joinable())  m_reader.join();
+    if (m_monitor.joinable()) m_monitor.join();
+
     if (!launch_engine() || !connect_ipc()) {
         disconnect_ipc();
         // Engine may have been launched before IPC connection failed — kill it.
@@ -105,30 +109,55 @@ bool ZoomEngineClient::start(const std::string &jwt_token)
     }
 
     m_running.store(true, std::memory_order_release);
-    m_reader = std::thread([this]() { reader_loop(); });
+    m_reader  = std::thread([this]() { reader_loop(); });
+    m_monitor = std::thread([this]() { monitor_loop(); });
     write_json(R"({"cmd":"init","jwt":")" + json_escape(jwt_token) + "\"}");
     return true;
 }
 
 void ZoomEngineClient::stop()
 {
-    if (!m_running.exchange(false, std::memory_order_acq_rel)) return;
-    write_json(R"({"cmd":"quit"})");
-    disconnect_ipc();
-    if (m_reader.joinable()) m_reader.join();
+    if (m_running.exchange(false, std::memory_order_acq_rel)) {
+        write_json(R"({"cmd":"quit"})");
+        disconnect_ipc();
+    }
+    // Always join both threads — safe even if they already exited.
+    if (m_reader.joinable())  m_reader.join();
+    if (m_monitor.joinable()) m_monitor.join(); // also reaps the child process
     m_state.store(MeetingState::Idle, std::memory_order_release);
+}
 
+void ZoomEngineClient::monitor_loop()
+{
+    // Wait for the engine process to exit.
+    int exit_code = 0;
 #if defined(WIN32)
     if (m_process) {
+        WaitForSingleObject(static_cast<HANDLE>(m_process), INFINITE);
+        DWORD code = 0;
+        GetExitCodeProcess(static_cast<HANDLE>(m_process), &code);
+        exit_code = static_cast<int>(code);
         CloseHandle(static_cast<HANDLE>(m_process));
         m_process = nullptr;
     }
 #else
     if (m_pid > 0) {
-        waitpid(m_pid, nullptr, 0);
+        int status = 0;
+        waitpid(m_pid, &status, 0);
+        exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
         m_pid = -1;
     }
 #endif
+
+    // If m_running is still true the engine exited without being asked to.
+    if (m_running.exchange(false, std::memory_order_acq_rel)) {
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] ZoomObsEngine exited unexpectedly (code %d) — "
+             "use the Join button to reconnect",
+             exit_code);
+        m_state.store(MeetingState::Failed, std::memory_order_release);
+        disconnect_ipc(); // unblocks reader_loop so it exits cleanly
+    }
 }
 
 bool ZoomEngineClient::join(const std::string &meeting_id,

--- a/src/zoom-engine-client.h
+++ b/src/zoom-engine-client.h
@@ -46,6 +46,7 @@ private:
     bool connect_ipc();
     void disconnect_ipc();
     void reader_loop();
+    void monitor_loop();
     void handle_event(const std::string &line);
     void write_json(const std::string &json);
 
@@ -53,6 +54,7 @@ private:
     IpcFd m_p2e = kIpcInvalidFd;
     IpcFd m_e2p = kIpcInvalidFd;
     std::thread m_reader;
+    std::thread m_monitor;
     std::atomic<bool> m_running{false};
     std::atomic<MeetingState> m_state{MeetingState::Idle};
     uint32_t m_active_speaker_id = 0;

--- a/src/zoom-settings-dialog.cpp
+++ b/src/zoom-settings-dialog.cpp
@@ -83,8 +83,15 @@ void ZoomSettingsDialog::onSave()
     s.save();
 
     ZoomControlServer::instance().set_token(s.control_token);
+
     ZoomOscServer::instance().stop();
-    ZoomOscServer::instance().start(s.osc_server_port);
+    if (!ZoomOscServer::instance().start(s.osc_server_port)) {
+        QMessageBox::warning(this, "OSC Server",
+            QString("Failed to bind OSC server on port %1.\n"
+                    "Check that the port is not already in use.")
+                .arg(s.osc_server_port));
+        return;
+    }
 
     accept();
 }


### PR DESCRIPTION
Closes #25, #26, #27, #28, #29

## Changes

### #28 — Weak error handling
- `plugin-main.cpp`: null-guard `obs_frontend_get_main_window()` before dock creation; skip and warn on headless/CLI OBS builds
- `plugin-main.cpp`: check and log return values from `ZoomControlServer::start()` and `ZoomOscServer::start()` instead of silently swallowing port-in-use failures
- `zoom-settings-dialog.cpp`: surface OSC restart failure as a `QMessageBox` warning instead of silently closing the dialog

### #26 — Resource leaks
- `zoom-engine-client.cpp`: add POSIX `waitpid()` in `stop()` to reap the child process and prevent zombies
- `zoom-engine-client.cpp`: `TerminateProcess`/`kill` + wait in the `start()` failure path so a launched-but-not-connected engine is never abandoned
- `plugin-main.cpp`: store dock in `QPointer<ZoomDock>` so the pointer is automatically nulled when OBS destroys the widget

### #27 — Threading races
- New `engine/src/engine-writer.h`: `EngineIpc::write()` wraps `ipc_write_line()` behind a process-wide `std::mutex`
- All `ipc_write_line()` call sites in the engine (`main.cpp`, `engine-video.cpp`, `engine-audio.cpp`) replaced with `EngineIpc::write()` — eliminates concurrent writes to `e2p` from the Zoom SDK callback threads and the main IPC loop

### #29 — Engine crash recovery + UUID validation
- `zoom-engine-client.cpp`: new `monitor_loop()` thread waits on the child process via `WaitForSingleObject`/`waitpid`; unexpected exit transitions state to `Failed`, disconnects IPC so the reader exits cleanly, and logs the exit code
- `start()` joins any leftover threads before launching a new engine, allowing clean restart after a crash via the Join button
- `stop()` now always joins both reader and monitor threads; process reaping is centralised in `monitor_loop()`
- Confirmed `is_valid_source_uuid()` is enforced at both subscribe and unsubscribe IPC command sites

### #25 — Licensing compliance
- `README.md`: prominent Enhanced Media license blockquote at the top; SDK version pinned to 5.17.x in the Requirements table

## Test plan
- [ ] Normal join/leave cycle works; dock shows correct state transitions
- [ ] Killing `ZoomObsEngine` mid-session shows `Failed` in the dock and allows re-join
- [ ] Starting plugin on a port already in use logs a warning and loads without crash
- [ ] OSC port conflict shows dialog in settings instead of silently failing
- [ ] No zombie processes after plugin unload on macOS/Linux

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP)_