### PR TITLE
Fix Windows CI: remove all backtick continuations and non-ASCII chars from PowerShell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: recursive
 
-      # Puts dumpbin.exe and lib.exe on PATH — needed to synthesise import libs.
+      # Puts dumpbin.exe and lib.exe on PATH - needed to synthesise import libs.
       - name: Set up MSVC tools
         uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -41,15 +41,15 @@ jobs:
           Invoke-WebRequest @params
           Expand-Archive obs.zip $obs -Force
 
-          # ── Fast path: portable zip already contains cmake config files ──────
+          # Fast path: portable zip already contains cmake config files
           if (Test-Path "$obs\cmake\LibObs\LibObsConfig.cmake") {
-            Write-Host "cmake config files found in portable zip — nothing extra to do."
+            Write-Host "cmake config files found in portable zip - nothing extra to do."
             exit 0
           }
 
           Write-Host "Portable zip has no cmake dev files. Bootstrapping from OBS source + DLL exports."
 
-          # ── Headers: sparse-checkout only libobs + frontend-api ──────────────
+          # Headers: sparse-checkout only libobs + frontend-api
           git clone --depth 1 --branch $ver --filter=blob:none --sparse https://github.com/obsproject/obs-studio.git C:\obs-source
           Push-Location C:\obs-source
           git sparse-checkout set libobs UI/obs-frontend-api
@@ -59,13 +59,13 @@ jobs:
           Copy-Item C:\obs-source\libobs\*.h                                    "$obs\include\obs\"
           Copy-Item C:\obs-source\UI\obs-frontend-api\obs-frontend-api.h        "$obs\include\obs\"
 
-          # ── Import libs: generate from DLL export tables via dumpbin + lib ───
+          # Import libs: generate from DLL export tables via dumpbin + lib
           New-Item -Force -ItemType Directory "$obs\lib" | Out-Null
           foreach ($name in @("obs", "obs-frontend-api")) {
             $dll = "$obs\bin\64bit\$name.dll"
             $def = "$obs\lib\$name.def"
             $lib = "$obs\lib\$name.lib"
-            if (-not (Test-Path $dll)) { Write-Warning "$dll not found — skipping"; continue }
+            if (-not (Test-Path $dll)) { Write-Warning "$dll not found - skipping"; continue }
 
             $exports = @("EXPORTS")
             (dumpbin /nologo /exports $dll) | ForEach-Object {
@@ -78,7 +78,7 @@ jobs:
             lib /nologo /def:$def /out:$lib /machine:x64
           }
 
-          # ── cmake config files: one per package ──────────────────────────────
+          # cmake config files: one per package
           $obsSlash = $obs -replace '\\', '/'
           foreach ($pkg in @(
             @{ name = "LibObs";           target = "OBS::libobs";            dll = "obs"              },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,7 @@ jobs:
           Write-Host "Portable zip has no cmake dev files. Bootstrapping from OBS source + DLL exports."
 
           # ── Headers: sparse-checkout only libobs + frontend-api ──────────────
-          git clone --depth 1 --branch $ver --filter=blob:none --sparse `
-            https://github.com/obsproject/obs-studio.git C:\obs-source
+          git clone --depth 1 --branch $ver --filter=blob:none --sparse https://github.com/obsproject/obs-studio.git C:\obs-source
           Push-Location C:\obs-source
           git sparse-checkout set libobs UI/obs-frontend-api
           Pop-Location
@@ -114,15 +113,20 @@ jobs:
       - name: Configure
         shell: powershell
         run: |
-          cmake -B build -G "Visual Studio 17 2022" -A x64 `
-            -DCMAKE_BUILD_TYPE=Release `
-            -DZOOM_SDK_DIR=third_party/zoom-sdk `
-            -DCMAKE_PREFIX_PATH="C:/obs-runtime" `
-            -DLibObs_DIR="C:/obs-runtime/cmake/LibObs" `
-            "-Dobs-frontend-api_DIR=C:/obs-runtime/cmake/obs-frontend-api" `
-            "-DZOOM_EMBED_SDK_KEY=${{ secrets.ZOOM_EMBED_SDK_KEY }}" `
-            "-DZOOM_EMBED_SDK_SECRET=${{ secrets.ZOOM_EMBED_SDK_SECRET }}" `
+          $cmakeArgs = @(
+            '-B', 'build',
+            '-G', 'Visual Studio 17 2022',
+            '-A', 'x64',
+            '-DCMAKE_BUILD_TYPE=Release',
+            '-DZOOM_SDK_DIR=third_party/zoom-sdk',
+            '-DCMAKE_PREFIX_PATH=C:/obs-runtime',
+            '-DLibObs_DIR=C:/obs-runtime/cmake/LibObs',
+            '-Dobs-frontend-api_DIR=C:/obs-runtime/cmake/obs-frontend-api',
+            "-DZOOM_EMBED_SDK_KEY=${{ secrets.ZOOM_EMBED_SDK_KEY }}",
+            "-DZOOM_EMBED_SDK_SECRET=${{ secrets.ZOOM_EMBED_SDK_SECRET }}",
             "-DZOOM_EMBED_JWT_TOKEN=${{ secrets.ZOOM_EMBED_JWT_TOKEN }}"
+          )
+          cmake @cmakeArgs
 
       - name: Build
         run: cmake --build build --config Release --parallel


### PR DESCRIPTION
## Summary

Two compounding issues were causing `RedirectionNotSupported` / parse errors in the Windows CI PowerShell steps:

**1. Backtick line continuations** — PowerShell backtick (`` ` ``) continuations are unreliable in non-interactive CI contexts. Fixed by collapsing `git clone` onto one line and replacing the `cmake` multi-line call with array splatting (`cmake @cmakeArgs`).

**2. Non-ASCII characters causing encoding corruption** — Em dashes (`—`, U+2014) and box-drawing chars (`─`, U+2500) both contain byte `0x94` in their UTF-8 encoding. The Windows CI runner reads the temp `.ps1` file as Windows-1252, where `0x94` maps to `"` (RIGHT DOUBLE QUOTATION MARK, U+201D). This injects spurious quote characters mid-string, prematurely closing string literals and cascading into dozens of parse errors. Replaced all non-ASCII characters in PowerShell `run:` blocks with plain ASCII hyphens.

## Changes
- `git clone` collapsed to single line
- `cmake` configure args use `@cmakeArgs` array splatting
- `Invoke-WebRequest` uses `@params` hashtable splatting  
- All em dashes (`—`) and box-drawing decorators (`──`) in PowerShell `run:` blocks replaced with `-`

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP)_