### PR TITLE
feat(sidecar): plugin-launch handshake, click-to-assign, command palette

### DIFF
--- a/sidecar/CMakeLists.txt
+++ b/sidecar/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     src/obs-client.cpp
     src/obs-connect-dialog.cpp
     src/sidecar-control-server.cpp
+    src/command-palette.cpp
 )
 
 set(RESOURCES sidecar.qrc)

--- a/sidecar/src/command-palette.cpp
+++ b/sidecar/src/command-palette.cpp
@@ -1,0 +1,140 @@
+#include "command-palette.h"
+#include <QVBoxLayout>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QKeyEvent>
+#include <QGuiApplication>
+#include <QScreen>
+
+CommandPalette::CommandPalette(QWidget *parent)
+    : QDialog(parent, Qt::Popup | Qt::FramelessWindowHint)
+{
+    setObjectName("commandPalette");
+    setModal(true);
+    setMinimumSize(560, 360);
+
+    setStyleSheet(
+        "#commandPalette { background: #14141c; border: 1px solid #2a2a3e; "
+        "border-radius: 10px; }"
+        "QLineEdit#cpSearch { background: #0e0e16; color: #e0e0f0; "
+        "border: 1px solid #232336; border-radius: 6px; padding: 8px 10px; "
+        "font-size: 14px; }"
+        "QListWidget#cpList { background: transparent; color: #d0d0e0; "
+        "border: none; outline: none; font-size: 13px; }"
+        "QListWidget#cpList::item { padding: 8px 10px; border-radius: 4px; }"
+        "QListWidget#cpList::item:selected { background: #2979ff; color: white; }");
+
+    auto *vl = new QVBoxLayout(this);
+    vl->setContentsMargins(10, 10, 10, 10);
+    vl->setSpacing(8);
+
+    m_search = new QLineEdit(this);
+    m_search->setObjectName("cpSearch");
+    m_search->setPlaceholderText("Type a command, scene, template, macro…");
+    m_search->installEventFilter(this);
+    vl->addWidget(m_search);
+
+    m_list = new QListWidget(this);
+    m_list->setObjectName("cpList");
+    m_list->setUniformItemSizes(true);
+    vl->addWidget(m_list, 1);
+
+    connect(m_search, &QLineEdit::textChanged,
+            this, &CommandPalette::onFilterChanged);
+    connect(m_search, &QLineEdit::returnPressed, this, [this]() {
+        if (auto *it = m_list->currentItem()) onItemActivated(it);
+    });
+    connect(m_list, &QListWidget::itemActivated,
+            this, &CommandPalette::onItemActivated);
+    connect(m_list, &QListWidget::itemClicked,
+            this, &CommandPalette::onItemActivated);
+}
+
+void CommandPalette::clearCommands()
+{
+    m_entries.clear();
+    m_list->clear();
+}
+
+void CommandPalette::addCommand(const QString &title,
+                                const QString &category,
+                                Action action)
+{
+    m_entries.append({title, category, std::move(action)});
+}
+
+void CommandPalette::run()
+{
+    m_search->clear();
+    refilter();
+
+    // Center over parent (or screen if orphaned)
+    QWidget *anchor = parentWidget();
+    QRect ref = anchor ? anchor->geometry()
+                       : QGuiApplication::primaryScreen()->availableGeometry();
+    if (anchor && anchor->window() != anchor)
+        ref = anchor->window()->geometry();
+    move(ref.center() - QPoint(width() / 2, height() / 2));
+
+    m_search->setFocus();
+    exec();
+}
+
+bool CommandPalette::eventFilter(QObject *o, QEvent *e)
+{
+    if (o == m_search && e->type() == QEvent::KeyPress) {
+        auto *ke = static_cast<QKeyEvent *>(e);
+        if (ke->key() == Qt::Key_Down || ke->key() == Qt::Key_Up) {
+            const int row = m_list->currentRow();
+            const int count = m_list->count();
+            if (count == 0) return true;
+            int next = row + (ke->key() == Qt::Key_Down ? 1 : -1);
+            if (next < 0) next = count - 1;
+            if (next >= count) next = 0;
+            m_list->setCurrentRow(next);
+            return true;
+        }
+        if (ke->key() == Qt::Key_Escape) { reject(); return true; }
+    }
+    return QDialog::eventFilter(o, e);
+}
+
+void CommandPalette::onFilterChanged(const QString &)
+{
+    refilter();
+}
+
+void CommandPalette::refilter()
+{
+    const QString needle = m_search->text().trimmed().toLower();
+    m_list->clear();
+    for (int i = 0; i < m_entries.size(); ++i) {
+        const auto &e = m_entries[i];
+        if (!needle.isEmpty()
+            && !e.title.toLower().contains(needle)
+            && !e.category.toLower().contains(needle)) {
+            continue;
+        }
+        auto *it = new QListWidgetItem(
+            e.category.isEmpty() ? e.title
+                                 : QString("%1   ·   %2").arg(e.title, e.category),
+            m_list);
+        it->setData(Qt::UserRole, i);
+    }
+    selectFirst();
+}
+
+void CommandPalette::selectFirst()
+{
+    if (m_list->count() > 0) m_list->setCurrentRow(0);
+}
+
+void CommandPalette::onItemActivated(QListWidgetItem *item)
+{
+    if (!item) return;
+    const int idx = item->data(Qt::UserRole).toInt();
+    if (idx < 0 || idx >= m_entries.size()) return;
+    Action act = m_entries[idx].action;
+    accept();
+    if (act) act();
+}

