### PR TITLE
Add audio routing control (Mixed/Isolated/Audience) for output slots

### DIFF
--- a/sidecar/src/audio-routing.h
+++ b/sidecar/src/audio-routing.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <QString>
+
+// Per-source audio routing — matches the plugin's tri-state model.
+// Mixed   : full meeting mix (default).
+// Isolated: only the bound participant's voice.
+// Audience: residual active speaker — every participant NOT bound to any
+//           isolated source. Use one Audience source as a "fallback mic"
+//           for overflow speakers when iso channels are spoken for.
+enum class AudioRouting { Mixed, Isolated, Audience };
+
+inline QString audioRoutingLabel(AudioRouting r)
+{
+    switch (r) {
+    case AudioRouting::Isolated: return QStringLiteral("Iso");
+    case AudioRouting::Audience: return QStringLiteral("Aud");
+    case AudioRouting::Mixed:    break;
+    }
+    return QStringLiteral("Mix");
+}
+
+inline QChar audioRoutingBadge(AudioRouting r)
+{
+    switch (r) {
+    case AudioRouting::Isolated: return QChar('I');
+    case AudioRouting::Audience: return QChar('A');
+    case AudioRouting::Mixed:    break;
+    }
+    return QChar('M');
+}
+
+inline AudioRouting nextAudioRouting(AudioRouting r)
+{
+    switch (r) {
+    case AudioRouting::Mixed:    return AudioRouting::Isolated;
+    case AudioRouting::Isolated: return AudioRouting::Audience;
+    case AudioRouting::Audience: break;
+    }
+    return AudioRouting::Mixed;
+}

--- a/sidecar/src/mainwindow.cpp
+++ b/sidecar/src/mainwindow.cpp
@@ -328,6 +328,12 @@ MainWindow::MainWindow(const StartupConfig &startup, QWidget *parent)
     connect(m_liveCanvas,  &PreviewCanvas::slotClicked, this, &MainWindow::onSlotClicked);
     connect(m_sceneCanvas, &PreviewCanvas::slotClicked, this, &MainWindow::onSlotClicked);
 
+    // Right-click on a slot cycles its audio routing (Mix → Iso → Aud → Mix).
+    connect(m_liveCanvas,  &PreviewCanvas::slotRoutingCycleRequested,
+            this, &MainWindow::onSlotRoutingCycle);
+    connect(m_sceneCanvas, &PreviewCanvas::slotRoutingCycleRequested,
+            this, &MainWindow::onSlotRoutingCycle);
+
     // Participant card click — consumed only while assign mode is armed
     connect(m_participantPanel, &ParticipantPanel::assignRequested, this,
             [this](int pid, int slot) { onSlotAssigned(slot, pid); });
@@ -951,8 +957,11 @@ void MainWindow::syncZoomOutputAssignments()
         if (m_lastSyncedSlotParticipants.value(it.key(), -1) == it.value())
             continue;
         const QString sourceName = sources.value(it.key());
-        if (!sourceName.isEmpty())
-            m_zoomClient->assignOutput(sourceName, it.value(), false, "mono");
+        if (!sourceName.isEmpty()) {
+            const AudioRouting routing =
+                m_slotRouting.value(it.key(), AudioRouting::Mixed);
+            m_zoomClient->assignOutput(sourceName, it.value(), routing, "mono");
+        }
     }
 
     for (auto it = m_lastSyncedSlotParticipants.constBegin();
@@ -961,7 +970,7 @@ void MainWindow::syncZoomOutputAssignments()
             continue;
         const QString sourceName = sources.value(it.key());
         if (!sourceName.isEmpty())
-            m_zoomClient->assignOutput(sourceName, 0, false, "mono");
+            m_zoomClient->assignOutput(sourceName, 0, AudioRouting::Mixed, "mono");
     }
 
     m_lastSyncedSlotParticipants = current;
@@ -1747,6 +1756,30 @@ void MainWindow::onSlotClicked(int slotIndex)
     m_participantPanel->setAssignTarget(slotIndex);
     onObsLog(QString("Selected Slot %1 — click a participant to assign.")
                  .arg(slotIndex + 1));
