### PR TITLE
CoreVideo Sidecar + OBS Plugin Phase 2 UI modernization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ if(COREVIDEO_BUILD_PLUGIN)
         src/obs-utils.cpp
         src/hw-video-pipeline.cpp
         src/cv-widgets.cpp
+        src/cv-onboarding.cpp
     )
 
     target_include_directories(obs-zoom-plugin PRIVATE

--- a/sidecar/CMakeLists.txt
+++ b/sidecar/CMakeLists.txt
@@ -16,6 +16,8 @@ set(SOURCES
     src/template-panel.cpp
     src/theme-panel.cpp
     src/participant-panel.cpp
+    src/scenes-panel.cpp
+    src/macros-panel.cpp
     src/settings-page.cpp
     src/layout-template.cpp
     src/template-manager.cpp

--- a/sidecar/CMakeLists.txt
+++ b/sidecar/CMakeLists.txt
@@ -14,7 +14,9 @@ set(SOURCES
     src/sidebar.cpp
     src/preview-canvas.cpp
     src/template-panel.cpp
+    src/theme-panel.cpp
     src/participant-panel.cpp
+    src/settings-page.cpp
     src/layout-template.cpp
     src/template-manager.cpp
     src/obs-client.cpp

--- a/sidecar/src/macro.h
+++ b/sidecar/src/macro.h
@@ -1,0 +1,147 @@
+#pragma once
+#include <QString>
+#include <QVector>
+#include <QJsonObject>
+#include <QJsonArray>
+
+// A single OBS request step inside a macro
+struct MacroStep {
+    QString requestType;   // e.g. "SetCurrentProgramScene"
+    QJsonObject data;      // requestData fields
+
+    static MacroStep fromJson(const QJsonObject &obj) {
+        MacroStep s;
+        s.requestType = obj["requestType"].toString();
+        s.data = obj["data"].toObject();
+        return s;
+    }
+
+    QJsonObject toJson() const {
+        QJsonObject obj;
+        obj["requestType"] = requestType;
+        obj["data"] = data;
+        return obj;
+    }
+};
+
+// A named macro — fires one or more OBS requests in sequence
+struct Macro {
+    QString id;
+    QString label;
+    QString icon;       // single emoji/glyph shown on button
+    QString color;      // hex color for button accent, e.g. "#2979ff"
+    QVector<MacroStep> steps;
+
+    bool isValid() const { return !id.isEmpty() && !steps.isEmpty(); }
+
+    static Macro fromJson(const QJsonObject &obj) {
+        Macro m;
+        m.id    = obj["id"].toString();
+        m.label = obj["label"].toString();
+        m.icon  = obj["icon"].toString();
+        m.color = obj["color"].toString();
+        const QJsonArray arr = obj["steps"].toArray();
+        for (const auto &v : arr)
+            m.steps.append(MacroStep::fromJson(v.toObject()));
+        return m;
+    }
+
+    QJsonObject toJson() const {
+        QJsonObject obj;
+        obj["id"]    = id;
+        obj["label"] = label;
+        obj["icon"]  = icon;
+        obj["color"] = color;
+        QJsonArray arr;
+        for (const auto &s : steps)
+            arr.append(s.toJson());
+        obj["steps"] = arr;
+        return obj;
+    }
+
+    // Built-in default macros
+    static QVector<Macro> defaults() {
+        QVector<Macro> list;
+
+        // 1. Go Live
+        {
+            Macro m;
+            m.id    = "go-live";
+            m.label = "Go Live";
+            m.icon  = "⏩";  // ⏩
+            m.color = "#e03040";
+            MacroStep s;
+            s.requestType = "StartStream";
+            m.steps.append(s);
+            list.append(m);
+        }
+
+        // 2. End Stream
+        {
+            Macro m;
+            m.id    = "end-stream";
+            m.label = "End Stream";
+            m.icon  = "⏹";  // ⏹
+            m.color = "#803020";
+            MacroStep s;
+            s.requestType = "StopStream";
+            m.steps.append(s);
+            list.append(m);
+        }
+
+        // 3. Record
+        {
+            Macro m;
+            m.id    = "start-record";
+            m.label = "Record";
+            m.icon  = "⏺";  // ⏺
+            m.color = "#e05020";
+            MacroStep s;
+            s.requestType = "StartRecord";
+            m.steps.append(s);
+            list.append(m);
+        }
+
+        // 4. Stop (recording)
+        {
+            Macro m;
+            m.id    = "stop-record";
+            m.label = "Stop";
+            m.icon  = "⏹";  // ⏹
+            m.color = "#604030";
+            MacroStep s;
+            s.requestType = "StopRecord";
+            m.steps.append(s);
+            list.append(m);
+        }
+
+        // 5. V-Cam
+        {
+            Macro m;
+            m.id    = "toggle-vcam";
+            m.label = "V-Cam";
+            m.icon  = "📷";  // 📷
+            m.color = "#2060c0";
+            MacroStep s;
+            s.requestType = "ToggleVirtualCam";
+            m.steps.append(s);
+            list.append(m);
+        }
+
+        // 6. Lower Thirds
+        {
+            Macro m;
+            m.id    = "scene-lower-thirds";
+            m.label = "Lower Thirds";
+            m.icon  = "▼";  // ▼
+            m.color = "#6030c0";
+            MacroStep s;
+            s.requestType = "SetCurrentProgramScene";
+            s.data["sceneName"] = "Lower Thirds";
+            m.steps.append(s);
+            list.append(m);
+        }
+
+        return list;
+    }
+};

--- a/sidecar/src/macros-panel.cpp
+++ b/sidecar/src/macros-panel.cpp
@@ -1,0 +1,168 @@
+#include "macros-panel.h"
+
+#include <QVBoxLayout>
+#include <QGridLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPainterPath>
+#include <QMouseEvent>
+#include <QEnterEvent>
+#include <QColor>
+#include <QFont>
+#include <QFontMetrics>
+#include <QSizePolicy>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MacroButton
+// ─────────────────────────────────────────────────────────────────────────────
+
+MacroButton::MacroButton(const Macro &macro, QWidget *parent)
+    : QWidget(parent)
+    , m_macro(macro)
+{
+    setFixedSize(118, 82);
+    setCursor(Qt::PointingHandCursor);
+    setAttribute(Qt::WA_Hover, true);
+}
+
+void MacroButton::paintEvent(QPaintEvent *)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    const QRectF r = rect().adjusted(1, 1, -1, -1);
+    const qreal radius = 10.0;
+
+    // Background color — parse accent, darken based on state
+    QColor accent(m_macro.color);
+    QColor bg = m_pressed  ? accent.darker(300)
+              : m_hovered  ? accent.darker(400)
+                           : accent.darker(500);
+
+    // Border width
+    const qreal borderWidth = m_hovered ? 2.0 : 1.5;
+
+    // Draw card background
+    QPainterPath path;
+    path.addRoundedRect(r, radius, radius);
+    p.fillPath(path, bg);
+
+    // Draw border
+    p.setPen(QPen(accent, borderWidth));
+    p.drawPath(path);
+
+    // ── Icon (top 55% of card) ────────────────────────────────────────────
+    const int iconAreaHeight = static_cast<int>(height() * 0.55);
+    const QRectF iconRect(0, 0, width(), iconAreaHeight);
+
+    QFont iconFont = p.font();
+    iconFont.setPixelSize(24);
+    p.setFont(iconFont);
+    p.setPen(Qt::white);
+    p.drawText(iconRect, Qt::AlignHCenter | Qt::AlignVCenter, m_macro.icon);
+
+    // ── Label (bottom 22px) ───────────────────────────────────────────────
+    const QRectF labelRect(0, height() - 22, width(), 22);
+
+    QFont labelFont = p.font();
+    labelFont.setPixelSize(10);   // ~10.5px
+    labelFont.setWeight(QFont::DemiBold);
+    p.setFont(labelFont);
+    p.setPen(Qt::white);
+    p.drawText(labelRect, Qt::AlignHCenter | Qt::AlignVCenter, m_macro.label);
+}
+
+void MacroButton::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton) {
+        m_pressed = true;
+        update();
+    }
+    QWidget::mousePressEvent(event);
+}
+
+void MacroButton::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton) {
+        if (rect().contains(event->pos()))
+            emit triggered(m_macro);
+        m_pressed = false;
+        update();
+    }
+    QWidget::mouseReleaseEvent(event);
+}
+
+void MacroButton::enterEvent(QEnterEvent *event)
+{
+    m_hovered = true;
+    update();
+    QWidget::enterEvent(event);
+}
+
+void MacroButton::leaveEvent(QEvent *event)
+{
+    m_hovered = false;
+    m_pressed = false;
+    update();
+    QWidget::leaveEvent(event);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MacrosPanel
+// ─────────────────────────────────────────────────────────────────────────────
+
+MacrosPanel::MacrosPanel(QWidget *parent)
+    : QWidget(parent)
+{
+    auto *vbox = new QVBoxLayout(this);
+    vbox->setContentsMargins(0, 0, 0, 0);
+    vbox->setSpacing(0);
+
+    // Header
+    auto *header = new QLabel("Macros", this);
+    header->setObjectName("sectionHeader");
+    vbox->addWidget(header);
+
+    // Grid container
+    m_grid = new QWidget(this);
+    auto *grid = new QGridLayout(m_grid);
+    grid->setContentsMargins(10, 0, 10, 8);
+    grid->setSpacing(8);
+    vbox->addWidget(m_grid);
+
+    vbox->addStretch();
+
+    loadMacros(Macro::defaults());
+}
+
+void MacrosPanel::loadMacros(const QVector<Macro> &macros)
+{
+    // Remove and delete all existing buttons
+    for (MacroButton *btn : m_buttons) {
+        btn->hide();
+        btn->deleteLater();
+    }
+    m_buttons.clear();
+
+    // Clear the grid layout
+    QGridLayout *grid = qobject_cast<QGridLayout *>(m_grid->layout());
+    if (!grid)
+        return;
+
+    // Remove all items from the layout
+    while (grid->count() > 0) {
+        QLayoutItem *item = grid->takeAt(0);
+        delete item;
+    }
+
+    // Rebuild grid with 2 columns
+    constexpr int cols = 2;
+    for (int i = 0; i < macros.size(); ++i) {
+        auto *btn = new MacroButton(macros[i], m_grid);
+        connect(btn, &MacroButton::triggered, this, [this](const Macro &macro) {
+            emit macroTriggered(macro);
+        });
+        grid->addWidget(btn, i / cols, i % cols);
+        m_buttons.append(btn);
+    }
+}

--- a/sidecar/src/macros-panel.h
+++ b/sidecar/src/macros-panel.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "macro.h"
+#include <QWidget>
+#include <QVector>
+
+class MacroButton;
+
+class MacrosPanel : public QWidget {
+    Q_OBJECT
+public:
+    explicit MacrosPanel(QWidget *parent = nullptr);
+
+    void loadMacros(const QVector<Macro> &macros);
+
+signals:
+    void macroTriggered(const Macro &macro);
+
+private:
+    QWidget *m_grid = nullptr;
+    QVector<MacroButton *> m_buttons;
+};
+
+// ── MacroButton ───────────────────────────────────────────────────────────────
+class MacroButton : public QWidget {
+    Q_OBJECT
+public:
+    explicit MacroButton(const Macro &macro, QWidget *parent = nullptr);
+    const Macro &macro() const { return m_macro; }
+
+signals:
+    void triggered(const Macro &macro);
+
+protected:
+    void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *) override;
+    void mouseReleaseEvent(QMouseEvent *) override;
+    void enterEvent(QEnterEvent *) override;
+    void leaveEvent(QEvent *) override;
+
+private:
+    Macro m_macro;
+    bool  m_hovered  = false;
+    bool  m_pressed  = false;
+};

--- a/sidecar/src/main.cpp
+++ b/sidecar/src/main.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "sidecar-style.h"
+#include "show-theme.h"
 #include <QApplication>
 #include <QStyleFactory>
 
@@ -12,7 +13,8 @@ int main(int argc, char *argv[])
 
     // Fusion gives clean cross-platform rendering with full QSS support
     app.setStyle(QStyleFactory::create("Fusion"));
-    app.setStyleSheet(sidecar_stylesheet());
+    const auto builtins = ShowTheme::builtIns();
+    app.setStyleSheet(sidecar_stylesheet(&builtins.first())); // Midnight Blue default
 
     MainWindow w;
     w.show();

--- a/sidecar/src/mainwindow.cpp
+++ b/sidecar/src/mainwindow.cpp
@@ -3,6 +3,8 @@
 #include "template-panel.h"
 #include "theme-panel.h"
 #include "participant-panel.h"
+#include "scenes-panel.h"
+#include "macros-panel.h"
 #include "template-manager.h"
 #include "settings-page.h"
 #include "obs-connect-dialog.h"
@@ -113,6 +115,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     connect(m_obsClient, &OBSClient::stateChanged,       this, &MainWindow::onObsState);
     connect(m_obsClient, &OBSClient::log,                this, &MainWindow::onObsLog);
     connect(m_obsClient, &OBSClient::scenesReceived,     this, &MainWindow::onScenesReceived);
+    connect(m_obsClient, &OBSClient::sceneChanged,       this, [this](const QString &name) {
+        m_scenesPanel->setCurrentScene(name);
+    });
     connect(m_obsClient, &OBSClient::virtualCamStateChanged, this, &MainWindow::onVirtualCamState);
     connect(m_obsClient, &OBSClient::templateApplied,    this,
             [this](const QString &name, int n) {
@@ -228,7 +233,22 @@ void MainWindow::buildRightPanel(QWidget *parent)
             this, &MainWindow::onThemeSelected);
     m_pageThemes = m_rightStack->addWidget(m_themePanel);
 
-    // Page 2: Settings
+    // Page 2: Scenes
+    m_scenesPanel = new ScenesPanel;
+    connect(m_scenesPanel, &ScenesPanel::sceneActivated,
+            this, &MainWindow::onSceneActivated);
+    connect(m_scenesPanel, &ScenesPanel::refreshRequested, this, [this]() {
+        m_obsClient->requestSceneList();
+    });
+    m_pageScenes = m_rightStack->addWidget(m_scenesPanel);
+
+    // Page 3: Macros
+    m_macrosPanel = new MacrosPanel;
+    connect(m_macrosPanel, &MacrosPanel::macroTriggered,
+            this, &MainWindow::onMacroTriggered);
+    m_pageMacros = m_rightStack->addWidget(m_macrosPanel);
+
+    // Page 4: Settings
     m_settingsPage = new SettingsPage;
     connect(m_settingsPage, &SettingsPage::settingsChanged,
             this, &MainWindow::onSettingsChanged);
@@ -279,16 +299,17 @@ void MainWindow::onPageSelected(Sidebar::Page p)
     switch (p) {
     case P::Templates:
     case P::Participants:
-        m_rightStack->setCurrentIndex(m_pageTemplates);
-        break;
+        m_rightStack->setCurrentIndex(m_pageTemplates);  break;
     case P::Themes:
-        m_rightStack->setCurrentIndex(m_pageThemes);
+        m_rightStack->setCurrentIndex(m_pageThemes);     break;
+    case P::Scenes:
+        m_rightStack->setCurrentIndex(m_pageScenes);
+        m_obsClient->requestSceneList();
         break;
+    case P::Macros:
+        m_rightStack->setCurrentIndex(m_pageMacros);     break;
     case P::Settings:
-        m_rightStack->setCurrentIndex(m_pageSettings);
-        break;
-    default:
-        break;
+        m_rightStack->setCurrentIndex(m_pageSettings);   break;
     }
 }
 
