### PR TITLE
Improve join meeting workflow ergonomics

### DIFF
--- a/src/obs-utils.cpp
+++ b/src/obs-utils.cpp
@@ -1,1 +1,107 @@
 #include "obs-utils.h"
+
+#include <cstring>
+
+namespace zoom_join_utils {
+
+namespace {
+
+std::string strip_whitespace(const std::string &s)
+{
+    const auto begin = s.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) return {};
+    const auto end = s.find_last_not_of(" \t\r\n");
+    return s.substr(begin, end - begin + 1);
+}
+
+bool all_digits(const std::string &s)
+{
+    if (s.empty()) return false;
+    for (char c : s)
+        if (c < '0' || c > '9') return false;
+    return true;
+}
+
+std::string read_digit_run(const std::string &s, size_t &pos)
+{
+    std::string out;
+    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9')
+        out.push_back(s[pos++]);
+    return out;
+}
+
+} // namespace
+
+bool is_valid_meeting_id(const std::string &s)
+{
+    const std::string stripped = strip_whitespace(s);
+    std::string digits;
+    digits.reserve(stripped.size());
+    for (char c : stripped) {
+        if (c == ' ' || c == '-') continue;
+        if (c < '0' || c > '9') return false;
+        digits.push_back(c);
+    }
+    return !digits.empty();
+}
+
+ParsedJoin parse_join_input(const std::string &input)
+{
+    ParsedJoin out;
+    const std::string s = strip_whitespace(input);
+    if (s.empty()) return out;
+
+    // No scheme separator → treat as raw meeting ID (allow spaces and dashes).
+    if (s.find("://") == std::string::npos) {
+        std::string digits;
+        digits.reserve(s.size());
+        for (char c : s) {
+            if (c == ' ' || c == '-') continue;
+            if (c < '0' || c > '9') return out;
+            digits.push_back(c);
+        }
+        out.meeting_id = std::move(digits);
+        return out;
+    }
+
+    // URL form: look for the meeting ID in known path markers first.
+    static const char *kPathMarkers[] = {"/j/", "/wc/", "/s/", "/meeting/"};
+    for (const char *marker : kPathMarkers) {
+        size_t pos = s.find(marker);
+        if (pos == std::string::npos) continue;
+        pos += std::strlen(marker);
+        std::string digits = read_digit_run(s, pos);
+        if (!digits.empty()) {
+            out.meeting_id = std::move(digits);
+            break;
+        }
+    }
+
+    // Walk the query string once for both the passcode and (as a fallback)
+    // confno-style meeting IDs.
+    const size_t qpos = s.find('?');
+    if (qpos != std::string::npos) {
+        size_t pos = qpos + 1;
+        while (pos < s.size()) {
+            const size_t amp = s.find('&', pos);
+            const size_t end = (amp == std::string::npos) ? s.size() : amp;
+            const size_t eq  = s.find('=', pos);
+            if (eq != std::string::npos && eq < end) {
+                const std::string key = s.substr(pos, eq - pos);
+                const std::string val = s.substr(eq + 1, end - eq - 1);
+                if (key == "pwd" || key == "password" || key == "passcode") {
+                    out.passcode = val;
+                } else if (out.meeting_id.empty() &&
+                           (key == "confno" || key == "meeting_id" || key == "mn")) {
+                    if (all_digits(val)) out.meeting_id = val;
+                }
+            }
+            if (amp == std::string::npos) break;
+            pos = amp + 1;
+        }
+    }
+
+    return out;
+}
+
+} // namespace zoom_join_utils

--- a/src/obs-utils.h
+++ b/src/obs-utils.h
@@ -1,2 +1,24 @@
 #pragma once