+}
+
+void MainWindow::onSlotRoutingCycle(int slotIndex)
+{
+    if (slotIndex < 0 || slotIndex >= 8) return;
+    const AudioRouting next =
+        nextAudioRouting(m_slotRouting.value(slotIndex, AudioRouting::Mixed));
+    if (next == AudioRouting::Mixed)
+        m_slotRouting.remove(slotIndex);
+    else
+        m_slotRouting.insert(slotIndex, next);
+
+    // Repaint both canvases so the badge updates.
+    if (m_liveCanvas)  m_liveCanvas->setSlotRouting(m_slotRouting);
+    if (m_sceneCanvas) m_sceneCanvas->setSlotRouting(m_slotRouting);
+
+    // Push the new routing to the plugin. Drop the slot from the sync cache
+    // so the next call re-emits assignOutput even when the participant id
+    // hasn't changed — without this the cache would short-circuit the resend.
+    m_lastSyncedSlotParticipants.remove(slotIndex);
+    syncZoomOutputAssignments();
+
+    onObsLog(QString("Slot %1 audio routing → %2")
+                 .arg(slotIndex + 1).arg(audioRoutingLabel(next)));
 }
 
 void MainWindow::onParticipantAssignClicked(int participantId)

--- a/sidecar/src/mainwindow.h
+++ b/sidecar/src/mainwindow.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "audio-routing.h"
 #include "sidebar.h"
 #include "layout-template.h"
 #include "obs-client.h"
@@ -73,6 +74,7 @@ private slots:
     void onPhaseSelected(ShowPhase phase);
     void onSlotAssigned(int slotIndex, int participantId);
     void onSlotClicked(int slotIndex);
+    void onSlotRoutingCycle(int slotIndex);
     void onParticipantAssignClicked(int participantId);
     void onCreateLookRequested();
     void onSetBackgroundRequested();
@@ -183,6 +185,9 @@ private:
     QVector<Look>              m_customLooks;
     QStringList                m_outputSources;
     QHash<int, int>            m_lastSyncedSlotParticipants;
+    // Per-slot audio routing — driven by right-click on a slot in either
+    // canvas. Defaults to Mixed; persisted in memory only for now.
+    QHash<int, AudioRouting>   m_slotRouting;
     QStringList                m_lastScenes;
     SidecarControlServer      *m_controlServer  = nullptr;
     ZoomControlClient         *m_zoomClient     = nullptr;

--- a/sidecar/src/preview-canvas.cpp
+++ b/sidecar/src/preview-canvas.cpp
@@ -74,6 +74,12 @@ void PreviewCanvas::setOpacity(float opacity)
     update();
 }
 
+void PreviewCanvas::setSlotRouting(const QHash<int, AudioRouting> &routing)
+{
+    m_slotRouting = routing;
+    update();
+}
+
 // ── Drag-and-drop ─────────────────────────────────────────────────────────────
 
 int PreviewCanvas::slotAtPoint(QPoint pt) const
@@ -123,6 +129,13 @@ void PreviewCanvas::dropEvent(QDropEvent *e)
 
 void PreviewCanvas::mousePressEvent(QMouseEvent *e)
 {
+    if (e->button() == Qt::RightButton) {
+        const int slot = slotAtPoint(e->pos());
+        if (slot >= 0) {
+            emit slotRoutingCycleRequested(slot);
+            return;
+        }
+    }
     if (e->button() != Qt::LeftButton) { QWidget::mousePressEvent(e); return; }
     m_pressedSlot = slotAtPoint(e->pos());
     m_pressPos    = e->pos();
@@ -461,6 +474,33 @@ void PreviewCanvas::drawSlot(QPainter &p, const QRectF &rect, int idx) const
         p.setPen(QColor(0x80, 0x80, 0xa8));
         p.drawText(strip.adjusted(8, 0, -8, -4), Qt::AlignLeft | Qt::AlignBottom,
                    "Resize  ⤢");
+    }
+
+    // Audio routing badge — small pill in the slot's top-right corner.
+    // Mixed is implicit so we only paint a badge for Iso / Aud to keep the
+    // composition clean. Right-click cycles the routing.
+    const AudioRouting routing = m_slotRouting.value(idx, AudioRouting::Mixed);
+    if (routing != AudioRouting::Mixed) {
+        const QString label = audioRoutingLabel(routing);
+        const QColor fill = (routing == AudioRouting::Isolated)
+            ? QColor(0xff, 0x60, 0x40)    // iso = warm red, matches "iso" mental model
+            : QColor(0x20, 0xc4, 0x60);   // audience = green
+        QFont f = p.font();
+        f.setPointSizeF(9);
+        f.setWeight(QFont::Black);
+        f.setLetterSpacing(QFont::AbsoluteSpacing, 0.5);
+        p.setFont(f);
+        const QFontMetricsF fm(f);
+        const double w = fm.horizontalAdvance(label) + 12;
+        const double h = 18;
+        const QRectF pill(rect.right() - w - 6, rect.top() + 6, w, h);
+        QPainterPath pillPath;
+        pillPath.addRoundedRect(pill, h * 0.5, h * 0.5);
+        p.fillPath(pillPath, fill);
+        p.setPen(QPen(QColor(0, 0, 0, 80), 1));
+        p.drawPath(pillPath);
+        p.setPen(Qt::white);
+        p.drawText(pill, Qt::AlignCenter, label);
     }
 }
 

--- a/sidecar/src/preview-canvas.h
+++ b/sidecar/src/preview-canvas.h
@@ -1,7 +1,9 @@
 #pragma once
+#include "audio-routing.h"
 #include "layout-template.h"
 #include "look.h"
 #include "overlay.h"
+#include <QHash>
 #include <QWidget>
 #include <QVector>
 #include <QColor>
@@ -33,10 +35,16 @@ public:
     void setAccent(const QColor &c);
     // 1.0 = fully visible, 0.0 = black. Used by MEBus for AUTO / FTB.
     void setOpacity(float opacity);
+    // Per-slot audio routing badge. Slots missing from the map render as
+    // Mixed. Only the PVW/PGM canvas in MainWindow shows these — the badge
+    // is purely an operator affordance and does not affect rendering.
+    void setSlotRouting(const QHash<int, AudioRouting> &routing);
 
 signals:
     void slotAssigned(int slotIndex, int participantId);
     void slotClicked(int slotIndex);
+    // Right-click on a slot — used to cycle the slot's audio routing.
+    void slotRoutingCycleRequested(int slotIndex);
 
 protected:
     void paintEvent(QPaintEvent *) override;
@@ -56,6 +64,7 @@ private:
     TileStyle            m_tileStyle;
     QColor               m_accent = QColor(0x29, 0x79, 0xff);
     float                m_opacity = 1.0f;
+    QHash<int, AudioRouting> m_slotRouting;
     int                  m_hoveredSlot = -1;
     int                  m_pressedSlot = -1;
     QPoint               m_pressPos;

