### PR TITLE
Simplify Zoom auth UI to a single sign-in button

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,8 @@ set($($pkg.name)_FOUND TRUE)
               "-Dobs-frontend-api_DIR=$obsFe" `
               "-DZOOM_EMBED_SDK_KEY=${{ secrets.ZOOM_EMBED_SDK_KEY }}" `
               "-DZOOM_EMBED_SDK_SECRET=${{ secrets.ZOOM_EMBED_SDK_SECRET }}" `
-              "-DZOOM_EMBED_JWT_TOKEN=${{ secrets.ZOOM_EMBED_JWT_TOKEN }}"
+              "-DZOOM_EMBED_JWT_TOKEN=${{ secrets.ZOOM_EMBED_JWT_TOKEN }}" `
+              "-DZOOM_EMBED_OAUTH_CLIENT_ID=${{ secrets.ZOOM_EMBED_OAUTH_CLIENT_ID }}"
 
       - name: Build
         run: cmake --build build --config Release --parallel
@@ -256,7 +257,8 @@ set($($pkg.name)_FOUND TRUE)
               "-Dobs-frontend-api_DIR=/tmp/obs-sdk/cmake/obs-frontend-api" \
               "-DZOOM_EMBED_SDK_KEY=${{ secrets.ZOOM_EMBED_SDK_KEY }}" \
               "-DZOOM_EMBED_SDK_SECRET=${{ secrets.ZOOM_EMBED_SDK_SECRET }}" \
-              "-DZOOM_EMBED_JWT_TOKEN=${{ secrets.ZOOM_EMBED_JWT_TOKEN }}"
+              "-DZOOM_EMBED_JWT_TOKEN=${{ secrets.ZOOM_EMBED_JWT_TOKEN }}" \
+              "-DZOOM_EMBED_OAUTH_CLIENT_ID=${{ secrets.ZOOM_EMBED_OAUTH_CLIENT_ID }}"
 
       - name: Build
         run: cmake --build build --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,10 @@ option(COREVIDEO_BUILD_PLUGIN "Build the OBS plugin module" ON)
 option(COREVIDEO_BUILD_ENGINE "Build the ZoomObsEngine helper process" ON)
 
 # ── Embedded credentials (set via -D or CI secrets; empty = user must enter) ──