-// Placeholder — utilities are implemented directly in their respective source files.
+#include <string>
+
+namespace zoom_join_utils {
+
+struct ParsedJoin {
+    std::string meeting_id; // numeric only; empty if input could not be parsed
+    std::string passcode;   // empty if not present in input
+};
+
+// Accepts either a raw meeting ID (digits, optionally with spaces/dashes) or
+// a Zoom join URL (https://zoom.us/j/123?pwd=abc, .../wc/123/join, .../s/123,
+// zoommtg://zoom.us/join?confno=123&pwd=abc, etc.) and extracts the numeric
+// meeting ID plus the passcode if one is present in the query string.
+//
+// Returns {meeting_id="", passcode=""} when the input cannot be interpreted as
+// either form.
+ParsedJoin parse_join_input(const std::string &input);
+
+// True if `s`, after stripping spaces and dashes, is a non-empty string of
+// decimal digits. Convenience helper for UI-side validation.
+bool is_valid_meeting_id(const std::string &s);
+
+} // namespace zoom_join_utils

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -1,4 +1,5 @@
 #include "zoom-control-server.h"
+#include "obs-utils.h"
 #include "zoom-engine-client.h"
 #include "zoom-output-manager.h"
 #include "zoom-reconnect.h"
@@ -251,14 +252,24 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
     }
 
     if (cmd == "join") {
-        const QString meeting_id = req.value("meeting_id").toString();
-        const QString passcode = req.value("passcode").toString();
+        const QString meeting_id   = req.value("meeting_id").toString();
+        const QString passcode_in  = req.value("passcode").toString();
         const QString display_name = req.value("display_name").toString("OBS");
+
+        // Accept either a numeric ID or a full Zoom URL in meeting_id.
+        const auto parsed = zoom_join_utils::parse_join_input(meeting_id.toStdString());
+        if (parsed.meeting_id.empty()) {
+            write_response(socket, {{"ok", false}, {"error", "invalid_meeting_id"}});
+            return;
+        }
+        std::string passcode = passcode_in.toStdString();
+        if (passcode.empty()) passcode = parsed.passcode;
+
         const ZoomPluginSettings settings = ZoomPluginSettings::load();
-        const bool ok = ZoomEngineClient::instance().start(settings.jwt_token) &&
-            ZoomEngineClient::instance().join(
-            meeting_id.toStdString(), passcode.toStdString(),
-            display_name.toStdString());
+        const bool ok =
+            ZoomEngineClient::instance().start(settings.jwt_token) &&
+            ZoomEngineClient::instance().join(parsed.meeting_id, passcode,
+                                              display_name.toStdString());
         write_response(socket, {{"ok", ok}});
         return;
     }

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -1,4 +1,5 @@
 #include "zoom-dock.h"
+#include "obs-utils.h"
 #include "zoom-engine-client.h"
 #include "zoom-output-manager.h"
 #include "zoom-reconnect.h"
@@ -97,11 +98,18 @@ ZoomDock::ZoomDock(QWidget *parent)
     auto *join_layout = new QVBoxLayout(join_group);
 
     m_meeting_id = new QLineEdit(join_group);
-    m_meeting_id->setPlaceholderText("Meeting ID");
+    m_meeting_id->setPlaceholderText("Meeting ID or Zoom URL");
+    m_meeting_id->setToolTip(
+        "Enter a numeric meeting ID or paste a full Zoom URL "
+        "(e.g. https://zoom.us/j/123?pwd=abc) — the ID and passcode "
+        "will be extracted automatically.");
 
     m_passcode = new QLineEdit(join_group);
     m_passcode->setPlaceholderText("Passcode (optional)");
     m_passcode->setEchoMode(QLineEdit::Password);
+
+    m_display_name = new QLineEdit(join_group);
+    m_display_name->setPlaceholderText("Display name");
 
     m_join_btn  = new QPushButton("Join",  join_group);
     m_leave_btn = new QPushButton("Leave", join_group);
@@ -115,9 +123,22 @@ ZoomDock::ZoomDock(QWidget *parent)
 
     join_layout->addWidget(m_meeting_id);
     join_layout->addWidget(m_passcode);
+    join_layout->addWidget(m_display_name);
     join_layout->addWidget(m_webinar_cb);
     join_layout->addLayout(join_btn_row);
     vLayout->addWidget(join_group);
