### PR TITLE
build: produce downloadable artifacts on every push; make Zoom SDK op…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
     tags:     ['v*']
   pull_request:
     branches: [main]
@@ -138,18 +138,38 @@ jobs:
       - name: Build
         run: cmake --build build --config Release --parallel
 
+      - name: List build outputs
+        if: always()
+        shell: powershell
+        run: |
+          Write-Host "=== build/ tree ==="
+          Get-ChildItem -Recurse build -ErrorAction SilentlyContinue |
+            Where-Object { -not $_.PSIsContainer } |
+            Select-Object FullName,Length |
+            Format-Table -AutoSize
+
       - name: Package (NSIS installer)
-        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
+        shell: powershell
         run: |
           cd build
           cpack -C Release -G NSIS
 
       - name: Upload installer artifact
-        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         uses: actions/upload-artifact@v4
         with:
           name: CoreVideo-Windows
           path: build/CoreVideo-*.exe
+          if-no-files-found: warn
+
+      - name: Upload plugin DLL (always)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: CoreVideo-Windows-plugin
+          path: |
+            build/Release/obs-zoom-plugin.dll
+            build/Release/ZoomObsEngine.exe
+          if-no-files-found: warn
 
   # ── macOS ──────────────────────────────────────────────────────────────────
   build-macos:
@@ -227,18 +247,33 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
+      - name: List build outputs
+        if: always()
+        run: |
+          echo "=== build/ tree ==="
+          find build -maxdepth 3 -type f | head -100 || true
+
       - name: Package (.dmg)
-        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         run: |
           cd build
           cpack -C Release -G DragNDrop
 
       - name: Upload installer artifact
-        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         uses: actions/upload-artifact@v4
         with:
           name: CoreVideo-macOS
           path: build/CoreVideo-*.dmg
+          if-no-files-found: warn
+
+      - name: Upload plugin bundle (always)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: CoreVideo-macOS-plugin
+          path: |
+            build/obs-zoom-plugin*
+            build/ZoomObsEngine*
+          if-no-files-found: warn
 
   # ── Release ────────────────────────────────────────────────────────────────
   release:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,21 +58,40 @@ if(WIN32)
     else()
         set(ZOOM_SDK_RUNTIME_DIR "")
     endif()
+endif()
 
-    if(NOT EXISTS "${ZOOM_SDK_INCLUDE_DIR}/zoom_sdk.h")
-        message(FATAL_ERROR
-            "Zoom SDK headers not found at ${ZOOM_SDK_INCLUDE_DIR}. "
-            "Set ZOOM_SDK_DIR to the SDK folder that contains h/zoom_sdk.h.")
+# Decide whether we have everything we need to build the engine binary.
+# The plugin DLL itself never includes Zoom SDK headers; only the engine does.
+# When the SDK isn't present we still build the plugin (useful for CI smoke
+# tests and OBS API development) and skip the engine target with a warning.
+set(BUILD_ZOOM_ENGINE OFF)
+if(WIN32)
+    if(EXISTS "${ZOOM_SDK_INCLUDE_DIR}/zoom_sdk.h"
+        AND EXISTS "${ZOOM_SDK_LIBRARY}"
+        AND NOT "${ZOOM_SDK_RUNTIME_DIR}" STREQUAL "")
+        set(BUILD_ZOOM_ENGINE ON)
+    else()
+        message(WARNING
+            "Zoom SDK not found under '${ZOOM_SDK_DIR}'. "
+            "Building plugin DLL only; ZoomObsEngine.exe will not be produced. "
+            "Set ZOOM_SDK_DIR to a directory containing h/zoom_sdk.h + lib/sdk.lib + bin/sdk.dll "
+            "to enable the engine target.")
     endif()
-    if(NOT EXISTS "${ZOOM_SDK_LIBRARY}")
-        message(FATAL_ERROR
-            "Zoom SDK import library not found at ${ZOOM_SDK_LIBRARY}. "
-            "Set ZOOM_SDK_DIR to the SDK folder that contains lib/sdk.lib.")
+elseif(APPLE)
+    if(EXISTS "${ZOOM_SDK_DIR}/ZoomSDK.framework")
+        set(BUILD_ZOOM_ENGINE ON)
+    else()
+        message(WARNING
+            "Zoom SDK framework not found at '${ZOOM_SDK_DIR}/ZoomSDK.framework'. "
+            "Building plugin bundle only; ZoomObsEngine will not be produced.")
     endif()
-    if(ZOOM_SDK_RUNTIME_DIR STREQUAL "")
-        message(FATAL_ERROR
-            "Zoom SDK runtime folder not found. Expected bin/sdk.dll under "
-            "${ZOOM_SDK_DIR} or ${ZOOM_SDK_BASE}.")
+elseif(UNIX)
+    if(EXISTS "${ZOOM_SDK_DIR}/lib/libsdk.so")
+        set(BUILD_ZOOM_ENGINE ON)
+    else()
+        message(WARNING
+            "Zoom SDK shared library not found at '${ZOOM_SDK_DIR}/lib/libsdk.so'. "
+            "Building plugin only; ZoomObsEngine will not be produced.")
     endif()
 endif()
 