@@ -395,13 +416,32 @@ void MainWindow::onObsLog(const QString &msg)
 
 void MainWindow::onScenesReceived(const QStringList &scenes)
 {
-    const QString scene = m_settingsPage->targetScene();
-    if (scenes.contains(scene)) {
-        m_obsClient->requestSceneItems(scene);
+    m_scenesPanel->setScenes(scenes);
+
+    const QString target = m_settingsPage->targetScene();
+    if (scenes.contains(target)) {
+        m_obsClient->requestSceneItems(target);
     } else if (!scenes.isEmpty()) {
         onObsLog(QStringLiteral("Scene '%1' not found. Available: %2")
-                     .arg(scene, scenes.join(", ")));
+                     .arg(target, scenes.join(", ")));
     }
+}
+
+void MainWindow::onSceneActivated(const QString &name)
+{
+    m_obsClient->setCurrentScene(name);
+    onObsLog(QStringLiteral("Switched to scene: %1").arg(name));
+}
+
+void MainWindow::onMacroTriggered(const Macro &macro)
+{
+    if (!m_obsClient->isConnected()) {
+        onObsLog(QStringLiteral("Macro '%1' — not connected to OBS.").arg(macro.label));
+        return;
+    }
+    m_obsClient->executeMacro(macro);
+    onObsLog(QStringLiteral("Macro '%1' triggered (%2 steps).")
+                 .arg(macro.label).arg(macro.steps.size()));
 }
 
 void MainWindow::onVirtualCamToggle()

--- a/sidecar/src/mainwindow.cpp
+++ b/sidecar/src/mainwindow.cpp
@@ -1,9 +1,12 @@
 #include "mainwindow.h"
 #include "preview-canvas.h"
 #include "template-panel.h"
+#include "theme-panel.h"
 #include "participant-panel.h"
 #include "template-manager.h"
+#include "settings-page.h"
 #include "obs-connect-dialog.h"
+#include "sidecar-style.h"
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QLabel>
@@ -11,11 +14,12 @@
 #include <QFrame>
 #include <QPlainTextEdit>
 #include <QDockWidget>
+#include <QStackedWidget>
 #include <QFile>
 #include <QJsonDocument>
 #include <QSettings>
 #include <QDateTime>
-#include <QStyle>
+#include <QApplication>
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 {
@@ -25,15 +29,14 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 
     auto *central = new QWidget(this);
     setCentralWidget(central);
-
     auto *rootH = new QHBoxLayout(central);
     rootH->setContentsMargins(0, 0, 0, 0);
     rootH->setSpacing(0);
 
-    // ── Sidebar ───────────────────────────────────────────────────────────────
-    auto *sidebar = new Sidebar(this);
-    sidebar->setFixedWidth(200);
-    rootH->addWidget(sidebar);
+    // ── Left sidebar ──────────────────────────────────────────────────────────
+    m_sidebar = new Sidebar(this);
+    m_sidebar->setFixedWidth(200);
+    rootH->addWidget(m_sidebar);
 
     // ── Center column ─────────────────────────────────────────────────────────
     auto *centerCol = new QWidget(central);
@@ -58,7 +61,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     tbRow->setContentsMargins(12, 0, 12, 0);
     tbRow->setSpacing(8);
 
-    auto makeToolBtn = [&](const QString &label, bool primary = false) -> QPushButton * {
+    auto makeBtn = [&](const QString &label, bool primary = false) -> QPushButton * {
         auto *btn = new QPushButton(label, toolbar);
         btn->setObjectName("toolBtn");
         btn->setFixedHeight(34);
@@ -66,51 +69,52 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
         return btn;
     };
 
-    auto *applyBtn  = makeToolBtn("⊞  Apply Template", true);
-    auto *spotBtn   = makeToolBtn("◉  Spotlight Speaker");
-    auto *lowerBtn  = makeToolBtn("▼  Lower Thirds");
-    auto *recBtn    = makeToolBtn("⏺  Record");
-    auto *streamBtn = makeToolBtn("⏩  Stream");
+    auto *applyBtn  = makeBtn("⊞  Apply Template", true);
+    auto *spotBtn   = makeBtn("◉  Spotlight");
+    auto *lowerBtn  = makeBtn("▼  Lower Thirds");
+    m_vcamBtn       = makeBtn("⏺  V-Cam OFF");
+    auto *streamBtn = makeBtn("⏩  Stream");
 
     tbRow->addWidget(applyBtn);
     tbRow->addWidget(spotBtn);
     tbRow->addWidget(lowerBtn);
     tbRow->addStretch(1);
-    tbRow->addWidget(recBtn);
+    tbRow->addWidget(m_vcamBtn);
     tbRow->addWidget(streamBtn);
 
     centerV->addWidget(toolbar);
     rootH->addWidget(centerCol, 1);
 
     // ── Right panel ───────────────────────────────────────────────────────────
-    auto *rightPanel = new QWidget(central);
-    rightPanel->setObjectName("rightPanel");
-    rightPanel->setFixedWidth(272);
-    buildRightPanel(rightPanel);
-    rootH->addWidget(rightPanel);
+    auto *rightOuter = new QWidget(central);
+    rightOuter->setObjectName("rightPanel");
+    rightOuter->setFixedWidth(272);
+    buildRightPanel(rightOuter);
+    rootH->addWidget(rightOuter);
 
     // ── Log dock ──────────────────────────────────────────────────────────────
     buildLogDock();
 
-    // ── Restore saved OBS config ──────────────────────────────────────────────
-    QSettings s;
-    m_obsConfig.host          = s.value("obs/host", "localhost").toString();
-    m_obsConfig.port          = s.value("obs/port", 4455).toInt();
-    m_obsConfig.password      = s.value("obs/password", "").toString();
-    m_obsConfig.autoReconnect = s.value("obs/autoReconnect", true).toBool();
+    // ── OBS config from settings ──────────────────────────────────────────────
+    QSettings cfg;
+    m_obsConfig.host          = cfg.value("obs/host", "localhost").toString();
+    m_obsConfig.port          = cfg.value("obs/port", 4455).toInt();
+    m_obsConfig.password      = cfg.value("obs/password", "").toString();
+    m_obsConfig.autoReconnect = cfg.value("obs/autoReconnect", true).toBool();
 
     // ── Connections ───────────────────────────────────────────────────────────
-    connect(sidebar,     &Sidebar::pageSelected, this, &MainWindow::onPageSelected);
-    connect(applyBtn,    &QPushButton::clicked,  this, &MainWindow::onApplyLayout);
-    connect(m_engineBtn, &QPushButton::clicked,  this, &MainWindow::onEngineToggle);
-    connect(m_obsBtn,    &QPushButton::clicked,  this, &MainWindow::onObsConnect);
+    connect(m_sidebar, &Sidebar::pageSelected, this, &MainWindow::onPageSelected);
+    connect(applyBtn,  &QPushButton::clicked,  this, &MainWindow::onApplyLayout);
+    connect(m_engineBtn, &QPushButton::clicked, this, &MainWindow::onEngineToggle);
+    connect(m_obsBtn,  &QPushButton::clicked,  this, &MainWindow::onObsConnect);
+    connect(m_vcamBtn, &QPushButton::clicked,  this, &MainWindow::onVirtualCamToggle);
 
-    // OBS client
     m_obsClient = new OBSClient(this);
-    connect(m_obsClient, &OBSClient::stateChanged,    this, &MainWindow::onObsState);
-    connect(m_obsClient, &OBSClient::log,             this, &MainWindow::onObsLog);
-    connect(m_obsClient, &OBSClient::scenesReceived,  this, &MainWindow::onScenesReceived);
-    connect(m_obsClient, &OBSClient::templateApplied, this,
+    connect(m_obsClient, &OBSClient::stateChanged,       this, &MainWindow::onObsState);
+    connect(m_obsClient, &OBSClient::log,                this, &MainWindow::onObsLog);
+    connect(m_obsClient, &OBSClient::scenesReceived,     this, &MainWindow::onScenesReceived);
+    connect(m_obsClient, &OBSClient::virtualCamStateChanged, this, &MainWindow::onVirtualCamState);
+    connect(m_obsClient, &OBSClient::templateApplied,    this,
             [this](const QString &name, int n) {
                 onObsLog(QStringLiteral("✓ Applied '%1' (%2 items).").arg(name).arg(n));
             });
@@ -119,12 +123,17 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     auto &tm = TemplateManager::instance();
     tm.loadBuiltIn();
     m_templatePanel->loadTemplates(tm.templates());
-
     if (const auto *grid4 = tm.findById("4-up-grid")) onTemplateSelected(*grid4);
 
+    // Themes
+    m_themePanel->loadThemes(ShowTheme::builtIns());
+
+    // Mock data
     loadMockParticipants();
+
+    // Initial UI state
     onObsState(OBSClient::State::Disconnected);
-    onObsLog("Sidecar ready. Click 'OBS' in the top bar to connect.");
+    onObsLog("Sidecar ready. Click 'OBS' to connect.");
 }
 
 // ── Top bar ───────────────────────────────────────────────────────────────────
@@ -194,26 +203,45 @@ void MainWindow::buildRightPanel(QWidget *parent)
     vl->setContentsMargins(0, 0, 0, 0);
     vl->setSpacing(0);
 
-    m_templatePanel = new TemplatePanel(parent);
+    m_rightStack = new QStackedWidget(parent);
+
+    // Page 0: Templates + Participants (combined scroll)
+    auto *tmplPage = new QWidget;
+    auto *tmplV = new QVBoxLayout(tmplPage);
+    tmplV->setContentsMargins(0, 0, 0, 0);
+    tmplV->setSpacing(0);
+    m_templatePanel = new TemplatePanel(tmplPage);
     connect(m_templatePanel, &TemplatePanel::templateSelected,
             this, &MainWindow::onTemplateSelected);
-    vl->addWidget(m_templatePanel);
-
-    auto *div = new QFrame(parent);
+    tmplV->addWidget(m_templatePanel);
+    auto *div = new QFrame(tmplPage);
     div->setFrameShape(QFrame::HLine);
     div->setStyleSheet("color: #1e1e2e;");
-    vl->addWidget(div);
+    tmplV->addWidget(div);
+    m_participantPanel = new ParticipantPanel(tmplPage);
+    tmplV->addWidget(m_participantPanel, 1);
+    m_pageTemplates = m_rightStack->addWidget(tmplPage);
 
-    m_participantPanel = new ParticipantPanel(parent);
-    vl->addWidget(m_participantPanel, 1);
+    // Page 1: Themes
+    m_themePanel = new ThemePanel;
+    connect(m_themePanel, &ThemePanel::themeSelected,
+            this, &MainWindow::onThemeSelected);
+    m_pageThemes = m_rightStack->addWidget(m_themePanel);
+
+    // Page 2: Settings
+    m_settingsPage = new SettingsPage;
+    connect(m_settingsPage, &SettingsPage::settingsChanged,
+            this, &MainWindow::onSettingsChanged);
+    m_pageSettings = m_rightStack->addWidget(m_settingsPage);
+
+    vl->addWidget(m_rightStack, 1);
 }
 
 // ── Log dock ──────────────────────────────────────────────────────────────────
 void MainWindow::buildLogDock()
 {
     m_logDock = new QDockWidget("OBS Log", this);
-    m_logDock->setFeatures(QDockWidget::DockWidgetClosable |
-                           QDockWidget::DockWidgetMovable);
+    m_logDock->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable);
     m_logView = new QPlainTextEdit(m_logDock);
     m_logView->setReadOnly(true);
     m_logView->setMaximumBlockCount(500);
@@ -237,15 +265,32 @@ void MainWindow::loadMockParticipants()
     };
     m_participantPanel->setParticipants(parts);
 
-    QVector<PreviewCanvas::Participant> canvasParts;
+    QVector<PreviewCanvas::Participant> cp;
     for (const auto &p : parts)
-        canvasParts.append({p.name, p.initials, p.color, p.isTalking, p.hasVideo});
-    m_liveCanvas->setParticipants(canvasParts);
-    m_sceneCanvas->setParticipants(canvasParts);
+        cp.append({p.name, p.initials, p.color, p.isTalking, p.hasVideo});
+    m_liveCanvas->setParticipants(cp);
+    m_sceneCanvas->setParticipants(cp);
 }
 
 // ── Slots ─────────────────────────────────────────────────────────────────────
-void MainWindow::onPageSelected(Sidebar::Page) { /* future */ }
+void MainWindow::onPageSelected(Sidebar::Page p)
+{
+    using P = Sidebar::Page;
+    switch (p) {
+    case P::Templates:
+    case P::Participants:
+        m_rightStack->setCurrentIndex(m_pageTemplates);
+        break;
+    case P::Themes:
+        m_rightStack->setCurrentIndex(m_pageThemes);
+        break;
+    case P::Settings:
+        m_rightStack->setCurrentIndex(m_pageSettings);
+        break;
+    default:
+        break;
+    }
+}
 
 void MainWindow::onTemplateSelected(const LayoutTemplate &tmpl)
 {
@@ -254,36 +299,36 @@ void MainWindow::onTemplateSelected(const LayoutTemplate &tmpl)
     m_sceneCanvas->setTemplate(tmpl);
 }
 
+void MainWindow::onThemeSelected(const ShowTheme &theme)
+{
+    qApp->setStyleSheet(sidecar_stylesheet(&theme));
+    onObsLog(QStringLiteral("Theme applied: %1.").arg(theme.name));
+}
+
 void MainWindow::onApplyLayout()
 {
-    if (!m_currentTemplate.isValid()) {
-        onObsLog("No template selected.");
-        return;
-    }
-    if (!m_obsClient->isConnected()) {
-        onObsLog("Not connected to OBS — preview-only apply.");
-        return;
-    }
+    if (!m_currentTemplate.isValid()) { onObsLog("No template selected."); return; }
+    if (!m_obsClient->isConnected())  { onObsLog("Not connected — preview only."); return; }
 
-    // Try the flat applied-template JSON first if one ships with the template
-    const QString applied = QString(":/applied/data/applied/%1.applied.json")
-                                .arg(m_currentTemplate.id);
-    QFile f(applied);
+    const QString scene   = m_settingsPage->targetScene();
+    const double  canvasW = m_settingsPage->canvasWidth();
+    const double  canvasH = m_settingsPage->canvasHeight();
+    const QString pattern = m_settingsPage->sourcePattern();
+
+    // Try bundled applied-JSON first
+    QFile f(QString(":/applied/data/applied/%1.applied.json").arg(m_currentTemplate.id));
     if (f.open(QIODevice::ReadOnly)) {
-        const QJsonObject obj = QJsonDocument::fromJson(f.readAll()).object();
-        // Override scene with our active target so the user can retarget without
-        // editing JSON.
-        QJsonObject withScene = obj;
-        if (!m_targetScene.isEmpty()) withScene["scene"] = m_targetScene;
-        m_obsClient->applyTemplate(withScene);
+        QJsonObject obj = QJsonDocument::fromJson(f.readAll()).object();
+        obj["scene"] = scene;
+        m_obsClient->applyTemplate(obj);
         return;
     }
 
     // Fall back to normalized layout
     QStringList sources;
     for (int i = 0; i < m_currentTemplate.slots.size(); ++i)
-        sources << QString("Zoom Participant %1").arg(i + 1);
-    m_obsClient->applyLayout(m_targetScene, m_currentTemplate, sources, 1920, 1080);
+        sources << pattern.arg(i + 1);
+    m_obsClient->applyLayout(scene, m_currentTemplate, sources, canvasW, canvasH);
 }
 
 void MainWindow::onEngineToggle()