+
+    // Pre-populate join fields from the last successful join, if any.
+    {
+        const ZoomPluginSettings prefill = ZoomPluginSettings::load();
+        if (!prefill.last_meeting_id.empty())
+            m_meeting_id->setText(QString::fromStdString(prefill.last_meeting_id));
+        m_display_name->setText(
+            prefill.last_display_name.empty()
+                ? QStringLiteral("OBS")
+                : QString::fromStdString(prefill.last_display_name));
+        m_webinar_cb->setChecked(prefill.last_was_webinar);
+    }
 
     connect(m_join_btn,  &QPushButton::clicked, this, [this]() { on_join_clicked(); });
     connect(m_leave_btn, &QPushButton::clicked, this, [this]() { on_leave_clicked(); });
@@ -392,20 +413,42 @@ void ZoomDock::apply_outputs()
 
 void ZoomDock::on_join_clicked()
 {
-    const QString meeting_id = m_meeting_id->text().trimmed();
-    if (meeting_id.isEmpty()) return;
+    const QString raw_input = m_meeting_id->text().trimmed();
+    if (raw_input.isEmpty()) return;
 
-    const ZoomPluginSettings s = ZoomPluginSettings::load();
+    // Accept either a raw meeting ID or a Zoom URL; the parser strips out a
+    // numeric meeting ID and an optional pwd= passcode from the URL.
+    const auto parsed = zoom_join_utils::parse_join_input(raw_input.toStdString());
+    if (parsed.meeting_id.empty()) {
+        m_meeting_id->setStyleSheet("border: 1px solid #ee3333;");
+        m_meeting_id->setToolTip(
+            "Could not parse a numeric meeting ID from this input. "
+            "Enter the ID directly or paste a Zoom join URL.");
+        return;
+    }
+    m_meeting_id->setStyleSheet(QString());
+
+    // If the URL carried a passcode, prefer it over an empty UI field;
+    // otherwise the user-entered passcode wins.
+    std::string passcode = m_passcode->text().toStdString();
+    if (passcode.empty()) passcode = parsed.passcode;
+
+    std::string display_name = m_display_name->text().trimmed().toStdString();
+    if (display_name.empty()) display_name = "OBS";
+
+    ZoomPluginSettings s = ZoomPluginSettings::load();
     if (!ZoomEngineClient::instance().start(s.jwt_token)) return;
 
-    const MeetingKind kind = (m_webinar_cb && m_webinar_cb->isChecked())
-        ? MeetingKind::Webinar : MeetingKind::Meeting;
+    const bool webinar = m_webinar_cb && m_webinar_cb->isChecked();
+    const MeetingKind kind = webinar ? MeetingKind::Webinar : MeetingKind::Meeting;
 
-    ZoomEngineClient::instance().join(
-        meeting_id.toStdString(),
-        m_passcode->text().toStdString(),
-        "OBS",
-        kind);
+    if (ZoomEngineClient::instance().join(parsed.meeting_id, passcode,
+                                          display_name, kind)) {
+        s.last_meeting_id   = parsed.meeting_id;
+        s.last_display_name = display_name;
+        s.last_was_webinar  = webinar;
+        s.save();
+    }
 
     update_state_indicator();
 }

--- a/src/zoom-dock.h
+++ b/src/zoom-dock.h
@@ -34,6 +34,7 @@ private:
     QLabel      *m_state_label  = nullptr;
     QLineEdit   *m_meeting_id   = nullptr;
     QLineEdit   *m_passcode     = nullptr;
+    QLineEdit   *m_display_name = nullptr;
     QPushButton *m_join_btn     = nullptr;
     QPushButton *m_leave_btn    = nullptr;
     QCheckBox   *m_webinar_cb   = nullptr;

--- a/src/zoom-osc-server.cpp
+++ b/src/zoom-osc-server.cpp
@@ -1,7 +1,9 @@
 #include "zoom-osc-server.h"
+#include "obs-utils.h"
 #include "zoom-engine-client.h"
 #include "zoom-output-manager.h"
 #include "zoom-reconnect.h"
+#include "zoom-settings.h"
 #include <QHostAddress>
 #include <QUdpSocket>
 #include <obs-module.h>
@@ -203,15 +205,30 @@ void ZoomOscServer::dispatch(const QString &address,
     }
 
     // /zoom/join  ,sss meeting_id passcode display_name