@@ -131,47 +150,49 @@ set(ENGINE_SOURCES
 )
 set(ENGINE_INCLUDES src engine/src ${ZOOM_SDK_INCLUDE_DIR})
 
-if(WIN32)
-    add_executable(ZoomObsEngine ${ENGINE_SOURCES})
-    target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
-    target_link_libraries(ZoomObsEngine PRIVATE
-        ws2_32 crypt32 winhttp shlwapi
-        ${ZOOM_SDK_LIBRARY}
-    )
-    set_target_properties(ZoomObsEngine PROPERTIES WIN32_EXECUTABLE FALSE)
-    add_custom_command(TARGET ZoomObsEngine POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${ZOOM_SDK_RUNTIME_DIR}"
-            "$<TARGET_FILE_DIR:ZoomObsEngine>"
-        COMMENT "Copying Zoom SDK runtime files to output directory"
-    )
-    install(TARGETS ZoomObsEngine
-        RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
-    )
-    install(DIRECTORY "${ZOOM_SDK_RUNTIME_DIR}/"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
-    )
-elseif(APPLE)
-    add_executable(ZoomObsEngine ${ENGINE_SOURCES})
-    target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
-    target_link_libraries(ZoomObsEngine PRIVATE
-        "-framework ${ZOOM_SDK_FRAMEWORK}"
-        "-framework CoreFoundation"
-        "-framework Foundation"
-    )
-    install(TARGETS ZoomObsEngine
-        RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
-    )
-elseif(UNIX)
-    add_executable(ZoomObsEngine ${ENGINE_SOURCES})
-    target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
-    target_link_libraries(ZoomObsEngine PRIVATE
-        ${ZOOM_SDK_DIR}/lib/libsdk.so
-        rt
-    )
-    install(TARGETS ZoomObsEngine
-        RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
-    )
+if(BUILD_ZOOM_ENGINE)
+    if(WIN32)
+        add_executable(ZoomObsEngine ${ENGINE_SOURCES})
+        target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
+        target_link_libraries(ZoomObsEngine PRIVATE
+            ws2_32 crypt32 winhttp shlwapi
+            ${ZOOM_SDK_LIBRARY}
+        )
+        set_target_properties(ZoomObsEngine PROPERTIES WIN32_EXECUTABLE FALSE)
+        add_custom_command(TARGET ZoomObsEngine POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${ZOOM_SDK_RUNTIME_DIR}"
+                "$<TARGET_FILE_DIR:ZoomObsEngine>"
+            COMMENT "Copying Zoom SDK runtime files to output directory"
+        )
+        install(TARGETS ZoomObsEngine
+            RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+        )
+        install(DIRECTORY "${ZOOM_SDK_RUNTIME_DIR}/"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+        )
+    elseif(APPLE)
+        add_executable(ZoomObsEngine ${ENGINE_SOURCES})
+        target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
+        target_link_libraries(ZoomObsEngine PRIVATE
+            "-framework ${ZOOM_SDK_FRAMEWORK}"
+            "-framework CoreFoundation"
+            "-framework Foundation"
+        )
+        install(TARGETS ZoomObsEngine
+            RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+        )
+    elseif(UNIX)
+        add_executable(ZoomObsEngine ${ENGINE_SOURCES})
+        target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
+        target_link_libraries(ZoomObsEngine PRIVATE
+            ${ZOOM_SDK_DIR}/lib/libsdk.so
+            rt
+        )
+        install(TARGETS ZoomObsEngine
+            RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+        )
+    endif()
 endif()
 
 install(TARGETS obs-zoom-plugin


### PR DESCRIPTION
…tional

This makes the build pipeline actually useful for testing. Three changes:

1. CI triggers on push to any branch (not just main). Previously only PRs against main rebuilt, so working branches got no feedback.

2. Package + Upload steps always run. Previously they were gated on tag pushes / workflow_dispatch with a version, so even a successful build produced nothing downloadable. The "List build outputs" step added before packaging makes it obvious what got built when CPack fails. A second artifact (plugin DLL/dylib + engine binary) is always uploaded with if-no-files-found: warn so something useful comes back even when NSIS/DragNDrop fails.

3. The Zoom SDK is now optional. CMake previously FATAL_ERRORed if ZOOM_SDK_DIR didn't contain h/zoom_sdk.h + lib/sdk.lib + bin/sdk.dll. That meant anyone without the (NDA-locked) SDK secret got no build at all -- but the plugin DLL itself never includes zoom_sdk.h; only the engine binary does. Now we detect the SDK and only emit the ZoomObsEngine target when it's present, with a clear WARNING message listing what's missing. The plugin DLL always builds.

This means: on the next push, the user can pull "CoreVideo-Windows" and "CoreVideo-Windows-plugin" artifacts directly from the Actions run.

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP