### PR TITLE
[codex] Fix sidecar OBS layout canvas normalization

### DIFF
--- a/sidecar/CMakeLists.txt
+++ b/sidecar/CMakeLists.txt
@@ -74,8 +74,16 @@ if(BUILD_TESTING)
     target_include_directories(CoreVideoSidecarCatalogTest PRIVATE src)
     target_link_libraries(CoreVideoSidecarCatalogTest PRIVATE Qt6::Core Qt6::Gui)
 
+    add_executable(CoreVideoSidecarRendererConfigTest
+        tests/renderer-config-test.cpp
+    )
+    target_include_directories(CoreVideoSidecarRendererConfigTest PRIVATE src)
+    target_link_libraries(CoreVideoSidecarRendererConfigTest PRIVATE Qt6::Core Qt6::Gui)
+
     add_test(NAME CoreVideoSidecarCatalog
         COMMAND CoreVideoSidecarCatalogTest "${CMAKE_CURRENT_SOURCE_DIR}/data")
+    add_test(NAME CoreVideoSidecarRendererConfig
+        COMMAND CoreVideoSidecarRendererConfigTest)
     if(WIN32 AND _qt_runtime_dir)
         set_tests_properties(CoreVideoSidecarVersion PROPERTIES
             ENVIRONMENT_MODIFICATION
@@ -83,6 +91,9 @@ if(BUILD_TESTING)
         set_tests_properties(CoreVideoSidecarCatalog PROPERTIES
             ENVIRONMENT_MODIFICATION
                 "PATH=path_list_prepend:$<TARGET_FILE_DIR:CoreVideoSidecarCatalogTest>;PATH=path_list_prepend:${_qt_runtime_dir}")
+        set_tests_properties(CoreVideoSidecarRendererConfig PROPERTIES
+            ENVIRONMENT_MODIFICATION
+                "PATH=path_list_prepend:$<TARGET_FILE_DIR:CoreVideoSidecarRendererConfigTest>;PATH=path_list_prepend:${_qt_runtime_dir}")
     endif()
 endif()
 

--- a/sidecar/src/mainwindow.cpp
+++ b/sidecar/src/mainwindow.cpp
@@ -559,6 +559,7 @@ OBSLookRenderer::Config MainWindow::obsRendererConfig() const
         config.canvasWidth = m_settingsPage->canvasWidth();
         config.canvasHeight = m_settingsPage->canvasHeight();
     }
+    config.normalizeBroadcastCanvas();
     return config;
 }
 

--- a/sidecar/src/obs-look-renderer.cpp
+++ b/sidecar/src/obs-look-renderer.cpp
@@ -5,6 +5,7 @@
 OBSLookRenderer::OBSLookRenderer(OBSClient *client, Config config)
     : m_client(client), m_config(std::move(config))
 {
+    m_config.normalizeBroadcastCanvas();
 }
 
 QStringList OBSLookRenderer::sourceNamesForSlots(int slotCount) const

--- a/sidecar/src/obs-look-renderer.h
+++ b/sidecar/src/obs-look-renderer.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QStringList>
 #include <QVector>
+#include <utility>
 
 class OBSLookRenderer {
 public:
@@ -13,6 +14,16 @@ public:
         QString fallbackSceneName;
         double canvasWidth = 1920.0;
         double canvasHeight = 1080.0;
+
+        void normalizeBroadcastCanvas()
+        {
+            if (canvasWidth <= 0.0)
+                canvasWidth = 1920.0;
+            if (canvasHeight <= 0.0)
+                canvasHeight = 1080.0;
+            if (canvasHeight > canvasWidth)
+                std::swap(canvasWidth, canvasHeight);
+        }
     };
 
     OBSLookRenderer(OBSClient *client, Config config);

--- a/sidecar/src/settings-page.cpp
+++ b/sidecar/src/settings-page.cpp
@@ -13,6 +13,8 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
+#include <utility>
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -183,8 +185,14 @@ void SettingsPage::loadSettings()
 
     m_scene->setText(s.value("scene/target", "CoreVideo Main").toString());
     m_sourcePattern->setText(s.value("scene/sourcePattern", "Zoom Participant %1").toString());
-    m_canvasW->setValue(s.value("scene/canvasW", 1920).toInt());
-    m_canvasH->setValue(s.value("scene/canvasH", 1080).toInt());
+    int canvasW = s.value("scene/canvasW", 1920).toInt();
+    int canvasH = s.value("scene/canvasH", 1080).toInt();
+    if (canvasW <= 0) canvasW = 1920;
+    if (canvasH <= 0) canvasH = 1080;
+    if (canvasH > canvasW)
+        std::swap(canvasW, canvasH);
+    m_canvasW->setValue(canvasW);
+    m_canvasH->setValue(canvasH);
 }
 
 // ---------------------------------------------------------------------------
@@ -202,8 +210,15 @@ void SettingsPage::saveSettings()
 
     s.setValue("scene/target",        m_scene->text());
     s.setValue("scene/sourcePattern", m_sourcePattern->text());
-    s.setValue("scene/canvasW",       m_canvasW->value());
-    s.setValue("scene/canvasH",       m_canvasH->value());
+    int canvasW = m_canvasW->value();
+    int canvasH = m_canvasH->value();
+    if (canvasH > canvasW) {
+        std::swap(canvasW, canvasH);
+        m_canvasW->setValue(canvasW);
+        m_canvasH->setValue(canvasH);
+    }
+    s.setValue("scene/canvasW",       canvasW);
+    s.setValue("scene/canvasH",       canvasH);
 }
 
 // ---------------------------------------------------------------------------

--- a/sidecar/tests/renderer-config-test.cpp
+++ b/sidecar/tests/renderer-config-test.cpp
@@ -1,0 +1,31 @@
+#include "obs-look-renderer.h"
+
+#include <QtGlobal>
+
+static int fail()
+{
+    return 1;
+}
+
+int main()
+{
+    OBSLookRenderer::Config portrait;
+    portrait.canvasWidth = 1080.0;
+    portrait.canvasHeight = 1920.0;
+    portrait.normalizeBroadcastCanvas();
+    if (!qFuzzyCompare(portrait.canvasWidth, 1920.0)
+        || !qFuzzyCompare(portrait.canvasHeight, 1080.0)) {
+        return fail();
+    }
+
+    OBSLookRenderer::Config invalid;
+    invalid.canvasWidth = 0.0;
+    invalid.canvasHeight = -1.0;
+    invalid.normalizeBroadcastCanvas();
+    if (!qFuzzyCompare(invalid.canvasWidth, 1920.0)
+        || !qFuzzyCompare(invalid.canvasHeight, 1080.0)) {
+        return fail();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- normalize sidecar OBS render canvas dimensions to landscape before creating scene transforms
- correct persisted portrait canvas settings on settings load/save
- add a sidecar renderer config regression test for the portrait-canvas failure mode

## Root Cause
The sidecar preview is fixed to a 16:9 broadcast canvas, but persisted OBS render settings could store a portrait canvas such as 1080x1920. That caused OBS transforms to be computed with off-screen Y coordinates even though the sidecar preview looked correct.

## Validation
- `ctest --test-dir build-nmake -C Release --output-on-failure -R "CoreVideoSidecar(RendererConfig|Catalog|Version)"`