+    // The meeting_id arg may also be a full Zoom join URL.
     if (address == "/zoom/join") {
         if (args.size() < 1 || args[0].type != OscArg::String) {
             blog(LOG_WARNING, "[obs-zoom-plugin] OSC /zoom/join: missing meeting_id arg");
             return;
         }
-        const std::string meeting_id   = args[0].s;
-        const std::string passcode     = args.size() >= 2 ? args[1].s : "";
+        const auto parsed = zoom_join_utils::parse_join_input(args[0].s);
+        if (parsed.meeting_id.empty()) {
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] OSC /zoom/join: could not parse meeting ID from '%s'",
+                 args[0].s.c_str());
+            return;
+        }
+        std::string passcode = args.size() >= 2 ? args[1].s : std::string();
+        if (passcode.empty()) passcode = parsed.passcode;
         const std::string display_name = args.size() >= 3 ? args[2].s : "OBS";
-        ZoomEngineClient::instance().join(meeting_id, passcode, display_name);
+
+        const ZoomPluginSettings settings = ZoomPluginSettings::load();
+        if (!ZoomEngineClient::instance().start(settings.jwt_token)) {
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] OSC /zoom/join: engine failed to start");
+            return;
+        }
+        ZoomEngineClient::instance().join(parsed.meeting_id, passcode, display_name);
         return;
     }
 

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -46,6 +46,12 @@ ZoomPluginSettings ZoomPluginSettings::load()
     const int rc_auth = config_get_int(cfg, SECTION, "ReconnectOnAuthFail");
     if (rc_auth >= 0) s.reconnect_policy.on_auth_fail = (rc_auth != 0);
 
+    const char *last_id   = config_get_string(cfg, SECTION, "LastMeetingId");
+    const char *last_name = config_get_string(cfg, SECTION, "LastDisplayName");
+    s.last_meeting_id   = last_id   ? last_id   : "";
+    s.last_display_name = last_name ? last_name : "";
+    s.last_was_webinar  = config_get_int(cfg, SECTION, "LastWasWebinar") != 0;
+
     return s;
 }
 
@@ -66,5 +72,8 @@ void ZoomPluginSettings::save() const
     config_set_int   (cfg, SECTION, "ReconnectOnCrash",       reconnect_policy.on_engine_crash ? 1 : 0);
     config_set_int   (cfg, SECTION, "ReconnectOnDisconnect",  reconnect_policy.on_disconnect ? 1 : 0);
     config_set_int   (cfg, SECTION, "ReconnectOnAuthFail",    reconnect_policy.on_auth_fail ? 1 : 0);
+    config_set_string(cfg, SECTION, "LastMeetingId",          last_meeting_id.c_str());
+    config_set_string(cfg, SECTION, "LastDisplayName",        last_display_name.c_str());
+    config_set_int   (cfg, SECTION, "LastWasWebinar",         last_was_webinar ? 1 : 0);
     config_save_safe(cfg, "tmp", nullptr);
 }

--- a/src/zoom-settings.h
+++ b/src/zoom-settings.h
@@ -11,6 +11,12 @@ struct ZoomPluginSettings {
     std::string         control_token;
     HwAccelMode         hw_accel_mode        = HwAccelMode::None;
     ZoomReconnectPolicy reconnect_policy;
+
+    // Last successful join, used to repopulate the dock on next launch.
+    std::string         last_meeting_id;
+    std::string         last_display_name;
+    bool                last_was_webinar     = false;
+
     static ZoomPluginSettings load();
     void save() const;
 };


### PR DESCRIPTION
Add Zoom URL parsing (zoom_join_utils) so the dock, TCP control API, and OSC API all accept either a numeric meeting ID or a full join URL, with the passcode extracted from pwd=/password=/passcode= query params.

Dock gains a display-name field (was hardcoded to "OBS") and now pre-populates meeting ID, display name, and the webinar flag from the last successful join, persisted via ZoomPluginSettings.

Also fix /zoom/join over OSC to start the engine if it isn't running yet — previously it would silently no-op when the engine hadn't been launched.