@@ -304,7 +349,8 @@ void MainWindow::onObsConnect()
         return;
     }
 
-    OBSConnectDialog dlg(m_obsConfig, this);
+    // Pre-populate dialog from settings page values (if user has saved)
+    OBSConnectDialog dlg(m_settingsPage->obsConfig(), this);
     if (dlg.exec() != QDialog::Accepted) return;
     m_obsConfig = dlg.config();
 
@@ -328,12 +374,12 @@ void MainWindow::onObsState(OBSClient::State s)
 
     QString color = "#8080a0";
     switch (s) {
-    case OBSClient::State::Connected:    color = "#20c460"; break;
+    case OBSClient::State::Connected:                          color = "#20c460"; break;
     case OBSClient::State::Connecting:
     case OBSClient::State::Authenticating:
-    case OBSClient::State::Reconnecting: color = "#e0a020"; break;
-    case OBSClient::State::Failed:       color = "#e04040"; break;
-    case OBSClient::State::Disconnected: color = "#8080a0"; break;
+    case OBSClient::State::Reconnecting:                       color = "#e0a020"; break;
+    case OBSClient::State::Failed:                             color = "#e04040"; break;
+    case OBSClient::State::Disconnected:                       color = "#8080a0"; break;
     }
     m_obsStatusLabel->setStyleSheet(
         QString("color: %1; font-size: 11px; background: transparent;").arg(color));
@@ -342,18 +388,41 @@ void MainWindow::onObsState(OBSClient::State s)
 void MainWindow::onObsLog(const QString &msg)
 {
     if (!m_logView) return;
-    const QString line = QString("[%1] %2")
-        .arg(QDateTime::currentDateTime().toString("HH:mm:ss"), msg);
-    m_logView->appendPlainText(line);
+    m_logView->appendPlainText(
+        QString("[%1] %2").arg(QDateTime::currentDateTime().toString("HH:mm:ss"), msg));
     if (!m_logDock->isVisible()) m_logDock->show();
 }
 
 void MainWindow::onScenesReceived(const QStringList &scenes)
 {
-    if (scenes.contains(m_targetScene)) {
-        m_obsClient->requestSceneItems(m_targetScene);
+    const QString scene = m_settingsPage->targetScene();
+    if (scenes.contains(scene)) {
+        m_obsClient->requestSceneItems(scene);
     } else if (!scenes.isEmpty()) {
-        onObsLog(QStringLiteral("Target scene '%1' not found. Available: %2")
-                     .arg(m_targetScene, scenes.join(", ")));
+        onObsLog(QStringLiteral("Scene '%1' not found. Available: %2")
+                     .arg(scene, scenes.join(", ")));
     }
+}
+
+void MainWindow::onVirtualCamToggle()
+{
+    if (m_obsClient->isVirtualCamActive())
+        m_obsClient->stopVirtualCam();
+    else
+        m_obsClient->startVirtualCam();
+}
+
+void MainWindow::onVirtualCamState(bool active)
+{
+    m_vcamBtn->setText(active ? "⏺  V-Cam ON" : "⏺  V-Cam OFF");
+    m_vcamBtn->setProperty("primary", active ? "true" : "false");
+    m_vcamBtn->style()->unpolish(m_vcamBtn);
+    m_vcamBtn->style()->polish(m_vcamBtn);
+}
+
+void MainWindow::onSettingsChanged()
+{
+    // Re-read the saved OBS config so the next connect picks it up
+    m_obsConfig = m_settingsPage->obsConfig();
+    onObsLog("Settings saved.");
 }

--- a/sidecar/src/mainwindow.cpp
+++ b/sidecar/src/mainwindow.cpp
@@ -124,6 +124,10 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
                 onObsLog(QStringLiteral("✓ Applied '%1' (%2 items).").arg(name).arg(n));
             });
 
+    // Canvas slot assignment from drag-and-drop
+    connect(m_liveCanvas,  &PreviewCanvas::slotAssigned, this, &MainWindow::onSlotAssigned);
+    connect(m_sceneCanvas, &PreviewCanvas::slotAssigned, this, &MainWindow::onSlotAssigned);
+
     // Templates
     auto &tm = TemplateManager::instance();
     tm.loadBuiltIn();
@@ -150,10 +154,39 @@ void MainWindow::buildTopBar(QWidget *parent)
 
     auto *row = new QHBoxLayout(m_topBar);
     row->setContentsMargins(16, 0, 12, 0);
-    row->setSpacing(12);
+    row->setSpacing(10);
 
     m_showNameLabel = new QLabel("Morning Show — Episode 142", m_topBar);
     m_showNameLabel->setStyleSheet("color: #e0e0f0; font-size: 15px; font-weight: 700;");
+
+    // Show phase segmented control
+    auto *phaseBar = new QWidget(m_topBar);
+    phaseBar->setObjectName("phaseSegment");
+    auto *phl = new QHBoxLayout(phaseBar);
+    phl->setContentsMargins(2, 2, 2, 2);
+    phl->setSpacing(0);
+
+    m_preShowBtn  = new QPushButton("PRE",     phaseBar);
+    m_liveBtn     = new QPushButton("● LIVE",  phaseBar);
+    m_postShowBtn = new QPushButton("POST",    phaseBar);
+
+    m_preShowBtn->setObjectName("phasePreBtn");
+    m_liveBtn->setObjectName("phaseLiveBtn");
+    m_postShowBtn->setObjectName("phasePostBtn");
+
+    for (auto *b : {m_preShowBtn, m_liveBtn, m_postShowBtn}) {
+        b->setCheckable(true);
+        b->setFixedHeight(28);
+        phl->addWidget(b);
+    }
+    m_preShowBtn->setChecked(true);
+
+    connect(m_preShowBtn,  &QPushButton::clicked, this,
+            [this]{ onPhaseSelected(ShowPhase::PreShow);  });
+    connect(m_liveBtn,     &QPushButton::clicked, this,
+            [this]{ onPhaseSelected(ShowPhase::Live);     });
+    connect(m_postShowBtn, &QPushButton::clicked, this,
+            [this]{ onPhaseSelected(ShowPhase::PostShow); });
 
     m_obsStatusLabel = new QLabel("Disconnected", m_topBar);
     m_obsStatusLabel->setStyleSheet("color: #8080a0; font-size: 11px; background: transparent;");
@@ -166,9 +199,11 @@ void MainWindow::buildTopBar(QWidget *parent)
     m_obsBtn->setObjectName("obsBtn");
     m_obsBtn->setFixedHeight(34);
 
-    row->addWidget(m_showNameLabel, 1);
+    row->addWidget(m_showNameLabel);
+    row->addStretch(1);
+    row->addWidget(phaseBar);
     row->addWidget(m_obsStatusLabel);
-    row->addSpacing(6);
+    row->addSpacing(4);
     row->addWidget(m_obsBtn);
     row->addWidget(m_engineBtn);
 }
@@ -277,16 +312,16 @@ void MainWindow::buildLogDock()
 // ── Mock data ─────────────────────────────────────────────────────────────────
 void MainWindow::loadMockParticipants()
 {
-    QVector<ParticipantInfo> parts = {
+    m_participants = {
         {1, "Alex Rivera",   "AR", QColor(0x1e, 0x6a, 0xe0), false, true,  0},
         {2, "Sam Chen",      "SC", QColor(0x20, 0xa0, 0x60), false, false, 1},
         {3, "Jordan Kim",    "JK", QColor(0x9b, 0x40, 0xd0), false, true,  2},
         {4, "Taylor Brooks", "TB", QColor(0xe0, 0x60, 0x20), false, false, 3},
     };
-    m_participantPanel->setParticipants(parts);
+    m_participantPanel->setParticipants(m_participants);
 
     QVector<PreviewCanvas::Participant> cp;
-    for (const auto &p : parts)
+    for (const auto &p : m_participants)
         cp.append({p.name, p.initials, p.color, p.isTalking, p.hasVideo});
     m_liveCanvas->setParticipants(cp);
     m_sceneCanvas->setParticipants(cp);
@@ -465,4 +500,54 @@ void MainWindow::onSettingsChanged()
     // Re-read the saved OBS config so the next connect picks it up
     m_obsConfig = m_settingsPage->obsConfig();
     onObsLog("Settings saved.");
+}
+
+void MainWindow::onPhaseSelected(ShowPhase phase)
+{
+    m_phase = phase;
+    m_preShowBtn->setChecked(phase == ShowPhase::PreShow);
+    m_liveBtn->setChecked(phase == ShowPhase::Live);
+    m_postShowBtn->setChecked(phase == ShowPhase::PostShow);
+
+    // Highlight top bar border red during LIVE
+    const QString border = (phase == ShowPhase::Live) ? "#cc2020" : "#181828";
+    m_topBar->setStyleSheet(
+        QString("#topBar { background: #0d0d12; border-bottom: 2px solid %1; }").arg(border));
+
+    const QStringList labels = {"PRE-SHOW", "LIVE", "POST-SHOW"};
+    onObsLog(QString("Show phase → %1").arg(labels[int(phase)]));
+}
+
+void MainWindow::onSlotAssigned(int slotIndex, int participantId)
+{
+    // Evict the old occupant of this slot, then assign the new one
+    for (auto &p : m_participants) {
+        if (p.slotAssign == slotIndex)
+            p.slotAssign = -1;
+    }
+    for (auto &p : m_participants) {
+        if (p.id == participantId)
+            p.slotAssign = slotIndex;
+    }
+
+    // Rebuild ordered participant list for canvas (slot index → position)
+    const int nSlots = m_currentTemplate.slots.size();
+    QVector<PreviewCanvas::Participant> cp(nSlots);
+    for (const auto &p : m_participants) {
+        if (p.slotAssign >= 0 && p.slotAssign < nSlots)
+            cp[p.slotAssign] = {p.name, p.initials, p.color, p.isTalking, p.hasVideo};
+    }
+    m_liveCanvas->setParticipants(cp);
+    m_sceneCanvas->setParticipants(cp);
+
+    // Refresh panel to show updated slot labels
+    m_participantPanel->setParticipants(m_participants);
+
+    onObsLog(QString("Slot %1 ← %2")
+             .arg(slotIndex + 1)
+             .arg([&]() -> QString {
+                 for (const auto &p : m_participants)
+                     if (p.id == participantId) return p.name;
+                 return QString::number(participantId);
+             }()));
 }

--- a/sidecar/src/mainwindow.h
+++ b/sidecar/src/mainwindow.h
@@ -2,15 +2,19 @@
 #include "sidebar.h"
 #include "layout-template.h"
 #include "obs-client.h"
+#include "show-theme.h"
 #include <QMainWindow>
 
 class PreviewCanvas;
 class TemplatePanel;
 class ParticipantPanel;
+class ThemePanel;
+class SettingsPage;
 class QLabel;
 class QPushButton;
 class QPlainTextEdit;
 class QDockWidget;
+class QStackedWidget;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -20,12 +24,16 @@ public:
 private slots:
     void onPageSelected(Sidebar::Page p);
     void onTemplateSelected(const LayoutTemplate &tmpl);
+    void onThemeSelected(const ShowTheme &theme);
     void onApplyLayout();
     void onEngineToggle();
     void onObsConnect();
     void onObsState(OBSClient::State s);
     void onObsLog(const QString &msg);
     void onScenesReceived(const QStringList &scenes);
+    void onVirtualCamToggle();
+    void onVirtualCamState(bool active);
+    void onSettingsChanged();
 
 private:
     void buildTopBar(QWidget *parent);
@@ -33,7 +41,6 @@ private:
     void buildRightPanel(QWidget *parent);
     void buildLogDock();
     void loadMockParticipants();
-    void updateObsButton();
 
     // Top bar
     QWidget     *m_topBar         = nullptr;
@@ -44,13 +51,25 @@ private:
     QPushButton *m_obsBtn         = nullptr;
     bool         m_engineOn       = false;
 
+    // Toolbar buttons (kept for state updates)
+    QPushButton *m_vcamBtn = nullptr;
+
     // Center
     PreviewCanvas *m_liveCanvas   = nullptr;
     PreviewCanvas *m_sceneCanvas  = nullptr;
 
-    // Right panel
+    // Right panel — stacked pages
+    QStackedWidget   *m_rightStack       = nullptr;
     TemplatePanel    *m_templatePanel    = nullptr;
     ParticipantPanel *m_participantPanel = nullptr;
+    ThemePanel       *m_themePanel       = nullptr;
+    SettingsPage     *m_settingsPage     = nullptr;
+
+    // Right panel page indices
+    int m_pageTemplates    = 0;
+    int m_pageThemes       = 0;
+    int m_pageParticipants = 0;
+    int m_pageSettings     = 0;
 
     // Log
     QDockWidget    *m_logDock = nullptr;
@@ -60,5 +79,5 @@ private:
     LayoutTemplate    m_currentTemplate;
     OBSClient        *m_obsClient = nullptr;
     OBSClient::Config m_obsConfig;
-    QString           m_targetScene = "CoreVideo Main";
+    Sidebar          *m_sidebar = nullptr;
 };

--- a/sidecar/src/mainwindow.h
+++ b/sidecar/src/mainwindow.h
@@ -4,6 +4,7 @@
 #include "obs-client.h"
 #include "show-theme.h"
 #include "macro.h"
+#include "participant-panel.h"
 #include <QMainWindow>
 
 class PreviewCanvas;
@@ -22,6 +23,8 @@ class QStackedWidget;
 class MainWindow : public QMainWindow {
     Q_OBJECT
 public:
+    enum class ShowPhase { PreShow, Live, PostShow };
+
     explicit MainWindow(QWidget *parent = nullptr);
 
 private slots:
@@ -39,6 +42,8 @@ private slots:
     void onSettingsChanged();
     void onSceneActivated(const QString &name);
     void onMacroTriggered(const Macro &macro);
+    void onPhaseSelected(ShowPhase phase);
+    void onSlotAssigned(int slotIndex, int participantId);
 
 private:
     void buildTopBar(QWidget *parent);
@@ -55,6 +60,12 @@ private:
     QPushButton *m_engineBtn      = nullptr;
     QPushButton *m_obsBtn         = nullptr;
     bool         m_engineOn       = false;
+
+    // Show phase segment
+    QPushButton *m_preShowBtn  = nullptr;
+    QPushButton *m_liveBtn     = nullptr;
+    QPushButton *m_postShowBtn = nullptr;
+    ShowPhase    m_phase       = ShowPhase::PreShow;
 
     // Toolbar buttons (kept for state updates)
     QPushButton *m_vcamBtn = nullptr;
@@ -84,8 +95,9 @@ private:
     QPlainTextEdit *m_logView = nullptr;
 
     // State
-    LayoutTemplate    m_currentTemplate;
-    OBSClient        *m_obsClient = nullptr;
-    OBSClient::Config m_obsConfig;
-    Sidebar          *m_sidebar = nullptr;
+    LayoutTemplate             m_currentTemplate;
+    OBSClient                 *m_obsClient   = nullptr;
+    OBSClient::Config          m_obsConfig;
+    Sidebar                   *m_sidebar     = nullptr;
+    QVector<ParticipantInfo>   m_participants;
 };

--- a/sidecar/src/mainwindow.h
+++ b/sidecar/src/mainwindow.h
@@ -3,12 +3,15 @@
 #include "layout-template.h"
 #include "obs-client.h"
 #include "show-theme.h"
+#include "macro.h"
 #include <QMainWindow>
 
 class PreviewCanvas;
 class TemplatePanel;
 class ParticipantPanel;
 class ThemePanel;
+class ScenesPanel;
+class MacrosPanel;
 class SettingsPage;
 class QLabel;
 class QPushButton;
@@ -34,6 +37,8 @@ private slots:
     void onVirtualCamToggle();
     void onVirtualCamState(bool active);
     void onSettingsChanged();
+    void onSceneActivated(const QString &name);
+    void onMacroTriggered(const Macro &macro);
 
 private:
     void buildTopBar(QWidget *parent);
@@ -63,13 +68,16 @@ private:
     TemplatePanel    *m_templatePanel    = nullptr;
     ParticipantPanel *m_participantPanel = nullptr;
     ThemePanel       *m_themePanel       = nullptr;
+    ScenesPanel      *m_scenesPanel      = nullptr;
+    MacrosPanel      *m_macrosPanel      = nullptr;
     SettingsPage     *m_settingsPage     = nullptr;
 
     // Right panel page indices
-    int m_pageTemplates    = 0;
-    int m_pageThemes       = 0;
-    int m_pageParticipants = 0;
-    int m_pageSettings     = 0;
+    int m_pageTemplates = 0;
+    int m_pageThemes    = 0;
+    int m_pageScenes    = 0;
+    int m_pageMacros    = 0;
+    int m_pageSettings  = 0;
 
     // Log
     QDockWidget    *m_logDock = nullptr;

--- a/sidecar/src/obs-client.cpp
+++ b/sidecar/src/obs-client.cpp
@@ -118,6 +118,7 @@ void OBSClient::onTextMessageReceived(const QString &msg)
         emit connected();
         emit log("Identified — connection ready.");
         requestSceneList();
+        requestVirtualCamStatus();
         break;
     case 5: handleEvent(d);    break;
     case 7: handleResponse(d); break;
@@ -198,6 +199,24 @@ void OBSClient::handleResponse(const QJsonObject &d)
         emit scenesReceived(names);
         emit log(QStringLiteral("Scenes: %1").arg(names.join(", ")));
     }
+    else if (type == "GetVirtualCamStatus") {
+        const bool active = rd["outputActive"].toBool();
+        if (m_virtualCamActive != active) {
+            m_virtualCamActive = active;
+            emit virtualCamStateChanged(active);
+        }
+        emit log(QStringLiteral("Virtual camera: %1.").arg(active ? "active" : "inactive"));
+    }
+    else if (type == "StartVirtualCam") {
+        m_virtualCamActive = true;
+        emit virtualCamStateChanged(true);
+        emit log("Virtual camera started.");
+    }
+    else if (type == "StopVirtualCam") {
+        m_virtualCamActive = false;
+        emit virtualCamStateChanged(false);
+        emit log("Virtual camera stopped.");
+    }
     else if (type == "GetSceneItemList") {
         const QString scene = rd["sceneName"].toString();
         QVector<SceneItem> items;
@@ -221,9 +240,16 @@ void OBSClient::handleEvent(const QJsonObject &d)
 {
     const QString type = d["eventType"].toString();
     if (type == "SceneItemCreated" || type == "SceneItemRemoved") {
-        // Invalidate cache for affected scene
         const QString scene = d["eventData"].toObject()["sceneName"].toString();
         m_itemCache.remove(scene);
+    }
+    else if (type == "VirtualcamStateChanged") {
+        const bool active = d["eventData"].toObject()["outputActive"].toBool();
+        if (m_virtualCamActive != active) {
+            m_virtualCamActive = active;
+            emit virtualCamStateChanged(active);
+            emit log(QStringLiteral("Virtual camera %1.").arg(active ? "started" : "stopped"));
+        }
     }
 }
 
@@ -282,6 +308,22 @@ void OBSClient::setSceneItemTransform(const QString  &sceneName,
         {"sceneItemId",        sceneItemId},
         {"sceneItemTransform", t.toJson()},
     });
+}
+
+// ── Virtual camera ────────────────────────────────────────────────────────────
+void OBSClient::requestVirtualCamStatus()
+{
+    if (m_state == State::Connected) sendRequest("GetVirtualCamStatus");
+}
+
+void OBSClient::startVirtualCam()
+{
+    if (m_state == State::Connected) sendRequest("StartVirtualCam");
+}
+
+void OBSClient::stopVirtualCam()
+{
+    if (m_state == State::Connected) sendRequest("StopVirtualCam");
 }
 
 // ── applyLayout (normalized LayoutTemplate) ───────────────────────────────────

--- a/sidecar/src/obs-client.cpp
+++ b/sidecar/src/obs-client.cpp
@@ -239,7 +239,10 @@ void OBSClient::handleResponse(const QJsonObject &d)
 void OBSClient::handleEvent(const QJsonObject &d)
 {
     const QString type = d["eventType"].toString();
-    if (type == "SceneItemCreated" || type == "SceneItemRemoved") {
+    if (type == "CurrentProgramSceneChanged") {
+        emit sceneChanged(d["eventData"].toObject()["sceneName"].toString());
+    }
+    else if (type == "SceneItemCreated" || type == "SceneItemRemoved") {
         const QString scene = d["eventData"].toObject()["sceneName"].toString();
         m_itemCache.remove(scene);
     }
@@ -308,6 +311,29 @@ void OBSClient::setSceneItemTransform(const QString  &sceneName,
         {"sceneItemId",        sceneItemId},
         {"sceneItemTransform", t.toJson()},
     });
+}
+
+// ── Macro execution ───────────────────────────────────────────────────────────
+void OBSClient::executeMacro(const Macro &macro)
+{
+    if (m_state != State::Connected) return;
+    QJsonArray requests;
+    for (const auto &step : macro.steps) {
+        QJsonObject req{
+            {"requestType", step.requestType},
+            {"requestId",   nextId()},
+        };
+        if (!step.data.isEmpty()) req["requestData"] = step.data;
+        requests.append(req);
+    }
+    if (requests.isEmpty()) return;
+    sendOp(8, QJsonObject{
+        {"requestId",     nextId()},
+        {"haltOnFailure", false},
+        {"requests",      requests},
+    });
+    emit log(QStringLiteral("Macro '%1': dispatched %2 steps.")
+                 .arg(macro.label).arg(requests.size()));
 }
 
 // ── Virtual camera ────────────────────────────────────────────────────────────

--- a/sidecar/src/obs-client.h
+++ b/sidecar/src/obs-client.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "layout-template.h"
+#include "macro.h"
 #include <QObject>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -95,6 +96,9 @@ public:
     // Returns false if not connected or template malformed.
     bool applyTemplate(const QJsonObject &templateJson);
 
+    // Execute a Macro: sends all steps as a RequestBatch.
+    void executeMacro(const Macro &macro);
+
 signals:
     void stateChanged(OBSClient::State s);
     void connected();
@@ -102,6 +106,7 @@ signals:
     void errorOccurred(const QString &msg);
     void scenesReceived(const QStringList &scenes);
     void sceneItemsReceived(const QString &scene, const QVector<SceneItem> &items);
+    void sceneChanged(const QString &name);
     void templateApplied(const QString &name, int itemCount);
     void virtualCamStateChanged(bool active);
     void log(const QString &msg);

--- a/sidecar/src/obs-client.h
+++ b/sidecar/src/obs-client.h
@@ -66,6 +66,12 @@ public:
     void requestSceneItems(const QString &sceneName);
     void setCurrentScene(const QString &name);
 
+    // ── Virtual camera ───────────────────────────────────────────────────────
+    void requestVirtualCamStatus();
+    void startVirtualCam();
+    void stopVirtualCam();
+    bool isVirtualCamActive() const { return m_virtualCamActive; }
+
     // ── Transform application ────────────────────────────────────────────────
     void setSceneItemTransform(const QString  &sceneName,
                                int             sceneItemId,
@@ -97,6 +103,7 @@ signals:
     void scenesReceived(const QStringList &scenes);
     void sceneItemsReceived(const QString &scene, const QVector<SceneItem> &items);
     void templateApplied(const QString &name, int itemCount);
+    void virtualCamStateChanged(bool active);
     void log(const QString &msg);
 
 private slots:
@@ -125,6 +132,7 @@ private:
     State       m_state = State::Disconnected;
     int         m_idSeq = 1;
     int         m_reconnectAttempt = 0;
-    QHash<QString, QString> m_pending;            // requestId → requestType
+    QHash<QString, QString> m_pending;               // requestId → requestType
     QHash<QString, QHash<QString, int>> m_itemCache; // scene → (source → itemId)
+    bool m_virtualCamActive = false;
 };

--- a/sidecar/src/participant-panel.cpp
+++ b/sidecar/src/participant-panel.cpp
@@ -6,6 +6,10 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QScrollArea>
+#include <QApplication>
+#include <QDrag>
+#include <QMimeData>
+#include <QMouseEvent>
 
 // ── ParticipantCard ───────────────────────────────────────────────────────────
 
@@ -47,6 +51,34 @@ ParticipantCard::ParticipantCard(const ParticipantInfo &info, QWidget *parent)
     connect(assignBtn, &QPushButton::clicked, this, [this]() {
         emit assignClicked(m_info.id);
     });
+}
+
+void ParticipantCard::mousePressEvent(QMouseEvent *e)
+{
+    if (e->button() == Qt::LeftButton)
+        m_dragStart = e->pos();
+    QWidget::mousePressEvent(e);
+}
+
+void ParticipantCard::mouseMoveEvent(QMouseEvent *e)
+{
+    if (!(e->buttons() & Qt::LeftButton)) return;
+    if ((e->pos() - m_dragStart).manhattanLength() < QApplication::startDragDistance()) return;
+
+    auto *drag = new QDrag(this);
+    auto *mime = new QMimeData;
+    mime->setData("application/x-cv-participant",
+                  QByteArray::number(m_info.id));
+    drag->setMimeData(mime);
+
+    // Render card as drag pixmap
+    QPixmap px(size());
+    px.fill(Qt::transparent);
+    render(&px);
+    drag->setPixmap(px.scaled(px.size() * 0.85, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+    drag->setHotSpot(e->pos() * 85 / 100);
+
+    drag->exec(Qt::CopyAction);
 }
 
 void ParticipantCard::paintEvent(QPaintEvent *)

--- a/sidecar/src/participant-panel.h
+++ b/sidecar/src/participant-panel.h
@@ -46,7 +46,10 @@ signals:
 
 protected:
     void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
 
 private:
     ParticipantInfo m_info;
+    QPoint          m_dragStart;
 };

--- a/sidecar/src/preview-canvas.cpp
+++ b/sidecar/src/preview-canvas.cpp
@@ -2,6 +2,11 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QFontMetrics>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDragLeaveEvent>
+#include <QDropEvent>
+#include <QMimeData>
 #include <cmath>
 
 static const QColor kSlotBg   {0x22, 0x22, 0x30};
@@ -14,6 +19,7 @@ PreviewCanvas::PreviewCanvas(QWidget *parent)
 {
     setMinimumSize(240, 135);
     setAttribute(Qt::WA_OpaquePaintEvent);
+    setAcceptDrops(true);
 }
 
 void PreviewCanvas::setTemplate(const LayoutTemplate &tmpl)
@@ -26,6 +32,53 @@ void PreviewCanvas::setParticipants(const QVector<Participant> &participants)
 {
     m_parts = participants;
     update();
+}
+
+// ── Drag-and-drop ─────────────────────────────────────────────────────────────
+
+int PreviewCanvas::slotAtPoint(QPoint pt) const
+{
+    for (int i = 0; i < m_tmpl.slots.size(); ++i) {
+        if (slotRect(m_tmpl.slots[i]).contains(pt))
+            return i;
+    }
+    return -1;
+}
+
+void PreviewCanvas::dragEnterEvent(QDragEnterEvent *e)
+{
+    if (e->mimeData()->hasFormat("application/x-cv-participant"))
+        e->acceptProposedAction();
+}
+
+void PreviewCanvas::dragMoveEvent(QDragMoveEvent *e)
+{
+    if (!e->mimeData()->hasFormat("application/x-cv-participant")) return;
+    const int slot = slotAtPoint(e->position().toPoint());
+    if (slot != m_hoveredSlot) {
+        m_hoveredSlot = slot;
+        update();
+    }
+    (slot >= 0) ? e->acceptProposedAction() : e->ignore();
+}
+
+void PreviewCanvas::dragLeaveEvent(QDragLeaveEvent *)
+{
+    m_hoveredSlot = -1;
+    update();
+}
+
+void PreviewCanvas::dropEvent(QDropEvent *e)
+{
+    if (!e->mimeData()->hasFormat("application/x-cv-participant")) return;
+    const int slot = slotAtPoint(e->position().toPoint());
+    m_hoveredSlot = -1;
+    update();
+    if (slot < 0) { e->ignore(); return; }
+    const int pid = QString::fromUtf8(
+        e->mimeData()->data("application/x-cv-participant")).toInt();
+    emit slotAssigned(slot, pid);
+    e->acceptProposedAction();
 }
 
 QRectF PreviewCanvas::slotRect(const TemplateSlot &s) const
@@ -66,8 +119,11 @@ void PreviewCanvas::drawSlot(QPainter &p, const QRectF &rect, int idx) const
     path.addRoundedRect(rect, 10, 10);
     p.fillPath(path, kSlotBg);
 
-    // Talking border
-    if (hasPart && part.isTalking) {
+    // Border: drop-target highlight > talking ring > normal
+    if (idx == m_hoveredSlot) {
+        p.setPen(QPen(QColor(0x29, 0x79, 0xff), 3.0, Qt::SolidLine));
+        p.drawPath(path);
+    } else if (hasPart && part.isTalking) {
         p.setPen(QPen(QColor(0x20, 0x90, 0xff), 2.5));
         p.drawPath(path);
     } else {

--- a/sidecar/src/preview-canvas.h
+++ b/sidecar/src/preview-canvas.h
@@ -3,9 +3,11 @@
 #include <QWidget>
 #include <QVector>
 #include <QColor>
+#include <QPoint>
 
 // Renders a broadcast preview panel — draws participant slots according to
 // the active LayoutTemplate using mock or live thumbnail data.
+// Accepts drops from participant cards (MIME: "application/x-cv-participant").
 class PreviewCanvas : public QWidget {
     Q_OBJECT
 public:
@@ -22,15 +24,24 @@ public:
     void setTemplate(const LayoutTemplate &tmpl);
     void setParticipants(const QVector<Participant> &participants);
 
+signals:
+    void slotAssigned(int slotIndex, int participantId);
+
 protected:
     void paintEvent(QPaintEvent *) override;
+    void dragEnterEvent(QDragEnterEvent *e) override;
+    void dragMoveEvent(QDragMoveEvent *e) override;
+    void dragLeaveEvent(QDragLeaveEvent *e) override;
+    void dropEvent(QDropEvent *e) override;
 
 private:
     LayoutTemplate       m_tmpl;
     QVector<Participant> m_parts;
+    int                  m_hoveredSlot = -1;
 
-    void drawSlot(QPainter &p, const QRectF &rect, int index) const;
-    void drawAvatar(QPainter &p, QPointF center, float r,
-                    const Participant &part) const;
+    int    slotAtPoint(QPoint pt) const;
+    void   drawSlot(QPainter &p, const QRectF &rect, int index) const;
+    void   drawAvatar(QPainter &p, QPointF center, float r,
+                      const Participant &part) const;
     QRectF slotRect(const TemplateSlot &s) const;
 };

--- a/sidecar/src/scenes-panel.cpp
+++ b/sidecar/src/scenes-panel.cpp
@@ -1,0 +1,143 @@
+#include "scenes-panel.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+ScenesPanel::ScenesPanel(QWidget *parent)
+    : QWidget(parent)
+{
+    auto *root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(0);
+
+    // ── Header row ────────────────────────────────────────────────────────────
+    auto *headerRow = new QHBoxLayout;
+    headerRow->setContentsMargins(12, 10, 12, 6);
+    headerRow->setSpacing(0);
+
+    auto *headerLabel = new QLabel("Scenes", this);
+    headerLabel->setObjectName("sectionHeader");
+    headerLabel->setStyleSheet(
+        "color: #c0c0e0;"
+        "font-size: 11px;"
+        "font-weight: 700;"
+        "letter-spacing: 0.08em;"
+        "text-transform: uppercase;"
+        "padding: 0;");
+
+    m_refreshBtn = new QPushButton("↻", this);
+    m_refreshBtn->setObjectName("iconBtn");
+    m_refreshBtn->setFixedSize(28, 28);
+    m_refreshBtn->setStyleSheet("padding: 0;");
+
+    headerRow->addWidget(headerLabel);
+    headerRow->addStretch();
+    headerRow->addWidget(m_refreshBtn);
+
+    root->addLayout(headerRow);
+
+    // ── Current scene row ─────────────────────────────────────────────────────
+    auto *currentRow = new QHBoxLayout;
+    currentRow->setContentsMargins(12, 4, 12, 4);
+    currentRow->setSpacing(4);
+
+    auto *programLabel = new QLabel("Program:", this);
+    programLabel->setStyleSheet(
+        "color: #5a5a7a;"
+        "font-size: 11px;"
+        "background: transparent;");
+
+    m_currentLabel = new QLabel("—", this);
+    m_currentLabel->setStyleSheet(
+        "color: #20c460;"
+        "font-size: 11px;"
+        "font-weight: 600;"
+        "background: transparent;");
+
+    currentRow->addWidget(programLabel);
+    currentRow->addWidget(m_currentLabel);
+    currentRow->addStretch();
+
+    root->addLayout(currentRow);
+
+    // ── Scene list ────────────────────────────────────────────────────────────
+    m_list = new QListWidget(this);
+    m_list->setFrameShape(QFrame::NoFrame);
+    m_list->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_list->setStyleSheet(
+        "QListWidget {"
+        "  background: transparent;"
+        "  border: none;"
+        "  outline: none;"
+        "}"
+        "QListWidget::item {"
+        "  color: #c0c0d8;"
+        "  padding: 8px 12px;"
+        "  border-radius: 6px;"
+        "}"
+        "QListWidget::item:hover {"
+        "  background: #18182a;"
+        "}"
+        "QListWidget::item:selected {"
+        "  background: #1d3de8;"
+        "  color: #ffffff;"
+        "}");
+
+    connect(m_list, &QListWidget::itemDoubleClicked,
+            this, [this](QListWidgetItem *item) {
+                if (item)
+                    emit sceneActivated(item->text());
+            });
+
+    root->addWidget(m_list, 1);
+
+    // ── Activate button row ───────────────────────────────────────────────────
+    auto *activateRow = new QHBoxLayout;
+    activateRow->setContentsMargins(10, 10, 10, 10);
+    activateRow->setSpacing(0);
+
+    m_activateBtn = new QPushButton("▶  Activate Scene", this);
+    m_activateBtn->setObjectName("toolBtn");
+    m_activateBtn->setProperty("primary", true);
+    m_activateBtn->setFixedHeight(34);
+
+    connect(m_activateBtn, &QPushButton::clicked,
+            this, [this]() {
+                const QString scene = selectedScene();
+                if (!scene.isEmpty())
+                    emit sceneActivated(scene);
+            });
+
+    activateRow->addWidget(m_activateBtn);
+
+    root->addLayout(activateRow);
+
+    // ── Refresh connection ────────────────────────────────────────────────────
+    connect(m_refreshBtn, &QPushButton::clicked,
+            this, &ScenesPanel::refreshRequested);
+}
+
+void ScenesPanel::setScenes(const QStringList &scenes)
+{
+    const bool wasEmpty = m_list->count() == 0;
+    m_list->clear();
+    for (const QString &name : scenes)
+        m_list->addItem(name);
+    if (wasEmpty && m_list->count() > 0)
+        m_list->setCurrentRow(0);
+}
+
+void ScenesPanel::setCurrentScene(const QString &name)
+{
+    m_currentLabel->setText(name);
+}
+
+QString ScenesPanel::selectedScene() const
+{
+    QListWidgetItem *item = m_list->currentItem();
+    return item ? item->text() : QString();
+}

--- a/sidecar/src/scenes-panel.h
+++ b/sidecar/src/scenes-panel.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <QWidget>
+#include <QStringList>
+
+class QListWidget;
+class QLabel;
+class QPushButton;
+
+class ScenesPanel : public QWidget {
+    Q_OBJECT
+public:
+    explicit ScenesPanel(QWidget *parent = nullptr);
+
+    void setScenes(const QStringList &scenes);
+    void setCurrentScene(const QString &name);
+    QString selectedScene() const;
+
+signals:
+    void sceneActivated(const QString &name);   // user double-clicked / pressed Activate
+    void refreshRequested();
+
+private:
+    QListWidget *m_list         = nullptr;
+    QLabel      *m_currentLabel = nullptr;
+    QPushButton *m_activateBtn  = nullptr;
+    QPushButton *m_refreshBtn   = nullptr;
+};

--- a/sidecar/src/settings-page.cpp
+++ b/sidecar/src/settings-page.cpp
@@ -1,0 +1,241 @@
+#include "settings-page.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QFrame>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QSettings>
+#include <QSpinBox>
+#include <QVBoxLayout>
+#include <QWidget>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static QLabel *makeSectionHeader(const QString &text)
+{
+    auto *lbl = new QLabel(text);
+    lbl->setStyleSheet(
+        "color: #c0c0e0;"
+        "font-size: 11px;"
+        "font-weight: 700;"
+        "letter-spacing: 0.08em;"
+        "padding: 10px 12px 4px 12px;"
+        "background: transparent;");
+    return lbl;
+}
+
+static QLabel *makeHelpText(const QString &text)
+{
+    auto *lbl = new QLabel(text);
+    lbl->setWordWrap(true);
+    lbl->setStyleSheet(
+        "color: #5a5a7a;"
+        "font-size: 10px;"
+        "background: transparent;"
+        "padding: 0 0 4px 0;");
+    return lbl;
+}
+
+static QFrame *makeHLine()
+{
+    auto *line = new QFrame();
+    line->setFrameShape(QFrame::HLine);
+    line->setFrameShadow(QFrame::Sunken);
+    return line;
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+SettingsPage::SettingsPage(QWidget *parent)
+    : QWidget(parent)
+{
+    // ---- Top-level layout (no margins, sections separated by HLines) ------
+    auto *rootLayout = new QVBoxLayout(this);
+    rootLayout->setContentsMargins(0, 0, 0, 0);
+    rootLayout->setSpacing(0);
+
+    // ======================================================================
+    // Section 1 — OBS Connection
+    // ======================================================================
+    rootLayout->addWidget(makeSectionHeader("OBS CONNECTION"));
+
+    auto *obsSection = new QWidget();
+    auto *obsForm    = new QFormLayout(obsSection);
+    obsForm->setContentsMargins(12, 4, 12, 8);
+    obsForm->setSpacing(8);
+
+    m_obsHost = new QLineEdit();
+    m_obsHost->setPlaceholderText("localhost");
+    obsForm->addRow("Host:", m_obsHost);
+
+    m_obsPort = new QSpinBox();
+    m_obsPort->setRange(1, 65535);
+    obsForm->addRow("Port:", m_obsPort);
+
+    m_obsPassword = new QLineEdit();
+    m_obsPassword->setEchoMode(QLineEdit::Password);
+    m_obsPassword->setPlaceholderText("Leave empty if no auth");
+    obsForm->addRow("Token:", m_obsPassword);
+
+    m_autoReconnect = new QCheckBox("Reconnect automatically on disconnect");
+    obsForm->addRow("", m_autoReconnect);
+
+    rootLayout->addWidget(obsSection);
+    rootLayout->addWidget(makeHLine());
+
+    // ======================================================================
+    // Section 2 — Scene Setup
+    // ======================================================================
+    rootLayout->addWidget(makeSectionHeader("SCENE SETUP"));
+
+    auto *sceneSection = new QWidget();
+    auto *sceneForm    = new QFormLayout(sceneSection);
+    sceneForm->setContentsMargins(12, 4, 12, 8);
+    sceneForm->setSpacing(8);
+
+    m_scene = new QLineEdit();
+    m_scene->setPlaceholderText("CoreVideo Main");
+    sceneForm->addRow("Target Scene:", m_scene);
+    sceneForm->addRow("", makeHelpText("The OBS scene where CoreVideo Zoom sources live."));
+
+    m_sourcePattern = new QLineEdit();
+    m_sourcePattern->setPlaceholderText("Zoom Participant %1");
+    sceneForm->addRow("Source Pattern:", m_sourcePattern);
+    sceneForm->addRow("", makeHelpText("Use %1 for slot number (1-based). e.g. 'Zoom Participant %1'"));
+
+    m_canvasW = new QSpinBox();
+    m_canvasW->setRange(640, 7680);
+    m_canvasW->setValue(1920);
+    sceneForm->addRow("Canvas Width:", m_canvasW);
+
+    m_canvasH = new QSpinBox();
+    m_canvasH->setRange(360, 4320);
+    m_canvasH->setValue(1080);
+    sceneForm->addRow("Canvas Height:", m_canvasH);
+
+    rootLayout->addWidget(sceneSection);
+    rootLayout->addWidget(makeHLine());
+
+    // ======================================================================
+    // Section 3 — About
+    // ======================================================================
+    rootLayout->addWidget(makeSectionHeader("ABOUT"));
+
+    auto *aboutSection  = new QWidget();
+    auto *aboutLayout   = new QVBoxLayout(aboutSection);
+    aboutLayout->setContentsMargins(12, 4, 12, 8);
+    aboutLayout->setSpacing(4);
+
+    auto *appName = new QLabel("CoreVideo Sidecar");
+    QFont boldFont = appName->font();
+    boldFont.setBold(true);
+    appName->setFont(boldFont);
+    aboutLayout->addWidget(appName);
+
+    aboutLayout->addWidget(new QLabel("Version 0.1.0 — obs-websocket v5"));
+
+    rootLayout->addWidget(aboutSection);
+
+    // ======================================================================
+    // Spacer + Save button
+    // ======================================================================
+    rootLayout->addStretch(1);
+
+    auto *saveBtn = new QPushButton("Save Settings");
+    saveBtn->setObjectName("toolBtn");
+    saveBtn->setProperty("primary", true);
+    // Use a small margin wrapper so the button isn't edge-to-edge
+    auto *btnWrapper  = new QWidget();
+    auto *btnLayout   = new QVBoxLayout(btnWrapper);
+    btnLayout->setContentsMargins(12, 8, 12, 12);
+    btnLayout->addWidget(saveBtn);
+    rootLayout->addWidget(btnWrapper);
+
+    connect(saveBtn, &QPushButton::clicked, this, [this]() {
+        saveSettings();
+        emit settingsChanged();
+    });
+
+    // Populate fields from persisted settings
+    loadSettings();
+}
+
+// ---------------------------------------------------------------------------
+// loadSettings
+// ---------------------------------------------------------------------------
+
+void SettingsPage::loadSettings()
+{
+    QSettings s;
+
+    m_obsHost->setText(s.value("obs/host", "localhost").toString());
+    m_obsPort->setValue(s.value("obs/port", 4455).toInt());
+    m_obsPassword->setText(s.value("obs/password", "").toString());
+    m_autoReconnect->setChecked(s.value("obs/autoReconnect", true).toBool());
+
+    m_scene->setText(s.value("scene/target", "CoreVideo Main").toString());
+    m_sourcePattern->setText(s.value("scene/sourcePattern", "Zoom Participant %1").toString());
+    m_canvasW->setValue(s.value("scene/canvasW", 1920).toInt());
+    m_canvasH->setValue(s.value("scene/canvasH", 1080).toInt());
+}
+
+// ---------------------------------------------------------------------------
+// saveSettings
+// ---------------------------------------------------------------------------
+
+void SettingsPage::saveSettings()
+{
+    QSettings s;
+
+    s.setValue("obs/host",          m_obsHost->text());
+    s.setValue("obs/port",          m_obsPort->value());
+    s.setValue("obs/password",      m_obsPassword->text());
+    s.setValue("obs/autoReconnect", m_autoReconnect->isChecked());
+
+    s.setValue("scene/target",        m_scene->text());
+    s.setValue("scene/sourcePattern", m_sourcePattern->text());
+    s.setValue("scene/canvasW",       m_canvasW->value());
+    s.setValue("scene/canvasH",       m_canvasH->value());
+}
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+QString SettingsPage::targetScene() const
+{
+    return m_scene->text();
+}
+
+QString SettingsPage::sourcePattern() const
+{
+    return m_sourcePattern->text();
+}
+
+int SettingsPage::canvasWidth() const
+{
+    return m_canvasW->value();
+}
+
+int SettingsPage::canvasHeight() const
+{
+    return m_canvasH->value();
+}
+
+OBSClient::Config SettingsPage::obsConfig() const
+{
+    OBSClient::Config cfg;
+    cfg.host          = m_obsHost->text();
+    cfg.port          = m_obsPort->value();
+    cfg.password      = m_obsPassword->text();
+    cfg.autoReconnect = m_autoReconnect->isChecked();
+    return cfg;
+}

--- a/sidecar/src/settings-page.h
+++ b/sidecar/src/settings-page.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "obs-client.h"
+#include <QWidget>
+
+class QLineEdit;
+class QSpinBox;
+class QCheckBox;
+
+class SettingsPage : public QWidget {
+    Q_OBJECT
+public:
+    explicit SettingsPage(QWidget *parent = nullptr);
+
+    // Load saved values from QSettings into the form
+    void loadSettings();
+    // Persist form values to QSettings
+    void saveSettings();
+
+    // Getters used by MainWindow
+    QString targetScene()       const;
+    QString sourcePattern()     const;  // e.g. "Zoom Participant %1"
+    int     canvasWidth()       const;
+    int     canvasHeight()      const;
+    OBSClient::Config obsConfig() const;
+
+signals:
+    void settingsChanged();
+
+private:
+    QLineEdit *m_scene         = nullptr;
+    QLineEdit *m_sourcePattern = nullptr;
+    QSpinBox  *m_canvasW       = nullptr;
+    QSpinBox  *m_canvasH       = nullptr;
+    QLineEdit *m_obsHost       = nullptr;
+    QSpinBox  *m_obsPort       = nullptr;
+    QLineEdit *m_obsPassword   = nullptr;
+    QCheckBox *m_autoReconnect = nullptr;
+};

--- a/sidecar/src/show-theme.h
+++ b/sidecar/src/show-theme.h
@@ -1,0 +1,109 @@
+#pragma once
+#include <QString>
+#include <QColor>
+#include <QVector>
+#include <QJsonObject>
+
+struct ShowTheme {
+    QString id;
+    QString name;
+    QColor  accent;          // primary accent (buttons, selected borders)
+    QColor  accentAlt;       // secondary (e.g. talking ring)
+    QColor  background;      // canvas/slot bg
+    QColor  panelBg;         // sidebar / right-panel bg
+    QColor  textPrimary;
+    QColor  textSecondary;
+
+    bool isValid() const { return !id.isEmpty(); }
+
+    static ShowTheme fromJson(const QJsonObject &obj)
+    {
+        ShowTheme t;
+        t.id            = obj.value("id").toString();
+        t.name          = obj.value("name").toString();
+        t.accent        = QColor::fromString(obj.value("accent").toString());
+        t.accentAlt     = QColor::fromString(obj.value("accentAlt").toString());
+        t.background    = QColor::fromString(obj.value("background").toString());
+        t.panelBg       = QColor::fromString(obj.value("panelBg").toString());
+        t.textPrimary   = QColor::fromString(obj.value("textPrimary").toString());
+        t.textSecondary = QColor::fromString(obj.value("textSecondary").toString());
+        return t;
+    }
+
+    QJsonObject toJson() const
+    {
+        QJsonObject obj;
+        obj["id"]            = id;
+        obj["name"]          = name;
+        obj["accent"]        = accent.name();
+        obj["accentAlt"]     = accentAlt.name();
+        obj["background"]    = background.name();
+        obj["panelBg"]       = panelBg.name();
+        obj["textPrimary"]   = textPrimary.name();
+        obj["textSecondary"] = textSecondary.name();
+        return obj;
+    }
+
+    // Built-in presets
+    static QVector<ShowTheme> builtIns()
+    {
+        QVector<ShowTheme> list;
+
+        ShowTheme midnight;
+        midnight.id            = "midnight";
+        midnight.name          = "Midnight Blue";
+        midnight.accent        = QColor("#2979ff");
+        midnight.accentAlt     = QColor("#20c4ff");
+        midnight.background    = QColor("#0d0d12");
+        midnight.panelBg       = QColor("#101016");
+        midnight.textPrimary   = QColor("#e0e0f0");
+        midnight.textSecondary = QColor("#6060a0");
+        list.append(midnight);
+
+        ShowTheme forest;
+        forest.id            = "forest";
+        forest.name          = "Forest";
+        forest.accent        = QColor("#20c460");
+        forest.accentAlt     = QColor("#00e090");
+        forest.background    = QColor("#080f0a");
+        forest.panelBg       = QColor("#0c1410");
+        forest.textPrimary   = QColor("#d0f0d8");
+        forest.textSecondary = QColor("#406050");
+        list.append(forest);
+
+        ShowTheme crimson;
+        crimson.id            = "crimson";
+        crimson.name          = "Crimson";
+        crimson.accent        = QColor("#e03040");
+        crimson.accentAlt     = QColor("#ff6080");
+        crimson.background    = QColor("#12080a");
+        crimson.panelBg       = QColor("#18080c");
+        crimson.textPrimary   = QColor("#f0d0d8");
+        crimson.textSecondary = QColor("#804050");
+        list.append(crimson);
+
+        ShowTheme gold;
+        gold.id            = "gold";
+        gold.name          = "Gold";
+        gold.accent        = QColor("#e0a020");
+        gold.accentAlt     = QColor("#ffcc40");
+        gold.background    = QColor("#110e04");
+        gold.panelBg       = QColor("#181404");
+        gold.textPrimary   = QColor("#f0e8c0");
+        gold.textSecondary = QColor("#806030");
+        list.append(gold);
+
+        ShowTheme violet;
+        violet.id            = "violet";
+        violet.name          = "Violet";
+        violet.accent        = QColor("#9040e0");
+        violet.accentAlt     = QColor("#c060ff");
+        violet.background    = QColor("#0e080f");
+        violet.panelBg       = QColor("#14081a");
+        violet.textPrimary   = QColor("#e8d0f8");
+        violet.textSecondary = QColor("#704090");
+        list.append(violet);
+
+        return list;
+    }
+};

--- a/sidecar/src/sidecar-style.h
+++ b/sidecar/src/sidecar-style.h
@@ -243,6 +243,37 @@ QPushButton#assignBtn {
 }
 QPushButton#assignBtn:hover { background-color: #2548f0; }
 
+/* ─── Show phase bar ──────────────────────────────────────────────────────── */
+#phaseSegment {
+    background-color: #171724;
+    border: 1px solid #232338;
+    border-radius: 8px;
+}
+QPushButton#phasePreBtn, QPushButton#phaseLiveBtn, QPushButton#phasePostBtn {
+    background-color: transparent;
+    border: none;
+    border-radius: 0;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.05em;
+    padding: 4px 10px;
+    min-height: 24px;
+    color: #40405e;
+}
+QPushButton#phasePreBtn  { border-radius: 6px 0 0 6px; }
+QPushButton#phasePostBtn { border-radius: 0 6px 6px 0; }
+QPushButton#phasePreBtn:hover, QPushButton#phaseLiveBtn:hover, QPushButton#phasePostBtn:hover {
+    background-color: #1c1c2e;
+    color: #7070a0;
+}
+QPushButton#phasePreBtn:checked  { background-color: #252545; color: #9090d0; }
+QPushButton#phaseLiveBtn:checked {
+    background-color: #6a1010;
+    color: #ff5050;
+    border: none;
+}
+QPushButton#phasePostBtn:checked { background-color: #252545; color: #9090d0; }
+
 /* ─── Bottom toolbar ──────────────────────────────────────────────────────── */
 #bottomBar {
     background-color: #0d0d12;