--- a/sidecar/src/command-palette.h
+++ b/sidecar/src/command-palette.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <QDialog>
+#include <QString>
+#include <QVector>
+#include <functional>
+
+class QLineEdit;
+class QListWidget;
+class QListWidgetItem;
+
+// Spotlight-style command palette. Owner clears + repopulates commands each
+// time before showing it via populate()/addCommand()/run().
+class CommandPalette : public QDialog {
+    Q_OBJECT
+public:
+    using Action = std::function<void()>;
+
+    explicit CommandPalette(QWidget *parent = nullptr);
+
+    void clearCommands();
+    void addCommand(const QString &title,
+                    const QString &category,
+                    Action          action);
+
+    // Show centered over the parent and focus the search field.
+    void run();
+
+protected:
+    bool eventFilter(QObject *o, QEvent *e) override;
+
+private slots:
+    void onFilterChanged(const QString &text);
+    void onItemActivated(QListWidgetItem *item);
+
+private:
+    struct Entry { QString title; QString category; Action action; };
+    QVector<Entry> m_entries;
+
+    QLineEdit   *m_search = nullptr;
+    QListWidget *m_list   = nullptr;
+
+    void refilter();
+    void selectFirst();
+};

--- a/sidecar/src/layout-template.cpp
+++ b/sidecar/src/layout-template.cpp
@@ -20,7 +20,7 @@ LayoutTemplate LayoutTemplate::fromJson(const QJsonObject &obj)
         slot.height  = s["height"].toDouble(1.0);
         slot.label   = s["label"].toString();
         slot.isMain  = s["isMain"].toBool(false);
-        t.slots.append(slot);
+        t.slotList.append(slot);
     }
     return t;
 }
