### PR TITLE
Stop dock output table from thrashing user selections

### DIFF
--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -22,6 +22,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 #include <algorithm>
+#include <unordered_map>
 
 // ── Column layout for the output table ───────────────────────────────────────
 enum DockOutputColumns {
@@ -166,10 +167,13 @@ ZoomDock::ZoomDock(QWidget *parent)
         update_recovery_panel();
     });
 
+    // Periodic tick only updates the lightweight state indicator (state dot,
+    // active speaker label, join-timeout watchdog). The output table is
+    // expensive to rebuild and is refreshed from the roster callback below.
     m_refresh_timer = new QTimer(this);
     m_refresh_timer->setInterval(500);
     connect(m_refresh_timer, &QTimer::timeout, this, [this]() {
-        refresh();
+        update_state_indicator();
     });
     m_refresh_timer->start();
 
@@ -321,6 +325,34 @@ void ZoomDock::refresh()
 
 void ZoomDock::refresh_outputs()
 {
+    // If a dropdown popup is open, the user is mid-selection — rebuilding the
+    // widgets right now would close the popup and lose the pick. Defer; the
+    // next roster update (or any later refresh) will rebuild instead.
+    for (int row = 0; row < m_output_table->rowCount(); ++row) {
+        if (auto *combo = qobject_cast<QComboBox *>(
+                m_output_table->cellWidget(row, DColAssignment))) {
+            if (combo->view() && combo->view()->isVisible()) return;
+        }
+    }
+
+    // Snapshot any in-flight (picked-but-not-yet-applied) selections so that
+    // a roster-driven rebuild does not silently revert the user's choice
+    // before they have a chance to click Apply.
+    struct PendingPick { QString assignment; int audio_idx; bool isolate; };
+    std::unordered_map<std::string, PendingPick> pending;
+    for (int row = 0; row < m_output_table->rowCount(); ++row) {
+        auto *name_item = m_output_table->item(row, DColName);
+        auto *assign = qobject_cast<QComboBox *>(m_output_table->cellWidget(row, DColAssignment));
+        auto *audio  = qobject_cast<QComboBox *>(m_output_table->cellWidget(row, DColAudio));
+        auto *isolate = qobject_cast<QCheckBox *>(m_output_table->cellWidget(row, DColIsolate));
+        if (!name_item || !assign || !audio || !isolate) continue;
+        pending[name_item->data(Qt::UserRole).toString().toStdString()] = {
+            assign->currentData().toString(),
+            audio->currentIndex(),
+            isolate->isChecked()
+        };
+    }
+
     const auto outputs = ZoomOutputManager::instance().outputs();
     const auto roster  = ZoomEngineClient::instance().roster();
 
@@ -396,6 +428,18 @@ void ZoomDock::refresh_outputs()
         isolate->setChecked(output.isolate_audio);
         isolate->setToolTip("Use isolated audio for the assigned participant");
         m_output_table->setCellWidget(row, DColIsolate, isolate);
+
+        // Restore any user pick that was in-flight before the rebuild. We only
+        // restore values that are still selectable in the rebuilt widgets so
+        // a stale snapshot can never resurrect a participant that just left.
+        auto pit = pending.find(output.source_name);
+        if (pit != pending.end()) {
+            const int aidx = assignment->findData(pit->second.assignment);
+            if (aidx >= 0) assignment->setCurrentIndex(aidx);
+            if (pit->second.audio_idx >= 0 && pit->second.audio_idx < audio->count())
+                audio->setCurrentIndex(pit->second.audio_idx);
+            isolate->setChecked(pit->second.isolate);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two related bugs in the Zoom dock's Outputs panel:

- **Output table thrashes selections.** A 500 ms refresh timer was calling `refresh() → refresh_outputs()`, which calls `QTableWidget::setRowCount()` plus `new QComboBox`/`new QCheckBox` for every row. Any dropdown the user had open was destroyed mid-pick, and a participant they had just selected was silently reset to the saved value before they could click **Apply**.
- **Participant has to be removed and re-added to get video.** Because `apply_outputs()` then read the reverted value, `configure_output_ex()` was called with the old participant ID, no new `subscribe` was sent to the engine, and no video flowed. The workaround was to remove the OBS source and add a fresh one — which routes through `create() → apply_settings()` with the intended participant ID baked into source settings, bypassing the dock entirely.

## Changes

`src/zoom-dock.cpp`

- The 500 ms periodic tick now updates only `update_state_indicator()` (state dot, active-speaker label, recovery panel, join-timeout watchdog). It no longer rebuilds the output table widgets.
- `refresh_outputs()` bails early while any assignment dropdown popup is visible, so a roster update can't close the picker mid-selection.
- Before rebuilding rows, `refresh_outputs()` snapshots every visible `(assignment, audio, isolate)` tuple keyed by source name and restores them on the rebuilt widgets when the value is still selectable. A roster-driven refresh now preserves in-flight selections instead of reverting them to the saved value.

The output table is still rebuilt on roster callbacks and on filter-text changes, but it no longer fires on a timer.

## Test plan

- [ ] Join a meeting with at least two other participants speaking; confirm the assignment dropdown for an existing Zoom source stays open while the active speaker changes.
- [ ] Open the assignment dropdown, hover over a participant, wait for several roster updates to arrive — confirm the popup does not close or jump.
- [ ] Pick a participant in the dropdown, wait a few seconds without clicking **Apply**, confirm the selection still reflects the user's pick (not the saved value).
- [ ] Click **Apply** and confirm the OBS source begins receiving video for that participant *without* having to remove and re-add the source.
- [ ] Change a participant's audio mode or isolate flag, wait for a roster update, click **Apply** — confirm the picked values are what get saved.
- [ ] Confirm the state dot, active-speaker label, and recovery countdown still update at the usual cadence (no UI regression on the rest of the dock).

https://claude.ai/code/session_014v8Be2imvuKAB8k41pVeBe

---
_Generated by [Claude Code](https://claude.ai/code/session_014v8Be2imvuKAB8k41pVeBe)_