### PR TITLE
Fix sidecar and OBS look layer parity

### DIFF
--- a/docs/SIDECAR_OBS_CONTROL_ISSUES.md
+++ b/docs/SIDECAR_OBS_CONTROL_ISSUES.md
@@ -34,6 +34,7 @@ Progress:
 
 Remaining:
 - True rounded-corner masking still needs an OBS-side matte/filter strategy.
+- Rounded corner controls are disabled in the designer and the sidecar preview renders rectangular tiles until that OBS mask/matte path exists, so preview and OBS remain WYSIWYG.
 
 ## Issue 3 - Add OBS read-back sync status
 Status: In progress

--- a/sidecar/src/mainwindow.cpp
+++ b/sidecar/src/mainwindow.cpp
@@ -1297,6 +1297,8 @@ void MainWindow::onDesignLookRequested()
     radius->setRange(0.0, 80.0);
     radius->setSingleStep(1.0);
     radius->setValue(m_working.tileStyle.cornerRadius);
+    radius->setEnabled(false);
+    radius->setToolTip(QStringLiteral("Rounded corners need an OBS mask/matte implementation before they can be WYSIWYG."));
     auto *opacity = new QDoubleSpinBox(&dlg);
     opacity->setRange(0.1, 1.0);
     opacity->setSingleStep(0.05);

--- a/sidecar/src/obs-client.cpp
+++ b/sidecar/src/obs-client.cpp
@@ -872,6 +872,13 @@ void OBSClient::loadSceneTemplate(const QString        &sceneName,
             setCurrentScene(sceneName);
         requestSceneList();
     });
+    QTimer::singleShot(3600, this, [this, sceneName, tmpl, tileStyle, backgroundImagePath, overlays]() {
+        applyLookLayerOrder(sceneName, tmpl, tileStyle, !backgroundImagePath.trimmed().isEmpty(), overlays.size());
+    });
+    QTimer::singleShot(4400, this, [this, sceneName, tmpl, tileStyle, backgroundImagePath, overlays]() {
+        applyLookLayerOrder(sceneName, tmpl, tileStyle, !backgroundImagePath.trimmed().isEmpty(), overlays.size());
+        requestSceneItems(sceneName);
+    });
 }
 
 void OBSClient::ensureCoreVideoSources(const QString &sceneName,
@@ -1753,6 +1760,80 @@ void OBSClient::applyTileDecorations(const QString &sceneName,
         });
         emit log(QStringLiteral("Applied tile design layers to '%1'.").arg(sceneName));
     });
+}
+
+void OBSClient::applyLookLayerOrder(const QString &sceneName,
+                                    const LayoutTemplate &tmpl,
+                                    const TileStyle &tileStyle,
+                                    bool hasBackgroundImage,
+                                    int overlayCount)
+{
+    if (m_state != State::Connected || sceneName.isEmpty() || !tmpl.isValid())
+        return;
+    if (!m_itemCache.contains(sceneName)) {
+        requestSceneItems(sceneName);
+        return;
+    }
+
+    QStringList bottomToTop;
+    bottomToTop << coreVideoCanvasSourceName(sceneName);
+    if (hasBackgroundImage)
+        bottomToTop << coreVideoBackgroundSourceName(sceneName);
+
+    if (tileStyle.dropShadow) {
+        for (const auto &slot : tmpl.slotList)
+            bottomToTop << coreVideoShadowSourceName(sceneName, slot.index);
+    }
+    if (tileStyle.borderWidth > 0.0) {
+        for (const auto &slot : tmpl.slotList)
+            bottomToTop << coreVideoBorderSourceName(sceneName, slot.index);
+    }
+    for (const auto &slot : tmpl.slotList)
+        bottomToTop << coreVideoSlotSceneName(slot.index);
+    if (tileStyle.opacity < 0.99) {
+        for (const auto &slot : tmpl.slotList)
+            bottomToTop << coreVideoDimSourceName(sceneName, slot.index);
+    }
+    if (tileStyle.showNameTag) {
+        for (const auto &slot : tmpl.slotList)
+            bottomToTop << coreVideoNameTagSourceName(sceneName, slot.index);
+    }
+    for (int i = 0; i < overlayCount; ++i)
+        bottomToTop << overlaySourceName(sceneName, i);
+
+    QJsonArray requests;
+    for (int i = 0; i < bottomToTop.size(); ++i) {
+        const int itemId = resolveItemId(sceneName, bottomToTop[i]);
+        if (itemId < 0)
+            continue;
+        requests.append(QJsonObject{
+            {"requestType", "SetSceneItemIndex"},
+            {"requestId",   nextId()},
+            {"requestData", QJsonObject{
+                {"sceneName",      sceneName},
+                {"sceneItemId",    itemId},
+                {"sceneItemIndex", i},
+            }},
+        });
+        requests.append(QJsonObject{
+            {"requestType", "SetSceneItemEnabled"},
+            {"requestId",   nextId()},
+            {"requestData", QJsonObject{
+                {"sceneName",        sceneName},
+                {"sceneItemId",      itemId},
+                {"sceneItemEnabled", true},
+            }},
+        });
+    }
+
+    if (requests.isEmpty())
+        return;
+    sendOp(8, QJsonObject{
+        {"requestId",     nextId()},
+        {"haltOnFailure", false},
+        {"requests",      requests},
+    });
+    emit log(QStringLiteral("Applied final Look layer order to '%1'.").arg(sceneName));
 }
 
 void OBSClient::applyOverlays(const QString &sceneName,

--- a/sidecar/src/obs-client.h
+++ b/sidecar/src/obs-client.h
@@ -138,6 +138,11 @@ public:
                               const QStringList &slotLabels,
                               double canvasW, double canvasH,
                               bool retryAfterCreate = true);
+    void applyLookLayerOrder(const QString &sceneName,
+                             const LayoutTemplate &tmpl,
+                             const TileStyle &tileStyle,
+                             bool hasBackgroundImage,
+                             int overlayCount);
 
     // Apply a flat applied-template JSON in the format:
     //   { "name": "...", "scene": "...", "items": [

--- a/sidecar/src/preview-canvas.cpp
+++ b/sidecar/src/preview-canvas.cpp
@@ -397,7 +397,10 @@ void PreviewCanvas::drawSlot(QPainter &p, const QRectF &rect, int idx) const
 
     // Slot background
     QPainterPath path;
-    const double radius = std::max(0.0, m_tileStyle.cornerRadius);
+    // OBS scene items are rectangular until we add a real mask/matte filter
+    // path. Keep the sidecar preview WYSIWYG with OBS instead of implying
+    // rounded clipping that OBS does not yet render.
+    const double radius = 0.0;
     path.addRoundedRect(rect, radius, radius);
     if (m_tileStyle.dropShadow) {
         QPainterPath shadow;


### PR DESCRIPTION
## Summary
- Add a final OBS look layer-order pass so rendered scenes match sidecar stacking: canvas, background, shadows, borders, slots, dim layers, name tags, overlays.
- Keep sidecar preview WYSIWYG with current OBS capabilities by disabling rounded-corner editing until an OBS mask/matte path exists.
- Document the remaining rounded-corner limitation in the sidecar OBS control issue list.

## Verification
- Built CoreVideoSidecar
- Built CoreVideoSidecarCatalogTest
- Ran CoreVideoSidecarVersion
- Ran CoreVideoSidecarCatalog
- All tests passed