@@ -28,7 +28,7 @@ LayoutTemplate LayoutTemplate::fromJson(const QJsonObject &obj)
 QJsonObject LayoutTemplate::toJson() const
 {
     QJsonArray slotArr;
-    for (const auto &s : slots) {
+    for (const auto &s : slotList) {
         slotArr.append(QJsonObject{
             {"index",  s.index},
             {"x",      s.x},

--- a/sidecar/src/layout-template.h
+++ b/sidecar/src/layout-template.h
@@ -19,9 +19,9 @@ struct LayoutTemplate {
     QString              description;
     int                  columns = 1;
     int                  rows    = 1;
-    QVector<TemplateSlot> slots;
+    QVector<TemplateSlot> slotList;
 
-    bool isValid() const { return !id.isEmpty() && !slots.isEmpty(); }
+    bool isValid() const { return !id.isEmpty() && !slotList.isEmpty(); }
 
     static LayoutTemplate fromJson(const QJsonObject &obj);
     QJsonObject toJson() const;

--- a/sidecar/src/main.cpp
+++ b/sidecar/src/main.cpp
@@ -2,6 +2,7 @@
 #include "sidecar-style.h"
 #include "show-theme.h"
 #include <QApplication>
+#include <QCommandLineParser>
 #include <QStyleFactory>
 
 int main(int argc, char *argv[])
@@ -16,7 +17,41 @@ int main(int argc, char *argv[])
     const auto builtins = ShowTheme::builtIns();
     app.setStyleSheet(sidecar_stylesheet(&builtins.first())); // Midnight Blue default
 
-    MainWindow w;
+    QCommandLineParser parser;
+    parser.setApplicationDescription("CoreVideo Sidecar — broadcast control surface.");
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    QCommandLineOption hostOpt("obs-host",
+        "Override OBS WebSocket host.", "host");
+    QCommandLineOption portOpt("obs-port",
+        "Override OBS WebSocket port.", "port");
+    QCommandLineOption passOpt("obs-password",
+        "Override OBS WebSocket password.", "password");
+    QCommandLineOption autoOpt("obs-autoconnect",
+        "Connect to OBS automatically on launch.");
+
+    parser.addOption(hostOpt);
+    parser.addOption(portOpt);
+    parser.addOption(passOpt);
+    parser.addOption(autoOpt);
+    parser.process(app);
+
+    MainWindow::StartupConfig startup;
+    if (parser.isSet(hostOpt)) {
+        startup.hostOverride = parser.value(hostOpt);
+    }
+    if (parser.isSet(portOpt)) {
+        bool ok = false;
+        const int p = parser.value(portOpt).toInt(&ok);
+        if (ok && p > 0 && p < 65536) startup.portOverride = p;
+    }
+    if (parser.isSet(passOpt)) {
+        startup.passwordOverride = parser.value(passOpt);
+    }
+    startup.autoConnect = parser.isSet(autoOpt);
+
+    MainWindow w(startup);
     w.show();
 
     return app.exec();

--- a/sidecar/src/mainwindow.cpp
+++ b/sidecar/src/mainwindow.cpp
@@ -8,7 +8,11 @@
 #include "template-manager.h"
 #include "settings-page.h"
 #include "obs-connect-dialog.h"
+#include "command-palette.h"
 #include "sidecar-style.h"
+#include <QShortcut>
+#include <QKeySequence>
+#include <QTimer>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QLabel>
@@ -22,8 +26,10 @@
 #include <QSettings>
 #include <QDateTime>
 #include <QApplication>
+#include <QStyle>
 
-MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
+MainWindow::MainWindow(const StartupConfig &startup, QWidget *parent)
+    : QMainWindow(parent)
 {
     setWindowTitle("CoreVideo Sidecar");
     setMinimumSize(1200, 720);
@@ -104,6 +110,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     m_obsConfig.password      = cfg.value("obs/password", "").toString();
     m_obsConfig.autoReconnect = cfg.value("obs/autoReconnect", true).toBool();
 
+    // CLI / launch-time overrides — typically supplied by the parent OBS
+    // plugin so "Launch Sidecar" delivers a one-click connected session.
+    if (startup.hostOverride)     m_obsConfig.host     = *startup.hostOverride;
+    if (startup.portOverride)     m_obsConfig.port     = *startup.portOverride;
+    if (startup.passwordOverride) m_obsConfig.password = *startup.passwordOverride;
+
     // ── Connections ───────────────────────────────────────────────────────────
     connect(m_sidebar, &Sidebar::pageSelected, this, &MainWindow::onPageSelected);
     connect(applyBtn,  &QPushButton::clicked,  this, &MainWindow::onApplyLayout);
@@ -160,6 +172,30 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     connect(m_liveCanvas,  &PreviewCanvas::slotAssigned, this, &MainWindow::onSlotAssigned);
     connect(m_sceneCanvas, &PreviewCanvas::slotAssigned, this, &MainWindow::onSlotAssigned);
 
+    // Click-to-assign — selecting a slot focuses the Templates page and arms
+    // the participant panel so the next card click fills that slot.
+    connect(m_liveCanvas,  &PreviewCanvas::slotClicked, this, &MainWindow::onSlotClicked);
+    connect(m_sceneCanvas, &PreviewCanvas::slotClicked, this, &MainWindow::onSlotClicked);
+
+    // Participant card click — consumed only while assign mode is armed
+    connect(m_participantPanel, &ParticipantPanel::assignRequested, this,
+            [this](int pid, int slot) { onSlotAssigned(slot, pid); });
+    connect(m_participantPanel, &ParticipantPanel::participantClicked,
+            this, &MainWindow::onParticipantAssignClicked);
+
+    // Command palette (Ctrl+K / Cmd+K)
+    m_commandPalette = new CommandPalette(this);
+    auto *paletteShortcut = new QShortcut(
+        QKeySequence(QKeySequence::Find), this);
+    paletteShortcut->setContext(Qt::ApplicationShortcut);
+    connect(paletteShortcut, &QShortcut::activated,
+            this, &MainWindow::openCommandPalette);
+    auto *paletteShortcutK = new QShortcut(
+        QKeySequence(Qt::CTRL | Qt::Key_K), this);
+    paletteShortcutK->setContext(Qt::ApplicationShortcut);
+    connect(paletteShortcutK, &QShortcut::activated,
+            this, &MainWindow::openCommandPalette);
+
     // Templates
     auto &tm = TemplateManager::instance();
     tm.loadBuiltIn();
@@ -174,7 +210,22 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 
     // Initial UI state
     onObsState(OBSClient::State::Disconnected);
-    onObsLog("Sidecar ready. Click 'OBS' to connect.");
+    onObsLog("Sidecar ready. Click 'OBS' to connect, or press Ctrl+K for the command palette.");
+
+    // Auto-connect on launch if the parent process asked for it (e.g. when
+    // launched from the OBS plugin's "Launch Sidecar" button).
+    if (startup.autoConnect) {
+        QSettings s;
+        s.setValue("obs/host",     m_obsConfig.host);
+        s.setValue("obs/port",     m_obsConfig.port);
+        s.setValue("obs/password", m_obsConfig.password);
+        // Defer one tick so the window paints first
+        QTimer::singleShot(0, this, [this]() {
+            onObsLog(QStringLiteral("Auto-connecting to %1:%2 …")
+                         .arg(m_obsConfig.host).arg(m_obsConfig.port));
+            m_obsClient->connectToOBS(m_obsConfig);
+        });
+    }
 }
 
 // ── Top bar ───────────────────────────────────────────────────────────────────
@@ -415,7 +466,7 @@ void MainWindow::onApplyLayout()
 
     // Fall back to normalized layout
     QStringList sources;
-    for (int i = 0; i < m_currentTemplate.slots.size(); ++i)
+    for (int i = 0; i < m_currentTemplate.slotList.size(); ++i)
         sources << pattern.arg(i + 1);
     m_obsClient->applyLayout(scene, m_currentTemplate, sources, canvasW, canvasH);
 }
@@ -484,6 +535,7 @@ void MainWindow::onObsLog(const QString &msg)
 
 void MainWindow::onScenesReceived(const QStringList &scenes)
 {
+    m_lastScenes = scenes;
     m_scenesPanel->setScenes(scenes);
 
     const QString target = m_settingsPage->targetScene();
@@ -549,8 +601,8 @@ void MainWindow::onPhaseSelected(ShowPhase phase)
     m_topBar->setStyleSheet(
         QString("#topBar { background: #0d0d12; border-bottom: 2px solid %1; }").arg(border));
 
-    const QStringList labels = {"PRE-SHOW", "LIVE", "POST-SHOW"};
-    onObsLog(QString("Show phase → %1").arg(labels[int(phase)]));
+    const QStringList humanLabels = {"PRE-SHOW", "LIVE", "POST-SHOW"};
+    onObsLog(QString("Show phase → %1").arg(humanLabels[int(phase)]));
 }
 
 void MainWindow::onSlotAssigned(int slotIndex, int participantId)
@@ -566,7 +618,7 @@ void MainWindow::onSlotAssigned(int slotIndex, int participantId)
     }
 
     // Rebuild ordered participant list for canvas (slot index → position)
-    const int nSlots = m_currentTemplate.slots.size();
+    const int nSlots = m_currentTemplate.slotList.size();
     QVector<PreviewCanvas::Participant> cp(nSlots);
     for (const auto &p : m_participants) {
         if (p.slotAssign >= 0 && p.slotAssign < nSlots)
@@ -585,4 +637,129 @@ void MainWindow::onSlotAssigned(int slotIndex, int participantId)
                      if (p.id == participantId) return p.name;
                  return QString::number(participantId);
              }()));
+}
+
+void MainWindow::onSlotClicked(int slotIndex)
+{
+    if (slotIndex < 0 || slotIndex >= m_currentTemplate.slotList.size()) return;
+
+    // Context-sensitive right panel: clicking a slot focuses the Templates
+    // page (which hosts the participants list) and arms click-to-assign so
+    // the user can pick a participant without dragging.
+    m_assignTargetSlot = slotIndex;
+    m_sidebar->setActivePage(Sidebar::Page::Templates);
+    m_rightStack->setCurrentIndex(m_pageTemplates);
+    m_participantPanel->setAssignTarget(slotIndex);
+    onObsLog(QString("Selected Slot %1 — click a participant to assign.")
+                 .arg(slotIndex + 1));
+}
+
+void MainWindow::onParticipantAssignClicked(int participantId)
+{
+    // assignRequested already handles the assign-mode path. This slot is
+    // a hook for any future "select participant first" flow.
+    Q_UNUSED(participantId);
+}
+
+void MainWindow::openCommandPalette()
+{
+    populateCommandPalette();
+    m_commandPalette->run();
+}
+
+void MainWindow::populateCommandPalette()
+{
+    auto *cp = m_commandPalette;
+    cp->clearCommands();
+
+    // Navigation
+    cp->addCommand("Go to Templates", "Navigate", [this]() {
+        m_sidebar->setActivePage(Sidebar::Page::Templates);
+        m_rightStack->setCurrentIndex(m_pageTemplates);
+    });
+    cp->addCommand("Go to Themes", "Navigate", [this]() {
+        m_sidebar->setActivePage(Sidebar::Page::Themes);
+        m_rightStack->setCurrentIndex(m_pageThemes);
+    });
+    cp->addCommand("Go to Scenes", "Navigate", [this]() {
+        m_sidebar->setActivePage(Sidebar::Page::Scenes);
+        m_rightStack->setCurrentIndex(m_pageScenes);
+        m_obsClient->requestSceneList();
+    });
+    cp->addCommand("Go to Macros", "Navigate", [this]() {
+        m_sidebar->setActivePage(Sidebar::Page::Macros);
+        m_rightStack->setCurrentIndex(m_pageMacros);
+    });
+    cp->addCommand("Go to Settings", "Navigate", [this]() {
+        m_sidebar->setActivePage(Sidebar::Page::Settings);
+        m_rightStack->setCurrentIndex(m_pageSettings);
+    });
+
+    // Connection / toggles
+    cp->addCommand(m_obsClient->isConnected() ? "Disconnect from OBS"
+                                              : "Connect to OBS",
+                   "OBS", [this]() { onObsConnect(); });
+    cp->addCommand(m_obsClient->isVirtualCamActive() ? "Stop Virtual Camera"
+                                                    : "Start Virtual Camera",
+                   "OBS", [this]() { onVirtualCamToggle(); });
+    cp->addCommand("Apply current template", "OBS",
+                   [this]() { onApplyLayout(); });
+
+    // Phase
+    cp->addCommand("Phase: Pre-show", "Phase",
+                   [this]() { onPhaseSelected(ShowPhase::PreShow); });
+    cp->addCommand("Phase: Live", "Phase",
+                   [this]() { onPhaseSelected(ShowPhase::Live); });
+    cp->addCommand("Phase: Post-show", "Phase",
+                   [this]() { onPhaseSelected(ShowPhase::PostShow); });
+
+    // Scenes (from last OBS sync)
+    for (const QString &s : m_lastScenes) {
+        const QString sc = s;
+        cp->addCommand(QString("Switch to scene: %1").arg(sc), "Scene",
+                       [this, sc]() { onSceneActivated(sc); });
+    }
+
+    // Templates
+    for (const auto &t : TemplateManager::instance().templates()) {
+        const QString id = t.id;
+        const QString name = t.name;
+        cp->addCommand(QString("Select template: %1").arg(name), "Template",
+                       [this, id]() {
+            if (const auto *tt = TemplateManager::instance().findById(id))
+                onTemplateSelected(*tt);
+        });
+    }
+    // Apply template directly
+    for (const auto &t : TemplateManager::instance().templates()) {
+        const QString id = t.id;
+        const QString name = t.name;
+        cp->addCommand(QString("Apply template: %1").arg(name), "Template",
+                       [this, id]() {
+            if (const auto *tt = TemplateManager::instance().findById(id)) {
+                onTemplateSelected(*tt);
+                onApplyLayout();
+            }
+        });
+    }
+
+    // Themes
+    for (const auto &t : ShowTheme::builtIns()) {
+        const ShowTheme theme = t;
+        cp->addCommand(QString("Theme: %1").arg(theme.name), "Theme",
+                       [this, theme]() { onThemeSelected(theme); });
+    }
+
+    // Participants — assign to currently selected slot (or slot 1 fallback)
+    for (const auto &p : m_participants) {
+        const int pid = p.id;
+        const QString name = p.name;
+        cp->addCommand(QString("Assign %1 to current slot").arg(name),
+                       "Participant", [this, pid]() {
+            int slot = m_assignTargetSlot;
+            if (slot < 0) slot = 0;
+            if (slot < m_currentTemplate.slotList.size())
+                onSlotAssigned(slot, pid);
+        });
+    }
 }

--- a/sidecar/src/mainwindow.h
+++ b/sidecar/src/mainwindow.h
@@ -7,6 +7,7 @@
 #include "participant-panel.h"
 #include "sidecar-control-server.h"
 #include <QMainWindow>
+#include <optional>
 
 class PreviewCanvas;
 class TemplatePanel;
@@ -20,13 +21,23 @@ class QPushButton;
 class QPlainTextEdit;
 class QDockWidget;
 class QStackedWidget;
+class CommandPalette;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
 public:
     enum class ShowPhase { PreShow, Live, PostShow };
 
-    explicit MainWindow(QWidget *parent = nullptr);
+    // Optional launch-time overrides — typically supplied by the parent
+    // OBS plugin via CLI flags so the user gets a one-click connected sidecar.
+    struct StartupConfig {
+        std::optional<QString> hostOverride;
+        std::optional<int>     portOverride;
+        std::optional<QString> passwordOverride;
+        bool                   autoConnect = false;
+    };
+
+    explicit MainWindow(const StartupConfig &startup, QWidget *parent = nullptr);
 
 private slots:
     void onPageSelected(Sidebar::Page p);
@@ -45,6 +56,10 @@ private slots:
     void onMacroTriggered(const Macro &macro);
     void onPhaseSelected(ShowPhase phase);
     void onSlotAssigned(int slotIndex, int participantId);
+    void onSlotClicked(int slotIndex);
+    void onParticipantAssignClicked(int participantId);
+    void openCommandPalette();
+    void populateCommandPalette();
 
 private:
     void buildTopBar(QWidget *parent);
@@ -101,5 +116,12 @@ private:
     OBSClient::Config          m_obsConfig;
     Sidebar                   *m_sidebar        = nullptr;
     QVector<ParticipantInfo>   m_participants;
+    QStringList                m_lastScenes;
     SidecarControlServer      *m_controlServer  = nullptr;
+
+    // Click-to-assign mode: when ≥ 0, the next participant card click is
+    // routed to this slot index instead of starting a drag flow.
+    int                        m_assignTargetSlot = -1;
+
+    CommandPalette            *m_commandPalette = nullptr;
 };