-set(ZOOM_EMBED_SDK_KEY    "" CACHE STRING "Pre-embedded Zoom SDK key")
-set(ZOOM_EMBED_SDK_SECRET "" CACHE STRING "Pre-embedded Zoom SDK secret")
-set(ZOOM_EMBED_JWT_TOKEN  "" CACHE STRING "Pre-embedded Zoom JWT token")
+set(ZOOM_EMBED_SDK_KEY          "" CACHE STRING "Pre-embedded Zoom SDK key")
+set(ZOOM_EMBED_SDK_SECRET       "" CACHE STRING "Pre-embedded Zoom SDK secret")
+set(ZOOM_EMBED_JWT_TOKEN        "" CACHE STRING "Pre-embedded Zoom JWT token")
+set(ZOOM_EMBED_OAUTH_CLIENT_ID  "" CACHE STRING "Pre-embedded Zoom OAuth (marketplace) client ID")
 configure_file(src/zoom-credentials.h.in
                "${CMAKE_CURRENT_BINARY_DIR}/zoom-credentials.h" @ONLY)
 configure_file(src/obs-zoom-version.h.in

--- a/src/zoom-credentials.h.in
+++ b/src/zoom-credentials.h.in
@@ -3,6 +3,7 @@
 // These are compile-time fallback credentials used when no config file entry exists.
 // Set ZOOM_EMBED_SDK_KEY / ZOOM_EMBED_SDK_SECRET / ZOOM_EMBED_JWT_TOKEN at cmake
 // configure time (e.g. via GitHub Actions secrets) to pre-configure the plugin.
-static constexpr const char *kEmbeddedSdkKey    = "@ZOOM_EMBED_SDK_KEY@";
-static constexpr const char *kEmbeddedSdkSecret = "@ZOOM_EMBED_SDK_SECRET@";
-static constexpr const char *kEmbeddedJwtToken  = "@ZOOM_EMBED_JWT_TOKEN@";
+static constexpr const char *kEmbeddedSdkKey         = "@ZOOM_EMBED_SDK_KEY@";
+static constexpr const char *kEmbeddedSdkSecret      = "@ZOOM_EMBED_SDK_SECRET@";
+static constexpr const char *kEmbeddedJwtToken       = "@ZOOM_EMBED_JWT_TOKEN@";
+static constexpr const char *kEmbeddedOAuthClientId  = "@ZOOM_EMBED_OAUTH_CLIENT_ID@";

--- a/src/zoom-settings-dialog.cpp
+++ b/src/zoom-settings-dialog.cpp
@@ -28,51 +28,6 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
 
     ZoomPluginSettings s = ZoomPluginSettings::load();
 
-    // ── Zoom SDK ──────────────────────────────────────────────────────────────
-    m_sdk_key_edit    = new QLineEdit(QString::fromStdString(s.sdk_key),    this);
-    m_sdk_secret_edit = new QLineEdit(QString::fromStdString(s.sdk_secret), this);
-    m_jwt_token_edit  = new QLineEdit(QString::fromStdString(s.jwt_token),  this);
-    m_oauth_client_id_edit = new QLineEdit(QString::fromStdString(s.oauth_client_id), this);
-    m_oauth_client_secret_edit =
-        new QLineEdit(QString::fromStdString(s.oauth_client_secret), this);
-    m_oauth_use_client_secret_cb =
-        new QCheckBox("Use Client Secret for confidential OAuth", this);
-    m_oauth_use_client_secret_cb->setChecked(s.oauth_use_client_secret);
-    m_oauth_authorization_url_edit =
-        new QLineEdit(QString::fromStdString(s.oauth_authorization_url), this);
-    m_oauth_redirect_uri_edit =
-        new QLineEdit(QString::fromStdString(s.oauth_redirect_uri), this);
-    m_oauth_scopes_edit = new QLineEdit(QString::fromStdString(s.oauth_scopes), this);
-
-    m_sdk_secret_edit->setEchoMode(QLineEdit::Password);
-    m_jwt_token_edit->setEchoMode(QLineEdit::Password);
-    m_oauth_client_secret_edit->setEchoMode(QLineEdit::Password);
-    m_oauth_client_secret_edit->setPlaceholderText(
-        "Optional; leave blank for public PKCE OAuth");
-    m_oauth_client_secret_edit->setEnabled(s.oauth_use_client_secret);
-    connect(m_oauth_use_client_secret_cb, &QCheckBox::toggled,
-            m_oauth_client_secret_edit, &QLineEdit::setEnabled);
-    m_jwt_token_edit->setPlaceholderText(
-        "Optional override; leave blank to generate from SDK key / secret");
-
-    auto *sdk_help = new QLabel(
-        "Obtain your SDK key and secret from the "
-        "<a href=\"https://marketplace.zoom.us\">Zoom Marketplace</a> "
-        "(Develop → Build App → Meeting SDK).", this);
-    sdk_help->setOpenExternalLinks(true);
-    sdk_help->setWordWrap(true);
-    sdk_help->setStyleSheet("QLabel { color: #7a8faa; font-size: 11px; }");
-
-    auto *sdk_form = new QFormLayout;
-    sdk_form->setSpacing(8);
-    sdk_form->addRow(new QLabel("SDK Key:",    this), m_sdk_key_edit);
-    sdk_form->addRow(new QLabel("SDK Secret:", this), m_sdk_secret_edit);
-    sdk_form->addRow(new QLabel("JWT Token:",  this), m_jwt_token_edit);
-    sdk_form->addRow(sdk_help);
-
-    auto *sdk_group = new QGroupBox("Zoom SDK", this);
-    sdk_group->setLayout(sdk_form);
-
     // ── Control Server ────────────────────────────────────────────────────────
     m_control_port_spin = new QSpinBox(this);
     m_control_port_spin->setRange(1024, 65535);
@@ -84,19 +39,16 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     m_control_token_edit->setEchoMode(QLineEdit::Password);
     m_control_token_edit->setPlaceholderText("Leave blank to allow unauthenticated access");
 
-    // ── OAuth / PKCE ──────────────────────────────────────────────────────────
-    m_oauth_authorize_btn = new QPushButton("Authorize with Zoom", this);
-    m_oauth_register_scheme_btn = new QPushButton("Register corevideo:// URL Scheme", this);
-    m_oauth_refresh_btn = new QPushButton("Refresh Token", this);
-    m_oauth_disconnect_btn = new QPushButton("Disconnect", this);
+    // ── Zoom Account (OAuth) ──────────────────────────────────────────────────
+    m_oauth_authorize_btn = new QPushButton("Sign in with Zoom", this);
+    m_oauth_refresh_btn = new QPushButton("Refresh", this);
+    m_oauth_disconnect_btn = new QPushButton("Sign out", this);
     m_oauth_status_label = new QLabel(this);
     m_oauth_status_label->setWordWrap(true);
     m_oauth_status_label->setStyleSheet("QLabel { color: #7a8faa; font-size: 11px; }");
     m_oauth_authorize_btn->setProperty("role", "primary");
     connect(m_oauth_authorize_btn, &QPushButton::clicked,
             this, &ZoomSettingsDialog::onAuthorizeOAuth);
-    connect(m_oauth_register_scheme_btn, &QPushButton::clicked,
-            this, &ZoomSettingsDialog::onRegisterUrlScheme);
     connect(m_oauth_refresh_btn, &QPushButton::clicked,
             this, &ZoomSettingsDialog::onRefreshOAuth);
     connect(m_oauth_disconnect_btn, &QPushButton::clicked,
@@ -108,21 +60,13 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     oauth_button_row->addWidget(m_oauth_refresh_btn);
     oauth_button_row->addWidget(m_oauth_disconnect_btn);
 
-    auto *oauth_form = new QFormLayout;
-    oauth_form->setSpacing(8);
-    oauth_form->addRow(new QLabel("Status:", this), m_oauth_status_label);
-    oauth_form->addRow(new QLabel("Client ID:",          this), m_oauth_client_id_edit);
-    oauth_form->addRow("", m_oauth_use_client_secret_cb);
-    oauth_form->addRow(new QLabel("Client Secret:",      this), m_oauth_client_secret_edit);
-    oauth_form->addRow(new QLabel("Authorization URL:",  this), m_oauth_authorization_url_edit);
-    oauth_form->addRow(new QLabel("Redirect URI:",       this), m_oauth_redirect_uri_edit);
-    oauth_form->addRow(new QLabel("Scopes:",             this), m_oauth_scopes_edit);
-    oauth_form->addRow("", m_oauth_register_scheme_btn);
-    oauth_form->addRow("", oauth_button_row);
+    auto *oauth_layout = new QVBoxLayout;
+    oauth_layout->setSpacing(8);
+    oauth_layout->addWidget(m_oauth_status_label);
+    oauth_layout->addLayout(oauth_button_row);
 
-    auto *oauth_group = new QGroupBox("Zoom OAuth (PKCE)", this);
-    oauth_group->setLayout(oauth_form);
-
+    auto *oauth_group = new QGroupBox("Zoom Account", this);
+    oauth_group->setLayout(oauth_layout);
 
     auto *ctrl_form = new QFormLayout;
     ctrl_form->setSpacing(8);
@@ -224,7 +168,6 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
 
     auto *layout = new QVBoxLayout(this);
     layout->setSpacing(8);
-    layout->addWidget(sdk_group);
     layout->addWidget(oauth_group);
     layout->addWidget(ctrl_group);
     layout->addWidget(osc_group);
@@ -240,16 +183,6 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
 void ZoomSettingsDialog::onSave()
 {
     ZoomPluginSettings s = ZoomPluginSettings::load();
-    s.sdk_key             = m_sdk_key_edit->text().toStdString();
-    s.sdk_secret          = m_sdk_secret_edit->text().toStdString();
-    s.jwt_token           = m_jwt_token_edit->text().toStdString();
-    s.oauth_client_id     = m_oauth_client_id_edit->text().toStdString();
-    s.oauth_client_secret = m_oauth_client_secret_edit->text().toStdString();
-    s.oauth_use_client_secret = m_oauth_use_client_secret_cb->isChecked();
-    s.oauth_authorization_url =
-        m_oauth_authorization_url_edit->text().toStdString();
-    s.oauth_redirect_uri  = m_oauth_redirect_uri_edit->text().toStdString();
-    s.oauth_scopes        = m_oauth_scopes_edit->text().toStdString();
     s.control_server_port = static_cast<uint16_t>(m_control_port_spin->value());
     s.osc_server_port     = static_cast<uint16_t>(m_osc_port_spin->value());
     s.control_token       = m_control_token_edit->text().toStdString();
@@ -289,40 +222,11 @@ void ZoomSettingsDialog::onSave()
 
 void ZoomSettingsDialog::onAuthorizeOAuth()
 {
-    ZoomPluginSettings s = ZoomPluginSettings::load();
-    s.oauth_client_id = m_oauth_client_id_edit->text().toStdString();
-    s.oauth_client_secret = m_oauth_client_secret_edit->text().toStdString();
-    s.oauth_use_client_secret = m_oauth_use_client_secret_cb->isChecked();
-    s.oauth_authorization_url =
-        m_oauth_authorization_url_edit->text().toStdString();
-    s.oauth_redirect_uri = m_oauth_redirect_uri_edit->text().toStdString();
-    s.oauth_scopes = m_oauth_scopes_edit->text().toStdString();
-    s.save();
     QString error;
     if (!ZoomOAuthManager::instance().begin_authorization(this, &error)) {
         QMessageBox::warning(this, "Zoom OAuth", error);
     }
     updateOAuthStatus();
-}
-
-void ZoomSettingsDialog::onRegisterUrlScheme()
-{
-    ZoomPluginSettings s = ZoomPluginSettings::load();
-    s.oauth_client_id = m_oauth_client_id_edit->text().toStdString();
-    s.oauth_client_secret = m_oauth_client_secret_edit->text().toStdString();
-    s.oauth_use_client_secret = m_oauth_use_client_secret_cb->isChecked();
-    s.oauth_authorization_url =
-        m_oauth_authorization_url_edit->text().toStdString();
-    s.oauth_redirect_uri = m_oauth_redirect_uri_edit->text().toStdString();
-    s.oauth_scopes = m_oauth_scopes_edit->text().toStdString();
-    s.save();
-    QString error;
-    if (!ZoomOAuthManager::instance().register_url_scheme(&error)) {
-        QMessageBox::warning(this, "Zoom OAuth", error);
-        return;
-    }
-    QMessageBox::information(this, "Zoom OAuth",
-        "Registered corevideo://oauth/callback for this user.");
 }
 
 void ZoomSettingsDialog::onRefreshOAuth()
@@ -346,7 +250,7 @@ void ZoomSettingsDialog::onDisconnectOAuth()
     s.save();
     updateOAuthStatus();
     QMessageBox::information(this, "Zoom OAuth",
-        "Stored Zoom OAuth tokens were cleared. Authorize again before joining as a signed-in user.");
+        "Signed out of Zoom. Sign in again before joining meetings that require signed-in user context.");
 }
 
 void ZoomSettingsDialog::updateOAuthStatus()
@@ -358,25 +262,17 @@ void ZoomSettingsDialog::updateOAuthStatus()
 
     QString status;
     if (!has_access && !has_refresh) {
-        status = "Not authorized. Use Authorize with Zoom before joining meetings that require signed-in user context.";
+        status = "Not signed in. Use Sign in with Zoom before joining meetings that require signed-in user context.";
     } else if (s.oauth_expires_at > now) {
-        status = QString("Authorized. Access token expires %1.")
+        status = QString("Signed in. Access token expires %1.")
             .arg(QLocale().toString(
                 QDateTime::fromSecsSinceEpoch(s.oauth_expires_at).toLocalTime(),
                 QLocale::ShortFormat));
     } else if (has_refresh) {
-        status = "Authorized, but the access token is expired. Refresh Token should renew it without reopening the browser.";
+        status = "Signed in, but the access token is expired. Refresh should renew it without reopening the browser.";
     } else {
-        status = "Authorization is incomplete or expired. Authorize with Zoom again.";
+        status = "Sign-in is incomplete or expired. Sign in with Zoom again.";
     }
-
-    if (m_control_port_spin && m_control_port_spin->value() != 19870) {
-        status += QString(" OAuth callbacks will use the configured control port %1 after the updated helper is installed.")
-            .arg(m_control_port_spin->value());
-    }
-    status += s.oauth_use_client_secret
-        ? " OAuth mode: confidential client."
-        : " OAuth mode: public PKCE client.";
 
     m_oauth_status_label->setText(status);
     m_oauth_refresh_btn->setEnabled(has_refresh);

--- a/src/zoom-settings-dialog.h
+++ b/src/zoom-settings-dialog.h
@@ -16,25 +16,14 @@ public:
 private slots:
     void onSave();
     void onAuthorizeOAuth();
-    void onRegisterUrlScheme();
     void onRefreshOAuth();
     void onDisconnectOAuth();
 
 private:
     void updateOAuthStatus();
 
-    QLineEdit *m_sdk_key_edit           = nullptr;
-    QLineEdit *m_sdk_secret_edit        = nullptr;
-    QLineEdit *m_jwt_token_edit         = nullptr;
-    QLineEdit *m_oauth_client_id_edit   = nullptr;
-    QLineEdit *m_oauth_client_secret_edit = nullptr;
-    QCheckBox *m_oauth_use_client_secret_cb = nullptr;
-    QLineEdit *m_oauth_authorization_url_edit = nullptr;
-    QLineEdit *m_oauth_redirect_uri_edit = nullptr;
-    QLineEdit *m_oauth_scopes_edit      = nullptr;
     QLabel *m_oauth_status_label        = nullptr;
     QPushButton *m_oauth_authorize_btn  = nullptr;
-    QPushButton *m_oauth_register_scheme_btn = nullptr;
     QPushButton *m_oauth_refresh_btn    = nullptr;
     QPushButton *m_oauth_disconnect_btn = nullptr;
     QSpinBox  *m_control_port_spin      = nullptr;

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -95,7 +95,9 @@ ZoomPluginSettings ZoomPluginSettings::load()
     s.sdk_key    = (key    && *key)    ? key    : kEmbeddedSdkKey;
     s.sdk_secret = (secret && *secret) ? secret : kEmbeddedSdkSecret;
     s.jwt_token  = (jwt    && *jwt)    ? jwt    : kEmbeddedJwtToken;
-    s.oauth_client_id = oauth_client_id ? oauth_client_id : "";
+    s.oauth_client_id = (oauth_client_id && *oauth_client_id)
+        ? oauth_client_id
+        : kEmbeddedOAuthClientId;
     s.oauth_client_secret = unprotect_secret(oauth_client_secret);
     s.oauth_use_client_secret = oauth_use_client_secret != 0;
     s.oauth_authorization_url = oauth_authorization_url ? oauth_authorization_url : "";


### PR DESCRIPTION
## Summary
- Collapse the Zoom Plugin Settings panel's auth section to status text + **Sign in / Refresh / Sign out** buttons. SDK Key/Secret/JWT group, OAuth URL/redirect/scopes/secret/checkbox, and the manual "Register URL Scheme" button are all removed.
- Bake the marketplace OAuth Client ID into builds via a new `ZOOM_EMBED_OAUTH_CLIENT_ID` CMake var (plumbed through `zoom-credentials.h.in` and the loader fallback). SDK key/secret/JWT already used the same embed-at-build pattern.
- Wire `ZOOM_EMBED_OAUTH_CLIENT_ID` through Windows + macOS CI configure steps.

End users now see one button to sign in; nothing to paste.

## Test plan
- [ ] CI builds (Windows + macOS) succeed on this branch with the new secret set.
- [ ] Download artifact and confirm Zoom Plugin Settings dialog shows only the OAuth status + 3 buttons (no SDK Key/Secret/JWT group, no Client ID/Secret/URL/Scopes fields).
- [ ] Click **Sign in with Zoom** on a fresh install: corevideo:// scheme auto-registers, browser opens Zoom authorization, callback returns and status flips to "Signed in".
- [ ] **Refresh** renews token; **Sign out** clears it and disables both buttons.
- [ ] Existing installs with previously-saved settings still load (on-disk schema unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_012hPN2dhDbunYuQ3zxDHxbs)_