--- a/sidecar/src/zoom-control-client.cpp
+++ b/sidecar/src/zoom-control-client.cpp
@@ -65,7 +65,7 @@ void ZoomControlClient::refreshOutputs()
 
 void ZoomControlClient::assignOutput(const QString &sourceName,
                                      int participantId,
-                                     bool isolateAudio,
+                                     AudioRouting routing,
                                      const QString &audioChannels)
 {
     sendRequest(QJsonObject{
@@ -73,7 +73,8 @@ void ZoomControlClient::assignOutput(const QString &sourceName,
                     {"source", sourceName},
                     {"mode", "participant"},
                     {"participant_id", participantId},
-                    {"isolate_audio", isolateAudio},
+                    {"isolate_audio",  routing == AudioRouting::Isolated},
+                    {"audience_audio", routing == AudioRouting::Audience},
                     {"audio_channels", audioChannels},
                     {"video_resolution", "1080p"},
                 },

--- a/sidecar/src/zoom-control-client.h
+++ b/sidecar/src/zoom-control-client.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "audio-routing.h"
 #include "participant-panel.h"
 #include <QColor>
 #include <QJsonObject>
@@ -20,7 +21,7 @@ public:
     void refreshOutputs();
     void assignOutput(const QString &sourceName,
                       int participantId,
-                      bool isolateAudio = false,
+                      AudioRouting routing = AudioRouting::Mixed,
                       const QString &audioChannels = QStringLiteral("mono"));
 
 signals:

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -441,6 +441,7 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
         if (spotlight_slot < 1) spotlight_slot = 1;
 
         const bool isolate = req.value("isolate_audio").toBool(false);
+        const bool audience = req.value("audience_audio").toBool(false);
         const AudioChannelMode amode =
             req.value("audio_channels").toString() == "stereo"
             ? AudioChannelMode::Stereo : AudioChannelMode::Mono;
@@ -448,7 +449,7 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
 
         const bool ok = ZoomOutputManager::instance().configure_output_ex(
             source.toStdString(), mode, participant_id, spotlight_slot, failover_id,
-            isolate, amode, vres);
+            isolate, amode, vres, audience);
         write_response(socket, ok
             ? QJsonObject{{"ok", true}}
             : QJsonObject{{"ok", false}, {"error", "unknown_output"}});

--- a/src/zoom-output-manager.cpp
+++ b/src/zoom-output-manager.cpp
@@ -71,7 +71,8 @@ bool ZoomOutputManager::configure_output_ex(const std::string &source_name,
                                             uint32_t failover_participant_id,
                                             bool isolate_audio,
                                             AudioChannelMode audio_mode,
-                                            VideoResolution video_resolution)
+                                            VideoResolution video_resolution,
+                                            bool audience_audio)
 {
     std::lock_guard<std::mutex> lk(m_mtx);
     for (auto *source : m_sources) {
@@ -79,7 +80,8 @@ bool ZoomOutputManager::configure_output_ex(const std::string &source_name,
         if (source->output_name() != source_name) continue;
         source->configure_output_ex(mode, participant_id, spotlight_slot,
                                     failover_participant_id, isolate_audio,
-                                    audio_mode, video_resolution);
+                                    audio_mode, video_resolution,
+                                    audience_audio);
         return true;
     }
     return false;
@@ -104,7 +106,8 @@ bool ZoomOutputManager::configure_output(const std::string &source_name,
                                          bool active_speaker,
                                          bool isolate_audio,
                                          AudioChannelMode audio_mode,
-                                         VideoResolution video_resolution)
+                                         VideoResolution video_resolution,
+                                         bool audience_audio)
 {
     // Hold the mutex for the full operation so a source cannot be unregistered
     // (and freed) between the find and the configure call.
@@ -113,7 +116,8 @@ bool ZoomOutputManager::configure_output(const std::string &source_name,
         if (!source) continue;
         if (source->output_name() != source_name) continue;
         source->configure_output(participant_id, active_speaker,
-                                 isolate_audio, audio_mode, video_resolution);
+                                 isolate_audio, audio_mode, video_resolution,
+                                 audience_audio);
         return true;
     }
     return false;

--- a/src/zoom-output-manager.h
+++ b/src/zoom-output-manager.h
@@ -38,7 +38,8 @@ public:
                           bool active_speaker,
                           bool isolate_audio,
                           AudioChannelMode audio_mode,
-                          VideoResolution video_resolution = VideoResolution::P720);
+                          VideoResolution video_resolution = VideoResolution::P720,
+                          bool audience_audio = false);
     // Extended variant supporting ZoomISO-style assignment modes (spotlight,
     // screen share) plus failover. Returns true if the output was found.
     bool configure_output_ex(const std::string &source_name,
@@ -48,7 +49,8 @@ public:
                              uint32_t failover_participant_id,
                              bool isolate_audio,
                              AudioChannelMode audio_mode,
-                             VideoResolution video_resolution = VideoResolution::P720);
+                             VideoResolution video_resolution = VideoResolution::P720,
+                             bool audience_audio = false);
 
     // Re-send subscribe commands for all active sources after engine recovery.
     void resubscribe_all();

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -273,8 +273,11 @@ void ZoomSource::configure_output(uint32_t new_participant_id,
                                   bool new_active_speaker_mode,
                                   bool new_isolate_audio,
                                   AudioChannelMode new_audio_mode,
-                                  VideoResolution new_resolution)
+                                  VideoResolution new_resolution,
+                                  bool new_audience_audio)
 {
+    // isolate wins if both somehow got requested — mirrors apply_settings().
+    if (new_isolate_audio) new_audience_audio = false;
     if (source) {
         obs_data_t *settings = obs_source_get_settings(source);
         const AssignmentMode mode = new_active_speaker_mode
@@ -284,6 +287,7 @@ void ZoomSource::configure_output(uint32_t new_participant_id,
         obs_data_set_int(settings, PROP_PARTICIPANT_ID, new_participant_id);
         obs_data_set_bool(settings, PROP_ACTIVE_SPEAKER, new_active_speaker_mode);
         obs_data_set_bool(settings, PROP_ISOLATE_AUDIO, new_isolate_audio);
+        obs_data_set_bool(settings, PROP_AUDIENCE_AUDIO, new_audience_audio);
         obs_data_set_int(settings, PROP_AUDIO_CHANNELS,
                          new_audio_mode == AudioChannelMode::Stereo
                          ? AUDIO_CH_STEREO : AUDIO_CH_MONO);
@@ -301,6 +305,7 @@ void ZoomSource::configure_output(uint32_t new_participant_id,
     participant_id = new_participant_id;
     active_speaker_mode = new_active_speaker_mode;
     isolate_audio = new_isolate_audio;
+    audience_audio = new_audience_audio;
     audio_mode = new_audio_mode;
     resolution = new_resolution;
     if (m_subscribed) subscribe();
@@ -312,8 +317,10 @@ void ZoomSource::configure_output_ex(AssignmentMode mode,
                                      uint32_t new_failover_participant_id,
                                      bool new_isolate_audio,
                                      AudioChannelMode new_audio_mode,
-                                     VideoResolution new_resolution)
+                                     VideoResolution new_resolution,
+                                     bool new_audience_audio)
 {
+    if (new_isolate_audio) new_audience_audio = false;
     const bool active_speaker = (mode == AssignmentMode::ActiveSpeaker);
     if (source) {
         obs_data_t *settings = obs_source_get_settings(source);
@@ -323,6 +330,7 @@ void ZoomSource::configure_output_ex(AssignmentMode mode,
         obs_data_set_int(settings, PROP_SPOTLIGHT_SLOT, new_spotlight_slot);
         obs_data_set_int(settings, PROP_FAILOVER_PARTICIPANT, new_failover_participant_id);
         obs_data_set_bool(settings, PROP_ISOLATE_AUDIO, new_isolate_audio);
+        obs_data_set_bool(settings, PROP_AUDIENCE_AUDIO, new_audience_audio);
         obs_data_set_int(settings, PROP_AUDIO_CHANNELS,
                          new_audio_mode == AudioChannelMode::Stereo
                          ? AUDIO_CH_STEREO : AUDIO_CH_MONO);
@@ -339,6 +347,7 @@ void ZoomSource::configure_output_ex(AssignmentMode mode,
     spotlight_slot.store(new_spotlight_slot, std::memory_order_release);
     failover_participant_id.store(new_failover_participant_id, std::memory_order_release);
     isolate_audio = new_isolate_audio;
+    audience_audio = new_audience_audio;
     audio_mode = new_audio_mode;
     resolution = new_resolution;
     if (m_subscribed) subscribe();

--- a/src/zoom-source.h
+++ b/src/zoom-source.h
@@ -53,7 +53,8 @@ struct ZoomSource {
                           bool new_active_speaker_mode,
                           bool new_isolate_audio,
                           AudioChannelMode new_audio_mode,
-                          VideoResolution new_resolution = VideoResolution::P720);
+                          VideoResolution new_resolution = VideoResolution::P720,
+                          bool new_audience_audio = false);
     // Extended variant accepting full ZoomISO-style assignment information.
     void configure_output_ex(AssignmentMode mode,
                              uint32_t new_participant_id,
@@ -61,7 +62,8 @@ struct ZoomSource {
                              uint32_t new_failover_participant_id,
                              bool new_isolate_audio,
                              AudioChannelMode new_audio_mode,
-                             VideoResolution new_resolution = VideoResolution::P720);
+                             VideoResolution new_resolution = VideoResolution::P720,
+                             bool new_audience_audio = false);
     void subscribe();
     void unsubscribe();
     void activate();


### PR DESCRIPTION
This PR introduces per-slot audio routing control, allowing operators to cycle between three audio modes for each output: Mixed (full meeting mix), Isolated (single participant), and Audience (residual active speakers).

## Summary
Adds a new audio routing system that lets operators right-click on output slots to cycle through audio routing modes. The routing state is displayed as a colored badge on each slot and is communicated to the Zoom plugin via the control protocol.

## Key Changes

- **New audio routing enum and utilities** (`audio-routing.h`):
  - `AudioRouting` enum with three states: Mixed, Isolated, Audience
  - Helper functions for labels, badges, and cycling to the next state

- **UI enhancements** (`preview-canvas`):
  - Right-click on a slot now cycles its audio routing mode
  - Visual badge in slot's top-right corner shows current routing (colored pill with "Iso"/"Aud" label; Mixed is implicit)
  - Isolated = warm red (#ff6040), Audience = green (#20c460)

- **MainWindow integration**:
  - New `m_slotRouting` hash tracks per-slot audio routing state
  - `onSlotRoutingCycle()` handler manages state transitions and syncs with plugin
  - Routing state persisted in memory (not yet saved to disk)

- **Plugin communication** (`zoom-control-client`, `zoom-control-server`):
  - Updated `assignOutput()` to accept `AudioRouting` enum instead of boolean
  - Protocol now sends both `isolate_audio` and `audience_audio` flags to plugin
  - Isolate takes precedence if both somehow requested

- **Source configuration** (`zoom-source`, `zoom-output-manager`):
  - Extended `configure_output()` and `configure_output_ex()` to accept `audience_audio` parameter
  - New `PROP_AUDIENCE_AUDIO` property set on sources
  - Audience mode properly handled alongside existing isolate mode

## Implementation Details

- Right-click cycles: Mixed → Isolated → Audience → Mixed
- Mixed mode is the default and doesn't display a badge to keep UI clean
- Routing state is dropped from sync cache on change to force plugin re-sync even when participant ID unchanged
- Status messages logged for each routing change

https://claude.ai/code/session_01LnArHejR82ozFukTJPmqfR