--- a/sidecar/src/sidecar-style.h
+++ b/sidecar/src/sidecar-style.h
@@ -1,8 +1,20 @@
 #pragma once
+#include "show-theme.h"
 #include <QString>
 
-inline QString sidecar_stylesheet()
+// Returns a stylesheet with theme colours substituted.
+// Defaults (no theme / null) produce the original Midnight Blue palette.
+inline QString sidecar_stylesheet(const ShowTheme *theme = nullptr)
 {
+    const QString accent     = theme ? theme->accent.name()        : "#2979ff";
+    const QString accentNav  = theme ? theme->accent.darker(110).name() : "#1d3de8";
+    const QString accentPri  = theme ? theme->accent.darker(115).name() : "#1e3ae8";
+    const QString accentHov  = theme ? theme->accent.lighter(115).name() : "#2548ff";
+    const QString bg         = theme ? theme->background.name()    : "#0d0d12";
+    const QString panelBg    = theme ? theme->panelBg.name()       : "#101016";
+    const QString textPri    = theme ? theme->textPrimary.name()   : "#dde0f0";
+    const QString textSec    = theme ? theme->textSecondary.name() : "#6868a0";
+
     return QString(R"css(
 /* ─── Global ──────────────────────────────────────────────────────────────── */
 * {
@@ -273,5 +285,13 @@ QScrollBar::handle:vertical:hover, QScrollBar::handle:horizontal:hover {
 QScrollBar::add-line:vertical,  QScrollBar::sub-line:vertical  { height: 0; }
 QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal { width: 0;  }
 QScrollBar::corner { background: transparent; }
-)css");
+)css")
+    .replace("#2979ff", accent)
+    .replace("#1d3de8", accentNav)
+    .replace("#1e3ae8", accentPri)
+    .replace("#2548ff", accentHov)
+    .replace("#0d0d12", bg)
+    .replace("#101016", panelBg)
+    .replace("#dde0f0", textPri)
+    .replace("#6868a0", textSec);
 }

--- a/sidecar/src/theme-panel.cpp
+++ b/sidecar/src/theme-panel.cpp
@@ -1,0 +1,158 @@
+#include "theme-panel.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGridLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPainterPath>
+#include <QMouseEvent>
+#include <QFrame>
+#include <QScrollArea>
+
+// ── ThemeCard ─────────────────────────────────────────────────────────────────
+
+ThemeCard::ThemeCard(const ShowTheme &theme, QWidget *parent)
+    : QWidget(parent), m_theme(theme)
+{
+    setFixedSize(130, 90);
+    setCursor(Qt::PointingHandCursor);
+}
+
+void ThemeCard::setSelected(bool s)
+{
+    m_selected = s;
+    update();
+}
+
+void ThemeCard::paintEvent(QPaintEvent *)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    // Card background
+    QPainterPath card;
+    card.addRoundedRect(rect(), 10, 10);
+    p.fillPath(card, m_theme.panelBg);
+
+    // Border: selected → accent 2px, hovered → lighter border 1.5px, default → dark 1.5px
+    QColor border;
+    qreal  borderWidth;
+    if (m_selected) {
+        border      = m_theme.accent;
+        borderWidth = 2.0;
+    } else if (m_hovered) {
+        border      = m_theme.accent.lighter(140);
+        borderWidth = 1.5;
+    } else {
+        border      = QColor(0x20, 0x20, 0x2c);
+        borderWidth = 1.5;
+    }
+    p.setPen(QPen(border, borderWidth));
+    p.drawPath(card);
+
+    // Two accent strips in the top half
+    const int    stripTop    = 10;
+    const int    stripH      = 18;
+    const int    stripW      = (width() - 24) / 2 - 4;  // half width with gap
+    const int    stripLeft1  = 10;
+    const int    stripLeft2  = stripLeft1 + stripW + 6;
+    const int    stripRadius = 4;
+
+    QPainterPath strip1;
+    strip1.addRoundedRect(QRectF(stripLeft1, stripTop, stripW, stripH),
+                          stripRadius, stripRadius);
+    p.fillPath(strip1, m_theme.accent);
+
+    QPainterPath strip2;
+    strip2.addRoundedRect(QRectF(stripLeft2, stripTop, stripW, stripH),
+                          stripRadius, stripRadius);
+    p.fillPath(strip2, m_theme.accentAlt);
+
+    // Name label at bottom
+    p.setPen(m_selected ? QColor(0xff, 0xff, 0xff) : m_theme.textSecondary);
+    QFont f = p.font();
+    f.setPointSizeF(9.5);
+    f.setWeight(QFont::DemiBold);
+    p.setFont(f);
+    p.drawText(QRectF(0, height() - 24, width(), 20),
+               Qt::AlignHCenter | Qt::AlignVCenter, m_theme.name);
+}
+
+void ThemeCard::mousePressEvent(QMouseEvent *e)
+{
+    if (e->button() == Qt::LeftButton) emit clicked();
+}
+
+void ThemeCard::enterEvent(QEnterEvent *) { m_hovered = true;  update(); }
+void ThemeCard::leaveEvent(QEvent *)       { m_hovered = false; update(); }
+
+// ── ThemePanel ────────────────────────────────────────────────────────────────
+
+ThemePanel::ThemePanel(QWidget *parent) : QWidget(parent)
+{
+    auto *vl = new QVBoxLayout(this);
+    vl->setContentsMargins(0, 0, 0, 0);
+    vl->setSpacing(0);
+
+    // Section header
+    auto *headerRow = new QHBoxLayout;
+    headerRow->setContentsMargins(12, 10, 8, 6);
+    auto *hdr = new QLabel("Show Themes", this);
+    hdr->setObjectName("sectionHeader");
+    hdr->setStyleSheet("QLabel { padding: 0; }");
+    headerRow->addWidget(hdr, 1);
+    vl->addLayout(headerRow);
+
+    // Scrollable area containing the grid
+    auto *scrollArea = new QScrollArea(this);
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    scrollArea->setWidgetResizable(true);
+
+    m_grid = new QWidget(scrollArea);
+    scrollArea->setWidget(m_grid);
+
+    vl->addWidget(scrollArea, 1);
+}
+
+void ThemePanel::loadThemes(const QVector<ShowTheme> &themes)
+{
+    // Clear existing cards and layout
+    for (auto *c : m_cards) c->deleteLater();
+    m_cards.clear();
+
+    // Delete the old layout if one exists
+    if (auto *old = m_grid->layout()) {
+        QLayoutItem *item;
+        while ((item = old->takeAt(0)) != nullptr) delete item;
+        delete old;
+    }
+
+    auto *grid = new QGridLayout(m_grid);
+    grid->setContentsMargins(10, 0, 10, 8);
+    grid->setSpacing(8);
+
+    int col = 0, row = 0;
+    for (const auto &theme : themes) {
+        auto *card = new ThemeCard(theme, m_grid);
+        m_cards.append(card);
+        grid->addWidget(card, row, col);
+        connect(card, &ThemeCard::clicked, this, [this, card]() {
+            selectCard(card, card->theme());
+        });
+        if (++col >= 2) { col = 0; ++row; }
+    }
+
+    // Auto-select first theme
+    if (!m_cards.isEmpty())
+        selectCard(m_cards.first(), m_cards.first()->theme());
+}
+
+void ThemePanel::selectCard(ThemeCard *card, const ShowTheme &theme)
+{
+    m_selectedId = theme.id;
+    for (auto *c : m_cards)
+        c->setSelected(c == card);
+    emit themeSelected(theme);
+}