--- a/sidecar/src/obs-client.cpp
+++ b/sidecar/src/obs-client.cpp
@@ -12,7 +12,13 @@ OBSClient::OBSClient(QObject *parent) : QObject(parent)
     connect(m_ws, &QWebSocket::disconnected, this, &OBSClient::onDisconnected);
     connect(m_ws, &QWebSocket::textMessageReceived,
             this, &OBSClient::onTextMessageReceived);
-    connect(m_ws, &QWebSocket::errorOccurred, this, [this](auto) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    constexpr auto wsErrorSignal = &QWebSocket::errorOccurred;
+#else
+    constexpr auto wsErrorSignal =
+        QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error);
+#endif
+    connect(m_ws, wsErrorSignal, this, [this](auto) {
         const QString err = m_ws->errorString();
         qWarning() << "[obs-ws]" << err;
         emit errorOccurred(err);
@@ -362,8 +368,8 @@ void OBSClient::applyLayout(const QString        &sceneName,
 
     QJsonArray requests;
     int matched = 0;
-    for (int i = 0; i < tmpl.slots.size() && i < sourceNames.size(); ++i) {
-        const TemplateSlot &slot = tmpl.slots[i];
+    for (int i = 0; i < tmpl.slotList.size() && i < sourceNames.size(); ++i) {
+        const TemplateSlot &slot = tmpl.slotList[i];
         const int itemId = resolveItemId(sceneName, sourceNames[i]);
         if (itemId < 0) {
             emit log(QStringLiteral("Skip '%1' — not in scene '%2'.")

--- a/sidecar/src/participant-panel.cpp
+++ b/sidecar/src/participant-panel.cpp
@@ -3,6 +3,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QToolButton>
 #include <QPainter>
 #include <QPainterPath>
 #include <QScrollArea>
@@ -157,6 +158,36 @@ ParticipantPanel::ParticipantPanel(QWidget *parent) : QWidget(parent)
 
     vl->addWidget(header);
 
+    // Assign-mode banner — hidden unless setAssignTarget() activates it
+    m_assignBanner = new QWidget(this);
+    m_assignBanner->setObjectName("assignBanner");
+    m_assignBanner->setStyleSheet(
+        "#assignBanner { background: #1a2a4a; border: 1px solid #2979ff; "
+        "border-radius: 6px; }");
+    auto *bl = new QHBoxLayout(m_assignBanner);
+    bl->setContentsMargins(10, 6, 6, 6);
+    bl->setSpacing(6);
+    m_assignLabel = new QLabel("", m_assignBanner);
+    m_assignLabel->setStyleSheet(
+        "color: #cfe0ff; font-size: 12px; font-weight: 600; background: transparent;");
+    auto *cancel = new QToolButton(m_assignBanner);
+    cancel->setText("✕");
+    cancel->setToolTip("Cancel assignment");
+    cancel->setStyleSheet(
+        "QToolButton { color: #cfe0ff; background: transparent; border: none; "
+        "font-size: 13px; padding: 2px 6px; }"
+        "QToolButton:hover { color: #ffffff; }");
+    connect(cancel, &QToolButton::clicked, this, [this]() { setAssignTarget(-1); });
+    bl->addWidget(m_assignLabel, 1);
+    bl->addWidget(cancel);
+    m_assignBanner->hide();
+
+    auto *bannerWrap = new QWidget(this);
+    auto *bwl = new QHBoxLayout(bannerWrap);
+    bwl->setContentsMargins(8, 0, 8, 6);
+    bwl->addWidget(m_assignBanner);
+    vl->addWidget(bannerWrap);
+
     // Scrollable list
     auto *scroll = new QScrollArea(this);
     scroll->setFrameShape(QFrame::NoFrame);
@@ -192,9 +223,25 @@ void ParticipantPanel::setParticipants(const QVector<ParticipantInfo> &participa
         m_cards.append(card);
         m_listLayout->insertWidget(m_listLayout->count() - 1, card);
         connect(card, &ParticipantCard::assignClicked, this, [this](int pid) {
-            emit assignRequested(pid, 0);
+            emit participantClicked(pid);
+            if (m_assignTarget >= 0) {
+                emit assignRequested(pid, m_assignTarget);
+                setAssignTarget(-1);
+            }
         });
     }
 
     m_countLabel->setText(QString::number(participants.size()));
+}
+
+void ParticipantPanel::setAssignTarget(int slotIndex)
+{
+    m_assignTarget = slotIndex;
+    if (slotIndex < 0) {
+        m_assignBanner->hide();
+        return;
+    }
+    m_assignLabel->setText(
+        QString("Click a participant to assign to Slot %1").arg(slotIndex + 1));
+    m_assignBanner->show();
 }

--- a/sidecar/src/participant-panel.h
+++ b/sidecar/src/participant-panel.h
@@ -25,13 +25,23 @@ public:
 
     void setParticipants(const QVector<ParticipantInfo> &participants);
 
+    // Drives the "Click a participant to assign to Slot N" banner. Pass -1
+    // to clear it (default browse mode).
+    void setAssignTarget(int slotIndex);
+
 signals:
     void assignRequested(int participantId, int slotIndex);
+    // Emitted whenever a participant card is clicked, regardless of mode.
+    // MainWindow decides whether to consume it as a slot assignment.
+    void participantClicked(int participantId);
 
 private:
-    QWidget      *m_listArea   = nullptr;
-    QVBoxLayout  *m_listLayout = nullptr;
-    QLabel       *m_countLabel = nullptr;
+    QWidget      *m_listArea    = nullptr;
+    QVBoxLayout  *m_listLayout  = nullptr;
+    QLabel       *m_countLabel  = nullptr;
+    QWidget      *m_assignBanner = nullptr;
+    QLabel       *m_assignLabel  = nullptr;
+    int           m_assignTarget = -1;
     QVector<ParticipantCard *> m_cards;
 };
 

--- a/sidecar/src/preview-canvas.cpp
+++ b/sidecar/src/preview-canvas.cpp
@@ -7,6 +7,8 @@
 #include <QDragLeaveEvent>
 #include <QDropEvent>
 #include <QMimeData>
+#include <QMouseEvent>
+#include <QApplication>
 #include <cmath>
 
 static const QColor kSlotBg   {0x22, 0x22, 0x30};
@@ -38,8 +40,8 @@ void PreviewCanvas::setParticipants(const QVector<Participant> &participants)
 
 int PreviewCanvas::slotAtPoint(QPoint pt) const
 {
-    for (int i = 0; i < m_tmpl.slots.size(); ++i) {
-        if (slotRect(m_tmpl.slots[i]).contains(pt))
+    for (int i = 0; i < m_tmpl.slotList.size(); ++i) {
+        if (slotRect(m_tmpl.slotList[i]).contains(pt))
             return i;
     }
     return -1;
@@ -81,6 +83,28 @@ void PreviewCanvas::dropEvent(QDropEvent *e)
     e->acceptProposedAction();
 }
 
+void PreviewCanvas::mousePressEvent(QMouseEvent *e)
+{
+    if (e->button() != Qt::LeftButton) { QWidget::mousePressEvent(e); return; }
+    m_pressedSlot = slotAtPoint(e->pos());
+    m_pressPos    = e->pos();
+    QWidget::mousePressEvent(e);
+}
+
+void PreviewCanvas::mouseReleaseEvent(QMouseEvent *e)
+{
+    if (e->button() == Qt::LeftButton && m_pressedSlot >= 0) {
+        const int slotNow = slotAtPoint(e->pos());
+        const int dist    = (e->pos() - m_pressPos).manhattanLength();
+        // Treat as a click only if release lands on the same slot and the
+        // pointer barely moved — anything larger is a drag/resize gesture.
+        if (slotNow == m_pressedSlot && dist < QApplication::startDragDistance())
+            emit slotClicked(m_pressedSlot);
+    }
+    m_pressedSlot = -1;
+    QWidget::mouseReleaseEvent(e);
+}
+
 QRectF PreviewCanvas::slotRect(const TemplateSlot &s) const
 {
     const float W = width()  - kGap;
@@ -105,8 +129,8 @@ void PreviewCanvas::paintEvent(QPaintEvent *)
         return;
     }
 
-    for (int i = 0; i < m_tmpl.slots.size(); ++i)
-        drawSlot(p, slotRect(m_tmpl.slots[i]), i);
+    for (int i = 0; i < m_tmpl.slotList.size(); ++i)
+        drawSlot(p, slotRect(m_tmpl.slotList[i]), i);
 }
 
 void PreviewCanvas::drawSlot(QPainter &p, const QRectF &rect, int idx) const

--- a/sidecar/src/preview-canvas.h
+++ b/sidecar/src/preview-canvas.h
@@ -26,6 +26,7 @@ public:
 
 signals:
     void slotAssigned(int slotIndex, int participantId);
+    void slotClicked(int slotIndex);
 
 protected:
     void paintEvent(QPaintEvent *) override;
@@ -33,11 +34,15 @@ protected:
     void dragMoveEvent(QDragMoveEvent *e) override;
     void dragLeaveEvent(QDragLeaveEvent *e) override;
     void dropEvent(QDropEvent *e) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
 
 private:
     LayoutTemplate       m_tmpl;
     QVector<Participant> m_parts;
     int                  m_hoveredSlot = -1;
+    int                  m_pressedSlot = -1;
+    QPoint               m_pressPos;
 
     int    slotAtPoint(QPoint pt) const;
     void   drawSlot(QPainter &p, const QRectF &rect, int index) const;

--- a/sidecar/src/sidebar.cpp
+++ b/sidecar/src/sidebar.cpp
@@ -1,4 +1,5 @@
 #include "sidebar.h"
+#include <QStyle>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QLabel>

--- a/sidecar/src/template-panel.cpp
+++ b/sidecar/src/template-panel.cpp
@@ -49,7 +49,7 @@ void TemplateThumbnail::paintEvent(QPaintEvent *)
                                         : QColor(0x3a, 0x3a, 0x58);
     const float  gap = 2.5f;
 
-    for (const auto &slot : m_tmpl.slots) {
+    for (const auto &slot : m_tmpl.slotList) {
         QRectF r(
             diag.left() + slot.x * diag.width()  + gap,
             diag.top()  + slot.y * diag.height() + gap,

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -29,8 +29,14 @@
 #include <QMetaObject>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QPointer>
+#include <QProcess>
 #include <QPushButton>
+#include <QSettings>
+#include <QStandardPaths>
 #include <QTableWidget>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -203,6 +209,89 @@ ZoomDock::ZoomDock(QWidget *parent)
     speaker_row->addWidget(new QLabel("Active speaker:", this));
     speaker_row->addWidget(m_speaker_label, 1);
     vLayout->addLayout(speaker_row);
+
+    // ── Launch Sidecar (companion control surface) ────────────────────────────
+    auto *launch_row = new QHBoxLayout;
+    launch_row->setSpacing(6);
+    auto *launch_btn = new QPushButton("Launch Sidecar", this);
+    launch_btn->setToolTip(
+        "Open the CoreVideo Sidecar broadcast control surface and connect it "
+        "to this OBS instance automatically.");
+    launch_btn->setProperty("role", "secondary");
+    launch_row->addStretch(1);
+    launch_row->addWidget(launch_btn);
+    vLayout->addLayout(launch_row);
+
+    connect(launch_btn, &QPushButton::clicked, this, [this, launch_btn]() {
+        // Discover the sidecar binary. Order:
+        //   1. COREVIDEO_SIDECAR_BIN env var
+        //   2. QSettings key "sidecar/binPath" (remembered last choice)
+        //   3. Same directory as the running OBS executable
+        //   4. PATH lookup ("CoreVideoSidecar" / ".app/Contents/MacOS/...")
+        //   5. Prompt the user to locate it, then remember.
+        const QStringList candidateNames = {
+#if defined(Q_OS_WIN)
+            "CoreVideoSidecar.exe",
+#elif defined(Q_OS_MAC)
+            "CoreVideo Sidecar.app/Contents/MacOS/CoreVideoSidecar",
+            "CoreVideoSidecar.app/Contents/MacOS/CoreVideoSidecar",
+#endif
+            "CoreVideoSidecar",
+        };
+
+        auto fileExists = [](const QString &p) {
+            return !p.isEmpty() && QFileInfo(p).isFile();
+        };
+
+        QString path = qEnvironmentVariable("COREVIDEO_SIDECAR_BIN");
+        if (!fileExists(path)) {
+            QSettings s;
+            path = s.value("sidecar/binPath").toString();
+        }
+        if (!fileExists(path)) {
+            const QString appDir = QCoreApplication::applicationDirPath();
+            for (const QString &name : candidateNames) {
+                const QString p = QDir(appDir).filePath(name);
+                if (fileExists(p)) { path = p; break; }
+            }
+        }
+        if (!fileExists(path)) {
+            for (const QString &name : candidateNames) {
+                const QString p = QStandardPaths::findExecutable(name);
+                if (fileExists(p)) { path = p; break; }
+            }
+        }
+        if (!fileExists(path)) {
+            const QString picked = QFileDialog::getOpenFileName(
+                this, "Locate CoreVideo Sidecar",
+                QCoreApplication::applicationDirPath(),
+                "Executables (*)");
+            if (picked.isEmpty()) return;
+            path = picked;
+            QSettings s;
+            s.setValue("sidecar/binPath", path);
+        }
+
+        QStringList args;
+        args << "--obs-host"        << "localhost"
+             << "--obs-port"        << "4455"
+             << "--obs-autoconnect";
+
+        qint64 pid = 0;
+        const bool ok = QProcess::startDetached(path, args, QString(), &pid);
+        if (!ok) {
+            QMessageBox::warning(this, "Launch Sidecar",
+                QString("Failed to launch sidecar at:\n%1").arg(path));
+            return;
+        }
+        launch_btn->setText("Sidecar launched");
+        launch_btn->setEnabled(false);
+        QTimer::singleShot(2500, launch_btn, [launch_btn]() {
+            if (!launch_btn) return;
+            launch_btn->setText("Launch Sidecar");
+            launch_btn->setEnabled(true);
+        });
+    });
 
     // ── Credentials notice (hidden once credentials are set) ──────────────────
     m_credentials_banner = new CvBanner(


### PR DESCRIPTION
Three high-leverage UX improvements that collapse the most common "where do I click?" moments in the sidecar:

- Plugin-launch handshake. The OBS dock now exposes a "Launch Sidecar" button that discovers the binary (env / setting / app dir / PATH / user-locate) and spawns it with --obs-host/--obs-port/--obs-autoconnect so the sidecar comes up already connected. Sidecar gains a QCommandLineParser front-end and a MainWindow::StartupConfig that threads the overrides into OBSClient and triggers connect on the first event-loop tick.

- Context-sensitive right panel. Clicking a slot in the canvas now switches the right panel to the Templates page and arms a banner on the participant panel ("Click a participant to assign to Slot N"). The next card click fills that slot, giving keyboard/trackpad users an alternative to drag-and-drop. PreviewCanvas grew mousePress/Release handlers that distinguish a click from a drag using QApplication::startDragDistance().

- Command palette (Ctrl+K / Ctrl+F). New CommandPalette popup lists navigation, OBS connect/V-Cam, phase, scene switches, template select/apply, theme, and participant-assign commands, with live fuzzy filtering and keyboard navigation.

Pre-existing fixes required to make the sidecar build outside macOS:
- Renamed LayoutTemplate::slots → slotList (the Qt slots macro swallowed the field on every non-macOS toolchain). JSON key "slots" preserved on disk.
- Added missing <QStyle> includes where ->style()->polish() is called.
- Added a QT_VERSION shim for QWebSocket::errorOccurred (Qt 6.5+) vs QWebSocket::error (Qt 6.4).
- Renamed a shadowed local labels QStringList in onPhaseSelected.