### PR TITLE
Fix PowerShell CI error: use double-quote doubling instead of backtick escaping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,11 @@ jobs:
         run: |
           $ver = "30.2.2"
           $obs = "C:\obs-runtime"
-          Invoke-WebRequest `
-            "https://github.com/obsproject/obs-studio/releases/download/$ver/OBS-Studio-$ver-Windows.zip" `
-            -OutFile obs.zip
+          $params = @{
+            Uri     = "https://github.com/obsproject/obs-studio/releases/download/$ver/OBS-Studio-$ver-Windows.zip"
+            OutFile = "obs.zip"
+          }
+          Invoke-WebRequest @params
           Expand-Archive obs.zip $obs -Force
 
           # ── Fast path: portable zip already contains cmake config files ──────

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,9 @@ jobs:
             $lines = @(
               "add_library($($pkg.target) SHARED IMPORTED GLOBAL)",
               "set_target_properties($($pkg.target) PROPERTIES",
-              "  IMPORTED_IMPLIB   `"$obsSlash/lib/$($pkg.dll).lib`"",
-              "  IMPORTED_LOCATION `"$obsSlash/bin/64bit/$($pkg.dll).dll`"",
-              "  INTERFACE_INCLUDE_DIRECTORIES `"$obsSlash/include`"",
+              "  IMPORTED_IMPLIB   ""$obsSlash/lib/$($pkg.dll).lib""",
+              "  IMPORTED_LOCATION ""$obsSlash/bin/64bit/$($pkg.dll).dll""",
+              "  INTERFACE_INCLUDE_DIRECTORIES ""$obsSlash/include""",
               ")",
               "set($($pkg.name)_FOUND TRUE)"
             )


### PR DESCRIPTION
## Summary

Fixes `RedirectionNotSupported` PowerShell parse error in the Windows CI step that writes CMake config files.

**Root cause:** Backtick-escaped quotes (`` `"..."` ``) inside a PowerShell double-quoted string were causing the CI runner's non-interactive PowerShell parser to throw `RedirectionNotSupported`. PowerShell supports both `` `" `` and `""` for embedding quotes in double-quoted strings, but the CI context only accepts the latter reliably.

**Fix:** Replace all `` `"` `` occurrences with `""` (PowerShell's own quote-doubling escape) in the cmake config string array.

```powershell
# Before (broken in CI)
"  IMPORTED_IMPLIB   `"$obsSlash/lib/$($pkg.dll).lib`"",

# After (works in all contexts)
"  IMPORTED_IMPLIB   ""$obsSlash/lib/$($pkg.dll).lib""",
```

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP)_