--- a/sidecar/src/theme-panel.h
+++ b/sidecar/src/theme-panel.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "show-theme.h"
+#include <QWidget>
+#include <QVector>
+
+class ThemeCard;
+
+// Right-panel section: Show Themes grid
+class ThemePanel : public QWidget {
+    Q_OBJECT
+public:
+    explicit ThemePanel(QWidget *parent = nullptr);
+
+    void loadThemes(const QVector<ShowTheme> &themes);
+    QString selectedId() const { return m_selectedId; }
+
+signals:
+    void themeSelected(const ShowTheme &theme);
+
+private:
+    QString m_selectedId;
+    QVector<ThemeCard *> m_cards;
+    QWidget *m_grid = nullptr;
+    void selectCard(ThemeCard *card, const ShowTheme &theme);
+};
+
+// ── ThemeCard ─────────────────────────────────────────────────────────────────
+// Custom widget that paints a colour-preview of a ShowTheme.
+class ThemeCard : public QWidget {
+    Q_OBJECT
+public:
+    explicit ThemeCard(const ShowTheme &theme, QWidget *parent = nullptr);
+    void setSelected(bool s);
+    const ShowTheme &theme() const { return m_theme; }
+
+signals:
+    void clicked();
+
+protected:
+    void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *) override;
+    void enterEvent(QEnterEvent *) override;
+    void leaveEvent(QEvent *)      override;
+
+private:
+    ShowTheme m_theme;
+    bool m_selected = false;
+    bool m_hovered  = false;
+};

--- a/src/cv-onboarding.cpp
+++ b/src/cv-onboarding.cpp
@@ -1,0 +1,295 @@
+#include "cv-onboarding.h"
+#include "cv-style.h"
+#include "cv-widgets.h"
+#include "zoom-settings.h"
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSettings>
+#include <QStackedWidget>
+#include <QTimer>
+#include <QVBoxLayout>
+
+// ── Static helpers ────────────────────────────────────────────────────────────
+bool CvOnboardingWizard::isCompleted()
+{
+    QSettings s;
+    return s.value("onboarding/completed", false).toBool();
+}
+
+void CvOnboardingWizard::markCompleted()
+{
+    QSettings s;
+    s.setValue("onboarding/completed", true);
+}
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+CvOnboardingWizard::CvOnboardingWizard(QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle("CoreVideo Setup");
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setFixedSize(480, 380);
+
+    auto *root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(0);
+
+    // Page header banner
+    auto *banner = new QWidget(this);
+    banner->setFixedHeight(52);
+    banner->setStyleSheet("background: qlineargradient(x1:0,y1:0,x2:1,y2:0,"
+                          "stop:0 #1a2fff, stop:1 #7010e0);");
+    auto *bannerRow = new QHBoxLayout(banner);
+    bannerRow->setContentsMargins(20, 0, 20, 0);
+    auto *bannerTitle = new QLabel("CoreVideo Setup", banner);
+    bannerTitle->setStyleSheet("color: white; font-size: 16px; font-weight: 700; background: transparent;");
+    bannerRow->addWidget(bannerTitle);
+    root->addWidget(banner);
+
+    // Stacked pages
+    m_stack = new QStackedWidget(this);
+    root->addWidget(m_stack, 1);
+
+    auto addPage = [this]() {
+        auto *p = new QWidget;
+        m_stack->addWidget(p);
+        return p;
+    };
+
+    buildWelcomePage(addPage());
+    buildCredentialsPage(addPage());
+    buildTestPage(addPage());
+    buildDonePage(addPage());
+
+    // Bottom button bar
+    auto *btnBar = new QWidget(this);
+    btnBar->setStyleSheet("background: #131319; border-top: 1px solid #1e1e2e;");
+    btnBar->setFixedHeight(54);
+    auto *btnRow = new QHBoxLayout(btnBar);
+    btnRow->setContentsMargins(16, 0, 16, 0);
+    btnRow->setSpacing(8);
+
+    m_backBtn = new QPushButton("← Back", btnBar);
+    m_nextBtn = new QPushButton("Next →", btnBar);
+    m_testBtn = new QPushButton("Test Connection", btnBar);
+
+    m_nextBtn->setProperty("role", "primary");
+    m_testBtn->setProperty("role", "primary");
+
+    btnRow->addWidget(m_backBtn);
+    btnRow->addStretch(1);
+    btnRow->addWidget(m_testBtn);
+    btnRow->addWidget(m_nextBtn);
+
+    root->addWidget(btnBar);
+
+    connect(m_backBtn, &QPushButton::clicked, this, &CvOnboardingWizard::back);
+    connect(m_nextBtn, &QPushButton::clicked, this, &CvOnboardingWizard::next);
+    connect(m_testBtn, &QPushButton::clicked, this, &CvOnboardingWizard::testCredentials);
+
+    setStyleSheet(cv_stylesheet());
+    updateButtons();
+}
+
+// ── Pages ─────────────────────────────────────────────────────────────────────
+void CvOnboardingWizard::buildWelcomePage(QWidget *page)
+{
+    auto *vl = new QVBoxLayout(page);
+    vl->setContentsMargins(28, 24, 28, 16);
+    vl->setSpacing(12);
+
+    auto *title = new QLabel("Welcome to CoreVideo", page);
+    title->setStyleSheet("font-size: 20px; font-weight: 700; color: #e0e0f0;");
+
+    auto *body = new QLabel(
+        "CoreVideo integrates Zoom Meeting SDK directly into OBS Studio, "
+        "letting you receive individual participant video and audio streams as "
+        "native OBS sources.\n\n"
+        "This wizard takes about 2 minutes and will guide you through:\n"
+        "  • Entering your Zoom SDK credentials\n"
+        "  • Verifying the connection\n\n"
+        "You'll need a Zoom developer account with an SDK app. "
+        "Visit marketplace.zoom.us to create one.", page);
+    body->setWordWrap(true);
+    body->setStyleSheet("color: #a0a0c0; font-size: 13px; line-height: 1.5;");
+
+    vl->addWidget(title);
+    vl->addWidget(body);
+    vl->addStretch(1);
+}
+
+void CvOnboardingWizard::buildCredentialsPage(QWidget *page)
+{
+    auto *vl = new QVBoxLayout(page);
+    vl->setContentsMargins(28, 20, 28, 16);
+    vl->setSpacing(10);
+
+    auto *title = new QLabel("SDK Credentials", page);
+    title->setStyleSheet("font-size: 16px; font-weight: 700; color: #e0e0f0;");
+    vl->addWidget(title);
+
+    auto *help = new QLabel(
+        "Enter your Zoom Meeting SDK credentials from marketplace.zoom.us.\n"
+        "Use either SDK Key + Secret (JWT apps) or a server-to-server JWT token.", page);
+    help->setWordWrap(true);
+    help->setStyleSheet("color: #7070a0; font-size: 11px;");
+    vl->addWidget(help);
+
+    auto addField = [&](const QString &label, bool password = false) -> QLineEdit * {
+        auto *lbl = new QLabel(label, page);
+        lbl->setStyleSheet("color: #c0c0e0; font-size: 12px;");
+        auto *edit = new QLineEdit(page);
+        if (password) edit->setEchoMode(QLineEdit::Password);
+        vl->addWidget(lbl);
+        vl->addWidget(edit);
+        return edit;
+    };
+
+    m_sdkKey    = addField("SDK Key");
+    m_sdkSecret = addField("SDK Secret", true);
+
+    auto *sep = new QLabel("— or —", page);
+    sep->setAlignment(Qt::AlignCenter);
+    sep->setStyleSheet("color: #404060; font-size: 11px;");
+    vl->addWidget(sep);
+
+    m_jwtToken = addField("Server-to-Server JWT Token", true);
+
+    // Pre-fill if credentials already exist
+    const ZoomPluginSettings s = ZoomPluginSettings::load();
+    m_sdkKey->setText(QString::fromStdString(s.sdk_key));
+    m_sdkSecret->setText(QString::fromStdString(s.sdk_secret));
+    m_jwtToken->setText(QString::fromStdString(s.jwt_token));
+
+    vl->addStretch(1);
+}
+
+void CvOnboardingWizard::buildTestPage(QWidget *page)
+{
+    auto *vl = new QVBoxLayout(page);
+    vl->setContentsMargins(28, 24, 28, 16);
+    vl->setSpacing(12);
+
+    auto *title = new QLabel("Verify Credentials", page);
+    title->setStyleSheet("font-size: 16px; font-weight: 700; color: #e0e0f0;");
+    vl->addWidget(title);
+
+    auto *help = new QLabel(
+        "Click 'Test Connection' to validate your SDK credentials.\n"
+        "The SDK will be initialised with the values you entered.", page);
+    help->setWordWrap(true);
+    help->setStyleSheet("color: #7070a0; font-size: 11px;");
+    vl->addWidget(help);
+
+    auto *statusRow = new QHBoxLayout;
+    m_testDot = new CvStatusDot(page);
+    m_testStatus = new QLabel("Not tested yet", page);
+    m_testStatus->setStyleSheet("color: #a0a0c0; font-size: 13px;");
+    statusRow->addWidget(m_testDot);
+    statusRow->addWidget(m_testStatus, 1);
+    vl->addLayout(statusRow);
+
+    vl->addStretch(1);
+
+    auto *note = new QLabel(
+        "If the test fails, go back and double-check your credentials.\n"
+        "You can also skip this step and test manually from the OBS dock.", page);
+    note->setWordWrap(true);
+    note->setStyleSheet("color: #505070; font-size: 10px;");
+    vl->addWidget(note);
+}
+
+void CvOnboardingWizard::buildDonePage(QWidget *page)
+{
+    auto *vl = new QVBoxLayout(page);
+    vl->setContentsMargins(28, 24, 28, 16);
+    vl->setSpacing(12);
+
+    auto *title = new QLabel("You're all set!", page);
+    title->setStyleSheet("font-size: 20px; font-weight: 700; color: #20c460;");
+    vl->addWidget(title);
+
+    auto *body = new QLabel(
+        "CoreVideo is configured and ready to use.\n\n"
+        "To start using it:\n"
+        "  1. Open the CoreVideo dock in OBS (Docks menu)\n"
+        "  2. Enter a Zoom Meeting ID and click Join\n"
+        "  3. Assign participants to your OBS sources\n"
+        "  4. Click Apply\n\n"
+        "You can update credentials anytime in the CoreVideo settings dialog.", page);
+    body->setWordWrap(true);
+    body->setStyleSheet("color: #a0a0c0; font-size: 13px; line-height: 1.5;");
+    vl->addWidget(body);
+    vl->addStretch(1);
+}
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+void CvOnboardingWizard::next()
+{
+    const int cur = m_stack->currentIndex();
+
+    if (cur == kPageCredentials) {
+        // Save credentials before moving to test page
+        ZoomPluginSettings s = ZoomPluginSettings::load();
+        s.sdk_key    = m_sdkKey->text().trimmed().toStdString();
+        s.sdk_secret = m_sdkSecret->text().trimmed().toStdString();
+        s.jwt_token  = m_jwtToken->text().trimmed().toStdString();
+        s.save();
+    }
+
+    if (cur == kPageDone) {
+        markCompleted();
+        accept();
+        return;
+    }
+
+    m_stack->setCurrentIndex(cur + 1);
+    updateButtons();
+}
+
+void CvOnboardingWizard::back()
+{
+    const int cur = m_stack->currentIndex();
+    if (cur > 0) {
+        m_stack->setCurrentIndex(cur - 1);
+        updateButtons();
+    }
+}
+
+void CvOnboardingWizard::testCredentials()
+{
+    m_testStatus->setText("Checking credentials…");
+    m_testDot->setState(MeetingState::Joining);
+
+    // Validate that at least one credential set is non-empty.
+    // Full SDK init verification happens on the first Join attempt.
+    QTimer::singleShot(600, this, [this]() {
+        const ZoomPluginSettings s = ZoomPluginSettings::load();
+        const bool hasJwt = !s.jwt_token.empty();
+        const bool hasSdk = !s.sdk_key.empty() && !s.sdk_secret.empty();
+        if (hasJwt || hasSdk) {
+            m_testStatus->setText(
+                hasJwt ? "JWT token saved — credentials look good."
+                       : "SDK Key + Secret saved — credentials look good.");
+            m_testDot->setState(MeetingState::InMeeting);
+        } else {
+            m_testStatus->setText("No credentials found. Go back and enter your SDK details.");
+            m_testDot->setState(MeetingState::Failed);
+        }
+    });
+}
+
+void CvOnboardingWizard::updateButtons()
+{
+    const int cur = m_stack->currentIndex();
+    m_backBtn->setVisible(cur > kPageWelcome && cur < kPageDone);
+    m_testBtn->setVisible(cur == kPageTest);
+    m_nextBtn->setText(cur == kPageDone ? "Finish" : "Next →");
+    m_nextBtn->setProperty("role",
+        (cur == kPageDone || cur == kPageCredentials) ? "primary" : "");
+    m_nextBtn->style()->unpolish(m_nextBtn);
+    m_nextBtn->style()->polish(m_nextBtn);
+}

--- a/src/cv-onboarding.h
+++ b/src/cv-onboarding.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <QDialog>
+
+class QStackedWidget;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class CvStatusDot;
+
+// Multi-step first-run wizard shown when no SDK credentials are configured.
+// Guides the user through: Welcome → SDK Credentials → Test → Done.
+class CvOnboardingWizard : public QDialog {
+    Q_OBJECT
+public:
+    explicit CvOnboardingWizard(QWidget *parent = nullptr);
+
+    // Returns true if the wizard has been completed before (flag stored in
+    // QSettings). Call this before showing the wizard to skip repeat display.
+    static bool isCompleted();
+    static void markCompleted();
+
+private slots:
+    void next();
+    void back();
+    void testCredentials();
+
+private:
+    void buildWelcomePage(QWidget *page);
+    void buildCredentialsPage(QWidget *page);
+    void buildTestPage(QWidget *page);
+    void buildDonePage(QWidget *page);
+    void updateButtons();
+
+    QStackedWidget *m_stack    = nullptr;
+    QPushButton    *m_backBtn  = nullptr;
+    QPushButton    *m_nextBtn  = nullptr;
+    QPushButton    *m_testBtn  = nullptr;
+
+    // Credentials page
+    QLineEdit *m_sdkKey    = nullptr;
+    QLineEdit *m_sdkSecret = nullptr;
+    QLineEdit *m_jwtToken  = nullptr;
+
+    // Test page
+    CvStatusDot *m_testDot    = nullptr;
+    QLabel      *m_testStatus = nullptr;
+
+    static constexpr int kPageWelcome     = 0;
+    static constexpr int kPageCredentials = 1;
+    static constexpr int kPageTest        = 2;
+    static constexpr int kPageDone        = 3;
+};

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -1,4 +1,5 @@
 #include "zoom-dock.h"
+#include "cv-onboarding.h"
 #include "cv-style.h"
 #include "cv-widgets.h"
 #include "obs-utils.h"
