### PR TITLE
fix: race conditions, broken retry counting, and OOB reads found in a…

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -12,6 +12,9 @@
 #include "zoom-osc-server.h"
 #include <QMainWindow>
 #include <QPointer>
+#if !defined(WIN32)
+#include <csignal>
+#endif
 
 static QPointer<ZoomDock> g_dock;
 
@@ -26,6 +29,13 @@ MODULE_EXPORT const char *obs_module_description(void)
 bool obs_module_load(void)
 {
     blog(LOG_INFO, "[obs-zoom-plugin] Loading plugin v%s", OBS_ZOOM_PLUGIN_VERSION);
+
+#if !defined(WIN32)
+    // Writing to a closed pipe (engine crashed) raises SIGPIPE on POSIX,
+    // which would kill the host OBS process. Ignore it so the write returns
+    // EPIPE instead and we can route the failure through normal error paths.
+    std::signal(SIGPIPE, SIG_IGN);
+#endif
 
     zoom_source_register();
 

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -85,7 +85,7 @@ bool ZoomEngineClient::start(const std::string &jwt_token)
         return false;
     }
     m_last_jwt = jwt_token;
-    m_user_leaving = false;
+    m_user_leaving.store(false, std::memory_order_release);
 
     // Join threads from any previous session (e.g. after a crash).
     if (m_reader.joinable())  m_reader.join();
