### PR TITLE
Add release pipeline: macOS DMG, workflow_dispatch trigger, fix YAML syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,12 @@ on:
     tags:     ['v*']
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.1.0) — leave blank to skip GitHub Release'
+        required: false
+        default: ''
 
 jobs:
   # ── Windows ────────────────────────────────────────────────────────────────
@@ -119,13 +125,13 @@ set($($pkg.name)_FOUND TRUE)
         run: cmake --build build --config Release --parallel
 
       - name: Package (NSIS installer)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         run: |
           cd build
           cpack -C Release -G NSIS
 
       - name: Upload installer artifact
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         uses: actions/upload-artifact@v4
         with:
           name: CoreVideo-Windows
@@ -207,13 +213,13 @@ set($($pkg.name)_FOUND TRUE)
         run: cmake --build build --parallel
 
       - name: Package (.dmg)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         run: |
           cd build
           cpack -C Release -G DragNDrop
 
       - name: Upload installer artifact
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         uses: actions/upload-artifact@v4
         with:
           name: CoreVideo-macOS
@@ -224,7 +230,7 @@ set($($pkg.name)_FOUND TRUE)
     name: Create GitHub Release
     needs: [build-windows, build-macos]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
     permissions:
       contents: write
     steps:
@@ -232,12 +238,26 @@ set($($pkg.name)_FOUND TRUE)
         with:
           path: artifacts
 
+      - name: Resolve release name
+        id: release_name
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=CoreVideo ${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ github.event.inputs.version }}"           >> "$GITHUB_OUTPUT"
+            echo "pre=${{ contains(github.event.inputs.version, '-') }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=CoreVideo ${{ github.ref_name }}"  >> "$GITHUB_OUTPUT"
+            echo "tag=${{ github.ref_name }}"             >> "$GITHUB_OUTPUT"
+            echo "pre=${{ contains(github.ref_name, '-') }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          name: CoreVideo ${{ github.ref_name }}
+          tag_name: ${{ steps.release_name.outputs.tag }}
+          name: ${{ steps.release_name.outputs.name }}
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ steps.release_name.outputs.pre == 'true' }}
           generate_release_notes: true
           files: |
             artifacts/CoreVideo-Windows/*.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,18 +206,18 @@ set($($pkg.name)_FOUND TRUE)
       - name: Build
         run: cmake --build build --parallel
 
-      - name: Package (.pkg)
+      - name: Package (.dmg)
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd build
-          cpack -C Release -G productbuild
+          cpack -C Release -G DragNDrop
 
       - name: Upload installer artifact
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: CoreVideo-macOS
-          path: build/CoreVideo-*.pkg
+          path: build/CoreVideo-*.dmg
 
   # ── Release ────────────────────────────────────────────────────────────────
   release:
@@ -241,4 +241,4 @@ set($($pkg.name)_FOUND TRUE)
           generate_release_notes: true
           files: |
             artifacts/CoreVideo-Windows/*.exe
-            artifacts/CoreVideo-macOS/*.pkg
+            artifacts/CoreVideo-macOS/*.dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,20 +80,21 @@ jobs:
           # ── cmake config files: one per package ──────────────────────────────
           $obsSlash = $obs -replace '\\', '/'
           foreach ($pkg in @(
-            @{ name = "LibObs";          target = "OBS::libobs";            dll = "obs"              },
-            @{ name = "obs-frontend-api"; target = "OBS::obs-frontend-api"; dll = "obs-frontend-api" }
+            @{ name = "LibObs";           target = "OBS::libobs";            dll = "obs"              },
+            @{ name = "obs-frontend-api"; target = "OBS::obs-frontend-api";  dll = "obs-frontend-api" }
           )) {
             $dir = "$obs\cmake\$($pkg.name)"
             New-Item -Force -ItemType Directory $dir | Out-Null
-            @"
-add_library($($pkg.target) SHARED IMPORTED GLOBAL)
-set_target_properties($($pkg.target) PROPERTIES
-  IMPORTED_IMPLIB   "$obsSlash/lib/$($pkg.dll).lib"
-  IMPORTED_LOCATION "$obsSlash/bin/64bit/$($pkg.dll).dll"
-  INTERFACE_INCLUDE_DIRECTORIES "$obsSlash/include"
-)
-set($($pkg.name)_FOUND TRUE)
-"@ | Set-Content "$dir\$($pkg.name)Config.cmake"
+            $lines = @(
+              "add_library($($pkg.target) SHARED IMPORTED GLOBAL)",
+              "set_target_properties($($pkg.target) PROPERTIES",
+              "  IMPORTED_IMPLIB   `"$obsSlash/lib/$($pkg.dll).lib`"",
+              "  IMPORTED_LOCATION `"$obsSlash/bin/64bit/$($pkg.dll).dll`"",
+              "  INTERFACE_INCLUDE_DIRECTORIES `"$obsSlash/include`"",
+              ")",
+              "set($($pkg.name)_FOUND TRUE)"
+            )
+            $lines -join "`n" | Set-Content "$dir\$($pkg.name)Config.cmake"
           }
 
       - name: Download Zoom Windows SDK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,10 +214,11 @@ if(WIN32)
     endif()
 
 elseif(APPLE)
-    # ── macOS productbuild .pkg ───────────────────────────────────────────────
-    set(CPACK_GENERATOR "productbuild")
-    set(CPACK_PACKAGING_INSTALL_PREFIX "/Applications/OBS.app/Contents/Resources")
-    set(CPACK_PRODUCTBUILD_IDENTIFIER  "com.corevideo.obs-zoom-plugin")
+    # ── macOS DragNDrop .dmg ──────────────────────────────────────────────────
+    # Users copy obs-plugins/ and data/ into OBS.app/Contents/Resources manually.
+    set(CPACK_GENERATOR "DragNDrop")
+    set(CPACK_DMG_VOLUME_NAME "CoreVideo ${PROJECT_VERSION}")
+    set(CPACK_DMG_FORMAT "UDZO")
 endif()
 
 include(CPack)


### PR DESCRIPTION
## Summary

- **macOS packaging switched from `.pkg` to `.dmg`** — CPack `DragNDrop` generator produces a compressed UDZO disk image; users mount the DMG and copy `obs-plugins/` + `data/` into `OBS.app/Contents/Resources`
- **`workflow_dispatch` release trigger** — adds a manual trigger with a `version` input (e.g. `v0.1.0`) so a full build + GitHub Release can be kicked off from the Actions UI without needing to push a git tag. The release job resolves the tag/name from the input when dispatched manually, or from `github.ref_name` when triggered by a tag push
- **YAML syntax fix** — PowerShell `@"..."@` here-strings require content at column 0, which conflicts with YAML literal block scalar indentation rules. Replaced with a string array joined by `` `n ``, which is fully indented and passes YAML validation

## How to release

1. Go to **Actions → Build → Run workflow**
2. Enter the version (e.g. `v0.1.0`) in the version field
3. Click **Run workflow**

The pipeline builds the Windows `.exe` (NSIS) and macOS `.dmg` (DragNDrop), then publishes a GitHub Release with both files attached.

## Test plan

- [ ] Confirm workflow file parses without YAML errors
- [ ] Trigger `workflow_dispatch` with version `v0.1.0-test` — verify Windows `.exe` and macOS `.dmg` are produced and attached to a GitHub Release
- [ ] Verify the release is marked pre-release when the version contains `-`
- [ ] Mount the macOS `.dmg` and confirm `obs-plugins/` and `data/` directories are present

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP)_