### PR TITLE
Fix CMake find_package case mismatch: libobs -> LibObs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(ZOOM_EMBED_JWT_TOKEN  "" CACHE STRING "Pre-embedded Zoom JWT token")
 configure_file(src/zoom-credentials.h.in
                "${CMAKE_CURRENT_BINARY_DIR}/zoom-credentials.h" @ONLY)
 
-find_package(libobs REQUIRED)
+find_package(LibObs REQUIRED)
 find_package(obs-frontend-api REQUIRED)
 find_package(Qt6 COMPONENTS Core Network Widgets REQUIRED)
 


### PR DESCRIPTION
## Problem

Windows and macOS builds were failing with:

```
CMake Error at CMakeLists.txt:15 (find_package):
  Could not find a package configuration file provided by "libobs"
  (libobsConfig.cmake or libobs-config.cmake)
```

## Root Cause

`find_package` is case-sensitive in how it constructs the filename to search for and the `_DIR` hint variable it reads:

| Call | File cmake looks for | Hint variable used |
|---|---|---|
| `find_package(libobs)` | `libobsConfig.cmake` | `libobs_DIR` |
| `find_package(LibObs)` | `LibObsConfig.cmake` | `LibObs_DIR` |

The CI workflow generates `LibObsConfig.cmake` and passes `-DLibObs_DIR`, but `CMakeLists.txt` was calling `find_package(libobs)` (lowercase), so cmake looked for `libobsConfig.cmake` and ignored the `LibObs_DIR` hint entirely — even on case-insensitive filesystems, because cmake constructs the search filename internally.

## Fix

One-line change in `CMakeLists.txt`:

```cmake
# Before
find_package(libobs REQUIRED)

# After
find_package(LibObs REQUIRED)
```

The imported target `OBS::libobs` is declared inside the config file itself, so that reference is unaffected.

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP)_