@@ -120,7 +120,16 @@ bool ZoomEngineClient::start(const std::string &jwt_token)
 
 void ZoomEngineClient::stop()
 {
-    m_user_leaving = true;
+    m_user_leaving.store(true, std::memory_order_release);
+    // Cancel any pending reconnect BEFORE tearing down the engine so a
+    // queued execute_retry on the UI thread cannot resurrect us.
+    ZoomReconnectManager::instance().cancel();
+    ZoomReconnectManager::instance().clear_session();
+    stop_for_reconnect();
+}
+
+void ZoomEngineClient::stop_for_reconnect()
+{
     if (m_running.exchange(false, std::memory_order_acq_rel)) {
         write_json(R"({"cmd":"quit"})");
         disconnect_ipc();
@@ -160,6 +169,13 @@ void ZoomEngineClient::monitor_loop()
              exit_code);
         disconnect_ipc(); // unblocks reader_loop so it exits cleanly
 
+        // If the user is in the middle of leaving / stopping, don't try to recover —
+        // we lost a race against stop() but the user's intent is clear.
+        if (m_user_leaving.load(std::memory_order_acquire)) {
+            m_state.store(MeetingState::Idle, std::memory_order_release);
+            return;
+        }
+
         RecoveryReason reason = RecoveryReason::EngineCrash;
         if (exit_code == 2) reason = RecoveryReason::AuthFailure;
         else if (exit_code == 3) reason = RecoveryReason::SdkError;
@@ -189,7 +205,7 @@ bool ZoomEngineClient::join(const std::string &meeting_id,
 void ZoomEngineClient::leave()
 {
     if (!m_running.load(std::memory_order_acquire)) return;
-    m_user_leaving = true;
+    m_user_leaving.store(true, std::memory_order_release);
     ZoomReconnectManager::instance().cancel(); // suppress any in-progress recovery
     m_state.store(MeetingState::Leaving, std::memory_order_release);
     write_json(R"({"cmd":"leave"})");
@@ -351,7 +367,7 @@ void ZoomEngineClient::handle_event(const std::string &line)
             ZoomReconnectManager::instance().trigger(RecoveryReason::HostEndedMeeting);
         } else {
             // Retriable failure — let reconnect manager decide.
-            if (!m_user_leaving) {
+            if (!m_user_leaving.load(std::memory_order_acquire)) {
                 ZoomReconnectManager::instance().on_join_failed(false);
             } else {
                 m_state.store(MeetingState::Failed, std::memory_order_release);

--- a/src/zoom-engine-client.h
+++ b/src/zoom-engine-client.h
@@ -21,6 +21,9 @@ public:
 
     bool start(const std::string &jwt_token);
     void stop();
+    // Same as stop() but does not set the user-leaving flag and does not
+    // cancel a pending recovery. Used by ZoomReconnectManager between retries.
+    void stop_for_reconnect();
 
     bool join(const std::string &meeting_id, const std::string &passcode,
               const std::string &display_name);
@@ -65,7 +68,7 @@ private:
     std::unordered_map<std::string, SourceCallbacks> m_sources;
     std::unordered_map<void *, RosterCallback> m_roster_callbacks;
     // Tracks whether the user deliberately requested a leave/stop (suppresses recovery).
-    bool m_user_leaving = false;
+    std::atomic<bool> m_user_leaving{false};
     std::string m_last_jwt; // stored so reconnect manager can access it
 
 #if defined(WIN32)

--- a/src/zoom-reconnect.cpp
+++ b/src/zoom-reconnect.cpp
@@ -11,12 +11,18 @@ ZoomReconnectManager &ZoomReconnectManager::instance()
     return inst;
 }
 
+ZoomReconnectManager::ZoomReconnectManager()
+{
+    m_timer = std::thread([this]() { timer_loop(); });
+}
+
 ZoomReconnectManager::~ZoomReconnectManager()
 {
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        m_timer_cancel = true;
-        m_destroyed    = true;
+        m_stop_thread = true;
+        m_pending     = false;
+        ++m_generation;
     }
     m_cv.notify_all();
     if (m_timer.joinable()) m_timer.join();
@@ -46,9 +52,20 @@ void ZoomReconnectManager::store_session(const std::string &jwt,
     m_display_name = display_name;
 }
 
-int ZoomReconnectManager::compute_delay(int attempt) const
+void ZoomReconnectManager::clear_session()
 {
-    // Already holds m_mtx.
+    std::lock_guard<std::mutex> lk(m_mtx);
+    // Wipe credentials we no longer need (defensive hygiene).
+    m_jwt.assign(m_jwt.size(), '\0');
+    m_jwt.clear();
+    m_meeting_id.clear();
+    m_passcode.assign(m_passcode.size(), '\0');
+    m_passcode.clear();
+    m_display_name.clear();
+}
+
+int ZoomReconnectManager::compute_delay_locked(int attempt) const
+{
     double delay = m_policy.base_delay_ms *
                    std::pow(static_cast<double>(m_policy.backoff_multiplier), attempt);
     return static_cast<int>(std::min(delay, static_cast<double>(m_policy.max_delay_ms)));
@@ -59,8 +76,17 @@ int ZoomReconnectManager::next_retry_ms() const
     if (!m_recovering.load(std::memory_order_acquire)) return 0;
     using namespace std::chrono;
     std::lock_guard<std::mutex> lk(m_mtx);
+    if (!m_pending) return 0;
     auto remaining = duration_cast<milliseconds>(m_retry_at - steady_clock::now());
     return std::max(0, static_cast<int>(remaining.count()));
+}
+
+void ZoomReconnectManager::reset_state_locked()
+{
+    m_pending = false;
+    ++m_generation;
+    m_recovering.store(false, std::memory_order_release);
+    m_attempt.store(0, std::memory_order_release);
 }
 
 void ZoomReconnectManager::trigger(RecoveryReason reason)
@@ -69,28 +95,36 @@ void ZoomReconnectManager::trigger(RecoveryReason reason)
 
     if (!m_policy.enabled) {
         blog(LOG_WARNING, "[obs-zoom-plugin] Reconnect disabled; not recovering");
+        reset_state_locked();
+        lk.unlock();
+        ZoomEngineClient::instance().set_state(MeetingState::Failed);
         return;
     }
 
-    // Check per-reason policy.
+    auto give_up = [&](const char *msg, MeetingState final_state) {
+        blog(LOG_INFO, "[obs-zoom-plugin] %s", msg);
+        reset_state_locked();
+        lk.unlock();
+        ZoomEngineClient::instance().set_state(final_state);
+    };
+
     switch (reason) {
     case RecoveryReason::LicenseError:
-        blog(LOG_ERROR, "[obs-zoom-plugin] License error — reconnect not attempted");
+        give_up("License error - reconnect not attempted", MeetingState::Failed);
         return;
     case RecoveryReason::AuthFailure:
         if (!m_policy.on_auth_fail) {
-            blog(LOG_ERROR, "[obs-zoom-plugin] Auth failure — reconnect suppressed by policy");
+            give_up("Auth failure - reconnect suppressed by policy", MeetingState::Failed);
             return;
         }
         break;
     case RecoveryReason::HostEndedMeeting:
-        blog(LOG_INFO, "[obs-zoom-plugin] Host ended meeting — not reconnecting");
-        // Set Idle, not Failed.
-        ZoomEngineClient::instance().set_state(MeetingState::Idle);
+        give_up("Host ended meeting - not reconnecting", MeetingState::Idle);
         return;
     case RecoveryReason::EngineCrash:
         if (!m_policy.on_engine_crash) {
-            blog(LOG_WARNING, "[obs-zoom-plugin] Engine crash — reconnect suppressed by policy");
+            give_up("Engine crash - reconnect suppressed by policy",
+                    MeetingState::Failed);
             return;
         }
         break;
@@ -98,46 +132,47 @@ void ZoomReconnectManager::trigger(RecoveryReason reason)
     case RecoveryReason::NetworkDrop:
     case RecoveryReason::SdkError:
         if (!m_policy.on_disconnect) {
-            blog(LOG_WARNING, "[obs-zoom-plugin] Disconnect — reconnect suppressed by policy");
+            give_up("Disconnect - reconnect suppressed by policy",
+                    MeetingState::Failed);
             return;
         }
         break;
     }
 
     if (m_meeting_id.empty()) {
-        blog(LOG_WARNING, "[obs-zoom-plugin] No stored session — cannot reconnect");
+        give_up("No stored session - cannot reconnect", MeetingState::Failed);
         return;
     }
 
     const int attempt = m_attempt.load(std::memory_order_relaxed);
     if (attempt >= m_policy.max_attempts) {
-        blog(LOG_ERROR, "[obs-zoom-plugin] Max reconnect attempts (%d) reached — giving up",
+        blog(LOG_ERROR, "[obs-zoom-plugin] Max reconnect attempts (%d) reached",
              m_policy.max_attempts);
+        reset_state_locked();
+        lk.unlock();
         ZoomEngineClient::instance().set_state(MeetingState::Failed);
-        m_recovering.store(false, std::memory_order_release);
         return;
     }
 
     m_recovering.store(true, std::memory_order_release);
-    ZoomEngineClient::instance().set_state(MeetingState::Recovering);
-
-    const int delay = compute_delay(attempt);
+    const int delay = compute_delay_locked(attempt);
     blog(LOG_INFO, "[obs-zoom-plugin] Scheduling reconnect attempt %d/%d in %d ms",
          attempt + 1, m_policy.max_attempts, delay);
 
-    schedule_retry(delay);
+    schedule_retry_locked(delay);
+    lk.unlock();
+    ZoomEngineClient::instance().set_state(MeetingState::Recovering);
 }
 
 void ZoomReconnectManager::cancel()
 {
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        m_timer_cancel = true;
-        m_recovering.store(false, std::memory_order_release);
-        m_attempt.store(0, std::memory_order_release);
+        if (!m_recovering.load(std::memory_order_acquire) && !m_pending) return;
+        reset_state_locked();
     }
     m_cv.notify_all();
-    blog(LOG_INFO, "[obs-zoom-plugin] Recovery cancelled by user");
+    blog(LOG_INFO, "[obs-zoom-plugin] Recovery cancelled");
     ZoomEngineClient::instance().set_state(MeetingState::Idle);
 }
 
@@ -145,107 +180,129 @@ void ZoomReconnectManager::on_join_success()
 {
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        m_timer_cancel = true;
-        m_recovering.store(false, std::memory_order_release);
-        m_attempt.store(0, std::memory_order_release);
+        reset_state_locked();
     }
     m_cv.notify_all();
 
-    blog(LOG_INFO, "[obs-zoom-plugin] Reconnect succeeded — resubscribing all outputs");
-    // Re-subscribe all sources so they receive video/audio again.
+    blog(LOG_INFO, "[obs-zoom-plugin] Reconnect succeeded - resubscribing outputs");
     ZoomOutputManager::instance().resubscribe_all();
 }
 
 void ZoomReconnectManager::on_join_failed(bool permanent)
 {
     if (permanent) {
-        blog(LOG_ERROR, "[obs-zoom-plugin] Permanent join failure — not retrying");
+        blog(LOG_ERROR, "[obs-zoom-plugin] Permanent join failure - not retrying");
         {
             std::lock_guard<std::mutex> lk(m_mtx);
-            m_recovering.store(false, std::memory_order_release);
-            m_attempt.store(0, std::memory_order_release);
+            reset_state_locked();
         }
+        m_cv.notify_all();
         ZoomEngineClient::instance().set_state(MeetingState::Failed);
         return;
     }
-
-    // Increment attempt counter and schedule next retry.
-    const int attempt = m_attempt.fetch_add(1, std::memory_order_acq_rel) + 1;
 
     std::unique_lock<std::mutex> lk(m_mtx);
+
+    // Count this attempt as consumed.
+    const int attempt = m_attempt.fetch_add(1, std::memory_order_acq_rel) + 1;
+
     if (attempt >= m_policy.max_attempts) {
-        blog(LOG_ERROR, "[obs-zoom-plugin] Reconnect attempt %d/%d failed — giving up",
+        blog(LOG_ERROR, "[obs-zoom-plugin] Reconnect attempt %d/%d failed - giving up",
              attempt, m_policy.max_attempts);
-        m_recovering.store(false, std::memory_order_release);
-        m_attempt.store(0, std::memory_order_release);
+        reset_state_locked();
         lk.unlock();
         ZoomEngineClient::instance().set_state(MeetingState::Failed);
         return;
     }
 
-    const int delay = compute_delay(attempt);
-    blog(LOG_WARNING, "[obs-zoom-plugin] Reconnect attempt %d/%d failed — retrying in %d ms",
+    const int delay = compute_delay_locked(attempt);
+    blog(LOG_WARNING, "[obs-zoom-plugin] Reconnect attempt %d/%d failed - retrying in %d ms",
          attempt, m_policy.max_attempts, delay);
 
+    m_recovering.store(true, std::memory_order_release);
+    schedule_retry_locked(delay);
+    lk.unlock();
     ZoomEngineClient::instance().set_state(MeetingState::Recovering);
-    schedule_retry(delay);
 }
 
-void ZoomReconnectManager::schedule_retry(int delay_ms)
+void ZoomReconnectManager::schedule_retry_locked(int delay_ms)
 {
-    // Must be called with m_mtx held.
-    m_timer_cancel = true;
-    m_cv.notify_all();
-    if (m_timer.joinable()) m_timer.detach(); // detach; cancellation via m_timer_cancel
-
-    m_timer_cancel = false;
+    // Must be called with m_mtx held. Bumps generation so any previously
+    // scheduled wake-up that races to fire will see the new generation and
+    // ignore itself.
+    ++m_generation;
+    m_pending  = true;
     m_retry_at = std::chrono::steady_clock::now() +
                  std::chrono::milliseconds(delay_ms);
-
-    m_timer = std::thread([this, delay_ms]() {
-        std::unique_lock<std::mutex> lk(m_mtx);
-        const bool cancelled = m_cv.wait_for(
-            lk, std::chrono::milliseconds(delay_ms),
-            [this]() { return m_timer_cancel || m_destroyed; });
-        const bool destroyed = m_destroyed;
-        lk.unlock();
-
-        if (!cancelled && !destroyed) {
-            obs_queue_task(OBS_TASK_UI, [](void *param) {
-                static_cast<ZoomReconnectManager *>(param)->execute_retry();
-            }, this, false);
-        }
-    });
+    m_cv.notify_all();
 }
 
-void ZoomReconnectManager::execute_retry()
+void ZoomReconnectManager::timer_loop()
+{
+    std::unique_lock<std::mutex> lk(m_mtx);
+    while (!m_stop_thread) {
+        if (!m_pending) {
+            m_cv.wait(lk, [this]() { return m_stop_thread || m_pending; });
+            continue;
+        }
+
+        const uint64_t gen      = m_generation;
+        const auto      deadline = m_retry_at;
+        // Sleep until deadline, but wake early if state changes.
+        m_cv.wait_until(lk, deadline, [this, gen]() {
+            return m_stop_thread || !m_pending || m_generation != gen;
+        });
+
+        if (m_stop_thread) break;
+        if (!m_pending || m_generation != gen) continue; // cancelled or rescheduled
+        if (std::chrono::steady_clock::now() < m_retry_at) continue; // spurious wake
+
+        // Consume the pending request before scheduling on UI thread.
+        m_pending = false;
+        const uint64_t fire_gen = m_generation;
+        lk.unlock();
+
+        // We pass the generation through to execute_retry so it can verify
+        // that a cancel() did not race between this point and OBS dispatching
+        // the task on the UI thread.
+        struct Payload { ZoomReconnectManager *mgr; uint64_t gen; };
+        auto *payload = new Payload{this, fire_gen};
+        obs_queue_task(OBS_TASK_UI, [](void *p) {
+            auto *pl = static_cast<Payload *>(p);
+            pl->mgr->execute_retry(pl->gen);
+            delete pl;
+        }, payload, false);
+
+        lk.lock();
+    }
+}
+
+void ZoomReconnectManager::execute_retry(uint64_t generation)
 {
     // Runs on the OBS UI thread.
-    if (!m_recovering.load(std::memory_order_acquire)) return;
-
     std::string jwt, meeting_id, passcode, display_name;
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        if (m_timer_cancel) return; // was cancelled between scheduling and execution
+        if (m_generation != generation) return;     // cancelled or superseded
+        if (!m_recovering.load(std::memory_order_acquire)) return;
         jwt          = m_jwt;
         meeting_id   = m_meeting_id;
         passcode     = m_passcode;
         display_name = m_display_name;
     }
 
-    const int attempt = m_attempt.fetch_add(1, std::memory_order_acq_rel) + 1;
-    blog(LOG_INFO, "[obs-zoom-plugin] Executing reconnect attempt %d", attempt);
+    // Note: the actual "attempt N" log message has already been emitted by
+    // trigger() / on_join_failed(). Do NOT increment m_attempt here -- the
+    // counter is advanced exactly once per attempt, when the attempt is
+    // scheduled. Incrementing here would double-count.
+    blog(LOG_INFO, "[obs-zoom-plugin] Executing scheduled reconnect");
 
-    // Bring down whatever state remains, then bring it back up.
-    ZoomEngineClient::instance().stop();
-
+    ZoomEngineClient::instance().stop_for_reconnect();
     if (!ZoomEngineClient::instance().start(jwt)) {
-        blog(LOG_ERROR, "[obs-zoom-plugin] Failed to start engine on reconnect attempt %d",
-             attempt);
+        blog(LOG_ERROR, "[obs-zoom-plugin] Failed to start engine on reconnect");
         on_join_failed(false);
         return;
     }
-
     ZoomEngineClient::instance().join(meeting_id, passcode, display_name);
-    // Success/failure reported via on_join_success() / on_join_failed() from handle_event().
+    // Result reported via on_join_success() / on_join_failed() from handle_event().
 }

--- a/src/zoom-reconnect.h
+++ b/src/zoom-reconnect.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -19,6 +20,14 @@ struct ZoomReconnectPolicy {
     bool  on_auth_fail       = false;
 };
 
+// Manages automatic reconnection after engine crashes / meeting disconnects.
+// Thread model:
+//   - Public API may be called from any thread.
+//   - A single, owned timer thread sleeps until the scheduled retry time, then
+//     marshals execute_retry() to the OBS UI thread via obs_queue_task.
+//   - Cancellation uses a monotonically increasing generation counter so
+//     a stale wake-up cannot fire a retry that was already cancelled or
+//     superseded by a newer schedule_retry call.
 class ZoomReconnectManager {
 public:
     static ZoomReconnectManager &instance();
@@ -31,6 +40,8 @@ public:
                        const std::string &meeting_id,
                        const std::string &passcode,
                        const std::string &display_name);
+    // Clear stored credentials (called on explicit stop/leave).
+    void clear_session();
 
     // Called when an unexpected disconnect occurs.
     void trigger(RecoveryReason reason);
@@ -48,13 +59,15 @@ public:
     int  next_retry_ms() const;
 
 private:
-    ZoomReconnectManager() = default;
+    ZoomReconnectManager();
     ~ZoomReconnectManager();
 
-    void schedule_retry(int delay_ms);
-    void execute_retry(); // always runs on OBS UI thread
+    void schedule_retry_locked(int delay_ms); // must hold m_mtx
+    void execute_retry(uint64_t generation);  // always runs on OBS UI thread
+    void timer_loop();
+    void reset_state_locked();                // must hold m_mtx
 
-    int compute_delay(int attempt) const;
+    int compute_delay_locked(int attempt) const; // must hold m_mtx
 
     mutable std::mutex          m_mtx;
     ZoomReconnectPolicy         m_policy;
@@ -67,9 +80,12 @@ private:
     std::atomic<int>            m_attempt{0};
     std::chrono::steady_clock::time_point m_retry_at;
 
-    // Timer thread state (guarded by m_mtx)
+    // Timer thread state (guarded by m_mtx unless otherwise noted)
     std::thread                 m_timer;
     std::condition_variable     m_cv;
-    bool                        m_timer_cancel  = false;
-    bool                        m_destroyed     = false;
+    bool                        m_pending     = false;  // a retry is scheduled
+    bool                        m_stop_thread = false;  // shut the timer thread down
+    // Generation: every call to schedule_retry_locked or cancel bumps this.
+    // execute_retry compares against the latest value and bails on mismatch.
+    uint64_t                    m_generation  = 0;
 };

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -111,6 +111,10 @@ void ZoomSource::apply_settings(obs_data_t *settings)
     }
 
     if (hw_accel_override != old_hw_accel_override) {
+        // Serialize against the IPC reader thread which uses m_hw_pipeline in
+        // on_engine_frame(). Without this lock, shutdown() can free filter
+        // graph state while another thread is mid-process() → use-after-free.
+        std::lock_guard<std::mutex> lk(m_mtx);
         m_hw_pipeline.shutdown();
         const HwAccelMode effective = hw_accel_override >= 0
             ? static_cast<HwAccelMode>(hw_accel_override)
@@ -207,6 +211,13 @@ void ZoomSource::on_engine_frame(uint32_t event_width, uint32_t event_height)
     const uint32_t y_len = hdr->y_len;
     if (!source || w == 0 || h == 0 || y_len != w * h) return;
 
+    // Bound the read: the header may claim a frame larger than the region
+    // we have mapped (engine wrote a bigger frame than the size we used to
+    // open the SHM). Reject those rather than walking past the mapping.
+    const size_t needed_bytes = sizeof(ShmFrameHeader) +
+        static_cast<size_t>(y_len) + static_cast<size_t>(y_len) / 2;
+    if (needed_bytes > m_video_shm.size) return;
+
     const auto *pixels = static_cast<const uint8_t *>(m_video_shm.ptr) + sizeof(ShmFrameHeader);
     const auto *y_ptr = pixels;
     const auto *u_ptr = pixels + y_len;
@@ -263,6 +274,7 @@ void ZoomSource::on_engine_audio(uint32_t event_byte_len)
     auto *hdr = static_cast<const ShmAudioHeader *>(m_audio_shm.ptr);
     const uint32_t byte_len = hdr->byte_len;
     if (!source || byte_len == 0) return;
+    if (sizeof(ShmAudioHeader) + byte_len > m_audio_shm.size) return;
     const auto *pcm = reinterpret_cast<const int16_t *>(
         static_cast<const uint8_t *>(m_audio_shm.ptr) + sizeof(ShmAudioHeader));
 

--- a/src/zoom-source.h
+++ b/src/zoom-source.h
@@ -23,11 +23,15 @@ struct ZoomSource {
     std::string passcode;
     std::string display_name;
     std::string output_display_name;
-    uint32_t participant_id = 0;
+    // These scalars are written from the OBS UI thread (apply_settings,
+    // configure_output) and read from the IPC reader thread
+    // (on_engine_audio, on_roster_changed). Make them atomic so the
+    // cross-thread reads are race-free without serializing the whole struct.
+    std::atomic<uint32_t> participant_id{0};
     bool auto_join = false;
-    bool active_speaker_mode = false;
+    std::atomic<bool> active_speaker_mode{false};
     bool isolate_audio = false;
-    AudioChannelMode audio_mode = AudioChannelMode::Mono;
+    std::atomic<AudioChannelMode> audio_mode{AudioChannelMode::Mono};
     VideoResolution resolution = VideoResolution::P1080;
     VideoLossMode video_loss_mode = VideoLossMode::LastFrame;
     uint32_t speaker_sensitivity_ms = 300;
@@ -66,7 +70,7 @@ private:
     std::vector<int16_t> m_stereo_buf;
     ZoomPreviewCallback m_preview_cb;
     uint64_t m_preview_last_ns = 0;
-    bool m_subscribed = false;
-    uint32_t m_current_subscription_id = 0;
+    std::atomic<bool> m_subscribed{false};
+    std::atomic<uint32_t> m_current_subscription_id{0};
     HwVideoPipeline m_hw_pipeline;
 };


### PR DESCRIPTION
…udit

Several real bugs surfaced from an architectural audit. Each fix below corresponds to an issue that can crash the host OBS process or break auto-reconnect in production.

ZoomReconnectManager:
- Replace per-schedule detached std::thread with a single owned timer thread driven by an atomic generation counter. The old implementation called m_timer.detach() while a previous timer was still in m_cv.wait, then reassigned m_timer — the detached thread could (a) outlive the singleton on static destruction (use-after-free) or (b) lose the cancel signal and fire a duplicate execute_retry. The new implementation joins exactly one thread at destruction.
- Stop incrementing m_attempt twice per retry. on_join_failed already bumps the counter; execute_retry was bumping it again, halving the user-configured max_attempts and making the dock countdown off-by-one.
- Reset attempt/recovery state on every "give up" path in trigger() (license, host-ended, policy-disabled). A stale m_attempt would leak into a subsequent legitimate disconnect.
- Add clear_session() so explicit stop() wipes JWT + passcode (defensive credential hygiene).

ZoomEngineClient:
- Make m_user_leaving std::atomic<bool>. It was a plain bool written from UI thread and read from IPC reader thread.
- monitor_loop() now suppresses ZoomReconnectManager::trigger() when m_user_leaving is set — fixes a race where stop() and an engine crash arrive simultaneously and the plugin would relaunch the engine the user just asked to terminate.
- stop() now cancels any pending recovery + clears the session BEFORE tearing down the engine. Previously a queued execute_retry could resurrect the engine after OBS_FRONTEND_EVENT_EXIT.
- Split out stop_for_reconnect() — same teardown but without the user-leaving / cancel-recovery side effects; used by the reconnect manager between retries.

ZoomSource:
- Convert participant_id, active_speaker_mode, audio_mode, m_subscribed, and m_current_subscription_id to std::atomic. These are written on the UI thread (apply_settings, configure_output) and read on the IPC reader thread (on_engine_audio reads audio_mode every audio packet; on_roster_changed reads active_speaker_mode + participant_id). The previous code was a textbook data race.
- Lock m_mtx around m_hw_pipeline.shutdown()/init() in apply_settings. Without the lock, the IPC reader thread could be mid-process() on the filter graph when the UI thread frees it — real use-after-free.
- Add bounds check in on_engine_frame: reject any header whose declared frame size walks past the currently mapped SHM region. The previous code re-opened the region based on event_width/height from the JSON message but trusted hdr->width/y_len for the read offsets.
- Same bounds check added for audio SHM.

Plugin entry:
- Install SIGPIPE -> SIG_IGN on POSIX. Writing to the IPC pipe after the engine crashes would otherwise raise SIGPIPE in the host OBS process, killing the entire application instead of returning EPIPE.

https://claude.ai/code/session_01Bg9rtSX7nNHhDZdezmdHQP