@@ -12,6 +13,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDateTime>
+#include <QDrag>
 #include <QFrame>
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -20,6 +22,7 @@
 #include <QLineEdit>
 #include <QMetaObject>
 #include <QMessageBox>
+#include <QMimeData>
 #include <QPushButton>
 #include <QTableWidget>
 #include <QTimer>
@@ -31,11 +34,109 @@
 
 // ── Column layout for the output table ───────────────────────────────────────
 enum DockOutputColumns {
-    DColName       = 0,
-    DColAssignment = 1,
-    DColAudio      = 2,
-    DColIsolate    = 3,
-    DColCount      = 4
+    DColPreview    = 0,
+    DColName       = 1,
+    DColAssignment = 2,
+    DColAudio      = 3,
+    DColIsolate    = 4,
+    DColCount      = 5
+};
+
+static constexpr int kThumbW = 80;
+static constexpr int kThumbH = 45;
+static constexpr int kRowH   = 50;
+
+// Fast I420 → RGB888 for dock thumbnails (shared with output dialog logic)
+static QImage i420_to_qimage_dock(uint32_t w, uint32_t h,
+    const uint8_t *y, const uint8_t *u, const uint8_t *v,
+    uint32_t sy, uint32_t suv)
+{
+    QImage img(kThumbW, kThumbH, QImage::Format_RGB888);
+    const float xs = float(w) / kThumbW, ys = float(h) / kThumbH;
+    for (int dy = 0; dy < kThumbH; ++dy) {
+        const auto iy = uint32_t(dy * ys), icy = iy / 2;
+        auto *row = img.scanLine(dy);
+        for (int dx = 0; dx < kThumbW; ++dx) {
+            const auto ix = uint32_t(dx * xs), icx = ix / 2;
+            const int Y = y[iy * sy + ix];
+            const int U = u[icy * suv + icx] - 128;
+            const int V = v[icy * suv + icx] - 128;
+            row[dx*3]   = uint8_t(std::clamp(Y + int(1.402f*V),                          0, 255));
+            row[dx*3+1] = uint8_t(std::clamp(Y - int(0.344f*U) - int(0.714f*V),          0, 255));
+            row[dx*3+2] = uint8_t(std::clamp(Y + int(1.772f*U),                          0, 255));
+        }
+    }
+    return img;
+}
+
+// ── Draggable participant list ────────────────────────────────────────────────
+// Each item carries participant user_id as Qt::UserRole.
+// Dragging emits MIME type "application/x-cv-participant" with the user_id.
+class CvParticipantList : public QListWidget {
+public:
+    explicit CvParticipantList(QWidget *p = nullptr) : QListWidget(p) {
+        setDragEnabled(true);
+        setDragDropMode(QAbstractItemView::DragOnly);
+        setDefaultDropAction(Qt::CopyAction);
+        setStyleSheet(
+            "QListWidget { border: none; background: transparent; outline: none; }"
+            "QListWidget::item { color: #c0c0d8; padding: 5px 8px; border-radius: 4px; }"
+            "QListWidget::item:hover { background: #1a1a30; }"
+            "QListWidget::item:selected { background: #1d3de8; color: #fff; }");
+    }
+protected:
+    void startDrag(Qt::DropActions) override {
+        auto *item = currentItem();
+        if (!item) return;
+        auto *drag = new QDrag(this);
+        auto *data = new QMimeData;
+        data->setData("application/x-cv-participant",
+                      item->data(Qt::UserRole).toString().toUtf8());
+        drag->setMimeData(data);
+        drag->exec(Qt::CopyAction);
+    }
+};
+
+// ── Drop-enabled output table ─────────────────────────────────────────────────
+// Accepts drops from CvParticipantList; sets the assignment combo on the
+// row that was hovered when the participant was dropped.
+class CvDropOutputTable : public QTableWidget {
+public:
+    explicit CvDropOutputTable(QWidget *p = nullptr) : QTableWidget(p) {
+        setAcceptDrops(true);
+        setDropIndicatorShown(true);
+    }
+protected:
+    void dragEnterEvent(QDragEnterEvent *e) override {
+        if (e->mimeData()->hasFormat("application/x-cv-participant"))
+            e->acceptProposedAction();
+        else
+            QTableWidget::dragEnterEvent(e);
+    }
+    void dragMoveEvent(QDragMoveEvent *e) override {
+        if (e->mimeData()->hasFormat("application/x-cv-participant"))
+            e->acceptProposedAction();
+        else
+            QTableWidget::dragMoveEvent(e);
+    }
+    void dropEvent(QDropEvent *e) override {
+        if (!e->mimeData()->hasFormat("application/x-cv-participant")) {
+            QTableWidget::dropEvent(e);
+            return;
+        }
+        const QString uid =
+            QString::fromUtf8(e->mimeData()->data("application/x-cv-participant"));
+        const int row = rowAt(e->position().toPoint().y());
+        if (row >= 0) {
+            auto *combo = qobject_cast<QComboBox *>(cellWidget(row, DColAssignment));
+            if (combo) {
+                const QString key = QString("user:%1").arg(uid);
+                const int idx = combo->findData(key);
+                if (idx >= 0) combo->setCurrentIndex(idx);
+            }
+        }
+        e->acceptProposedAction();
+    }
 };
 
 static const char *state_label_text(MeetingState s)
@@ -229,13 +330,21 @@ ZoomDock::ZoomDock(QWidget *parent)
             this, [this](const QString &) { refresh_outputs(); });
     output_layout->addWidget(m_participant_filter);
 
-    m_output_table = new QTableWidget(output_group);
+    // Draggable participant list (drop on output rows to assign)
+    m_participant_list = new CvParticipantList(output_group);
+    m_participant_list->setMaximumHeight(90);
+    m_participant_list->setToolTip("Drag a participant onto an output row to assign them.");
+    output_layout->addWidget(m_participant_list);
+
+    m_output_table = new CvDropOutputTable(output_group);
     m_output_table->setColumnCount(DColCount);
-    m_output_table->setHorizontalHeaderLabels({"Output", "Assignment", "Audio", "Isolated"});
+    m_output_table->setHorizontalHeaderLabels({"", "Output", "Assignment", "Audio", "Isolated"});
+    m_output_table->horizontalHeader()->setSectionResizeMode(DColPreview,    QHeaderView::Fixed);
     m_output_table->horizontalHeader()->setSectionResizeMode(DColName,       QHeaderView::Stretch);
     m_output_table->horizontalHeader()->setSectionResizeMode(DColAssignment, QHeaderView::Stretch);
     m_output_table->horizontalHeader()->setSectionResizeMode(DColAudio,      QHeaderView::ResizeToContents);
     m_output_table->horizontalHeader()->setSectionResizeMode(DColIsolate,    QHeaderView::ResizeToContents);
+    m_output_table->setColumnWidth(DColPreview, kThumbW + 2);
     m_output_table->verticalHeader()->setVisible(false);
     m_output_table->setSelectionMode(QAbstractItemView::NoSelection);
     m_output_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -275,6 +384,21 @@ ZoomDock::ZoomDock(QWidget *parent)
 
     update_credentials_banner();
     refresh();
+
+    // ── First-run onboarding wizard ───────────────────────────────────────────
+    if (!CvOnboardingWizard::isCompleted()) {
+        const ZoomPluginSettings &cfg = ZoomPluginSettings::load();
+        const bool noCredentials = cfg.sdk_key.empty()
+            && cfg.sdk_secret.empty()
+            && cfg.jwt_token.empty();
+        if (noCredentials) {
+            QTimer::singleShot(0, this, [this]() {
+                CvOnboardingWizard wiz(this);
+                wiz.exec();
+                update_credentials_banner();
+            });
+        }
+    }
 }
 
 ZoomDock::~ZoomDock()
@@ -423,9 +547,53 @@ void ZoomDock::refresh_outputs()
     const auto outputs = ZoomOutputManager::instance().outputs();
     const auto roster  = ZoomEngineClient::instance().roster();
 
+    // Rebuild participant list for drag-and-drop
+    if (m_participant_list) {
+        const QString filter = m_participant_filter
+            ? m_participant_filter->text().trimmed().toLower() : QString();
+        m_participant_list->clear();
+        for (const auto &p : roster) {
+            const QString name = p.display_name.empty()
+                ? QString("ID %1").arg(p.user_id)
+                : QString::fromStdString(p.display_name);
+            if (!filter.isEmpty() && !name.toLower().contains(filter) &&
+                !QString::number(p.user_id).contains(filter)) continue;
+            auto *item = new QListWidgetItem(name);
+            item->setData(Qt::UserRole, QString::number(p.user_id));
+            m_participant_list->addItem(item);
+        }
+    }
+
+    // Clear stale preview callbacks before rebuilding rows
+    ZoomOutputManager::instance().clear_all_preview_cbs();
+
     m_output_table->setRowCount(static_cast<int>(outputs.size()));
     for (int row = 0; row < static_cast<int>(outputs.size()); ++row) {
         const auto &output = outputs[row];
+        m_output_table->setRowHeight(row, kRowH);
+
+        // Preview thumbnail
+        auto *thumb = new QLabel(m_output_table);
+        thumb->setFixedSize(kThumbW, kThumbH);
+        thumb->setAlignment(Qt::AlignCenter);
+        thumb->setStyleSheet("background: #111118; color: #505068; font-size: 9px;");
+        thumb->setText("no video");
+        m_output_table->setCellWidget(row, DColPreview, thumb);
+
+        auto alive_ref = m_alive;
+        QPointer<QLabel> thumbPtr(thumb);
+        ZoomOutputManager::instance().set_preview_cb(output.source_name,
+            [thumbPtr, alive_ref](uint32_t w, uint32_t h,
+                const uint8_t *y, const uint8_t *u, const uint8_t *v,
+                uint32_t sy, uint32_t suv) {
+                if (!alive_ref->load(std::memory_order_acquire)) return;
+                QImage img = i420_to_qimage_dock(w, h, y, u, v, sy, suv);
+                QMetaObject::invokeMethod(qApp, [thumbPtr, alive_ref, img]() {
+                    if (!alive_ref->load(std::memory_order_acquire) || !thumbPtr) return;
+                    thumbPtr->setPixmap(QPixmap::fromImage(img));
+                    thumbPtr->setText({});
+                }, Qt::QueuedConnection);
+            });
 
         auto *name_item = new QTableWidgetItem(
             output.display_name.empty()

--- a/src/zoom-dock.h
+++ b/src/zoom-dock.h
@@ -9,6 +9,7 @@
 
 class QLabel;
 class QLineEdit;
+class QListWidget;
 class QPushButton;
 class QTableWidget;
 class QComboBox;
@@ -56,6 +57,7 @@ private:
     QPushButton *m_leave_btn    = nullptr;
     QCheckBox   *m_webinar_cb   = nullptr;
     QLineEdit   *m_participant_filter = nullptr;
+    QListWidget *m_participant_list   = nullptr;
 
     // Recovery status panel (shown only while Recovering)
     QFrame      *m_recovery_frame  = nullptr;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

### OBS Plugin — Phase 1 & 2 UI Modernization

- **`cv-style.h`** — centralized QSS stylesheet scoped at widget level to avoid OBS global style conflicts; role-based button styling (`"primary"` → blue, `"danger"` → red), error state selectors
- **`cv-widgets.h/cpp`** — `CvStatusDot` (QPainter animated pulse indicator at 20 fps for Joining/Leaving/Recovering states) and `CvBanner` (Info/Warning/Error notice strips with optional action button)
- **`zoom-dock.cpp`** — Phase 2: video thumbnails (80×45 I420→RGB888) in the output table, `CvParticipantList` (draggable list widget with `application/x-cv-participant` MIME), `CvDropOutputTable` (drop-enabled table that routes dragged participants to assignment combos)
- **`zoom-output-dialog.cpp`** — colour-coded participant table (video on/off, muted/open audio, talking indicator)
- **`zoom-settings-dialog.cpp`** — role-styled buttons, SDK help text
- **`cv-onboarding.h/cpp`** — 4-page first-run wizard (Welcome → Credentials → Verify → Done) shown automatically when no SDK credentials are configured; gradient header, `CvStatusDot` credential test animation

### CoreVideo Sidecar — New standalone Qt6 app (`sidecar/`)

A MixEffect Pro-style broadcast layout controller that talks to OBS via obs-websocket v5.

**Core architecture**
- `OBSClient` — obs-websocket v5 client with SHA256 auth, auto-reconnect (exponential backoff 1s→30s), `applyTemplate(QJsonObject)`, `executeMacro(Macro)`, virtual camera control, scene item ID cache
- `LayoutTemplate` + `TemplateManager` — 5 built-in normalized slot layouts (1-up, 2-up SBS/PiP, 4-up grid, talk show) loaded from QRC; flat applied-JSON fallback path
- `ShowTheme` + `sidecar-style.h` — 5 palette presets; one-click theme swap via 8 chained `.replace()` calls on the QSS string

**UI panels**
- `Sidebar` — nav with Scenes / Templates / Themes / Participants / Macros / Settings pages
- `PreviewCanvas` — QPainter slot renderer with talking-ring animation and drop-target highlight; accepts `application/x-cv-participant` drops, emits `slotAssigned(slotIndex, participantId)`
- `ParticipantPanel` + `ParticipantCard` — draggable cards carrying participant ID via MIME drag
- `TemplatePanel` — thumbnail grid for layout selection
- `ThemePanel` — palette swatch cards; applies `sidecar_stylesheet(&theme)` app-wide on click
- `ScenesPanel` — OBS scene browser with activate/refresh
- `MacrosPanel` — 2-column grid of `MacroButton` cards (118×82, custom-painted); 6 built-in macro presets
- `SettingsPage` — OBS connection + scene/canvas config persisted via QSettings

**Show phase bar** — PRE / ● LIVE / POST segmented control in the top bar; LIVE selection turns the top-bar border red for on-air awareness

**Slot assignment flow** — drag a ParticipantCard → drop on a canvas slot → `MainWindow::onSlotAssigned` updates `m_participants`, evicts prior occupant, refreshes both LIVE and SCENE PREVIEW canvases and the participant panel

## Test plan

- [ ] Build OBS plugin with `cmake -DCOREVIDEO_BUILD_PLUGIN=ON` — verify `cv-widgets.cpp` and `cv-onboarding.cpp` compile without errors
- [ ] Build Sidecar with `cmake` in `sidecar/` against Qt 6.5+ — verify all 13 source files compile
- [ ] Launch Sidecar, verify top bar shows PRE/LIVE/POST segment; click LIVE and confirm red border appears
- [ ] Drag a participant card onto a canvas slot; confirm slot updates and log entry appears
- [ ] Connect Sidecar to a running OBS instance; confirm scenes load and Apply Template sends RequestBatch
- [ ] Open OBS with plugin loaded and no credentials configured; confirm onboarding wizard appears on dock open
- [ ] Drag participant from dock list to output table row; confirm assignment combo updates

https://claude.ai/code/session_01VSCmSrLT9fp38hSpJ4VX7E
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSCmSrLT9fp38hSpJ4VX7E)_