### PR TITLE
[codex] Simplify Zoom join auth around ZAK

### DIFF
--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -678,6 +678,51 @@ public:
 #endif
     }
 
+    void set_host_start_fallback(uint64_t meeting_number,
+                                 const std::string &display_name,
+                                 const std::string &user_zak)
+    {
+        m_host_start_attempted = false;
+        m_host_start_meeting_number = meeting_number;
+        m_host_start_name = to_zstr(display_name);
+        m_host_start_zak = to_zstr(user_zak);
+    }
+
+    void clear_host_start_fallback()
+    {
+        m_host_start_attempted = false;
+        m_host_start_meeting_number = 0;
+        m_host_start_name.clear();
+        m_host_start_zak.clear();
+    }
+
+    bool try_host_start_after_external_join_failure()
+    {
+        if (m_host_start_attempted || m_host_start_meeting_number == 0 ||
+            m_host_start_zak.empty() || !m_meeting_svc || !*m_meeting_svc) {
+            return false;
+        }
+        m_host_start_attempted = true;
+
+        ZOOMSDK::StartParam sp;
+        sp.userType = ZOOMSDK::SDK_UT_WITHOUT_LOGIN;
+        ZOOMSDK::StartParam4WithoutLogin &p = sp.param.withoutloginStart;
+        p.meetingNumber = m_host_start_meeting_number;
+        p.userZAK = m_host_start_zak.c_str();
+        p.userName = m_host_start_name.empty() ? nullptr : m_host_start_name.c_str();
+        p.zoomuserType = ZOOMSDK::ZoomUserType_APIUSER;
+        p.isVideoOff = true;
+        p.isAudioOff = false;
+        p.isMyVoiceInMix = true;
+        p.eAudioRawdataSamplingRate = ZOOMSDK::AudioRawdataSamplingRate_48K;
+        p.eVideoRawdataColorspace = ZOOMSDK::VideoRawdataColorspace_BT709_F;
+
+        const ZOOMSDK::SDKError err = (*m_meeting_svc)->Start(sp);
+        EngineIpc::write(R"({"cmd":"debug","stage":"host_start_after_external_join_failure","code":)" +
+                         std::to_string(static_cast<int>(err)) + "}");
+        return err == ZOOMSDK::SDKERR_SUCCESS;
+    }
+
     void stop_raw_media(const char *reason)
     {
         m_raw_media_requested = false;
@@ -800,6 +845,12 @@ public:
             EngineIpc::write( R"({"cmd":"left"})");
             break;
         case ZOOMSDK::MEETING_STATUS_FAILED:
+            if (iResult == ZOOMSDK::MEETING_FAIL_UNABLE_TO_JOIN_EXTERNAL_MEETING &&
+                try_host_start_after_external_join_failure()) {
+                EngineIpc::write(
+                    R"({"cmd":"debug","stage":"external_join_failed_retrying_host_start"})");
+                break;
+            }
             EngineAudio::instance().reset_subscription("meeting_failed");
             if (m_participants) m_participants->detach();
             EngineIpc::write( R"({"cmd":"error","msg":"meeting_failed","code":)" +
@@ -929,6 +980,10 @@ private:
     EngineVideo *m_video_engine = nullptr;
     bool m_raw_media_requested = false;
     bool m_raw_media_active = false;
+    bool m_host_start_attempted = false;
+    uint64_t m_host_start_meeting_number = 0;
+    std::basic_string<zchar_t> m_host_start_name;
+    std::basic_string<zchar_t> m_host_start_zak;
 };
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -1064,6 +1119,10 @@ int main()
                     EngineIpc::write( R"({"cmd":"error","msg":"invalid_meeting_id"})");
                     continue;
                 }
+                if (!user_zak.empty())
+                    meeting_event.set_host_start_fallback(meeting_number, display_name, user_zak);
+                else
+                    meeting_event.clear_host_start_fallback();
 
                 ZOOMSDK::JoinParam jp;
                 jp.userType = ZOOMSDK::SDK_UT_WITHOUT_LOGIN;

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -375,6 +375,37 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
         tokens.app_privilege_token = req.value("app_privilege_token").toString(
             QString::fromStdString(parsed.app_privilege_token)).toStdString();
         ZoomPluginSettings settings = ZoomPluginSettings::load();
+        const bool needs_oauth_zak =
+            tokens.user_zak.empty() &&
+            tokens.on_behalf_token.empty();
+        if (needs_oauth_zak) {
+            if (settings.oauth_access_token.empty() &&
+                settings.oauth_refresh_token.empty()) {
+                write_response(socket, {
+                    {"ok", false},
+                    {"error", "zoom_auth_required"},
+                    {"message", "Sign in with Zoom before joining meetings that require owner/host context."},
+                });
+                return;
+            }
+
+            std::string zak;
+            QString zak_error;
+            if (!ZoomOAuthManager::instance().fetch_zak_blocking(zak, parsed.meeting_id, &zak_error)) {
+                blog(LOG_WARNING, "[obs-zoom-plugin] Control join OAuth ZAK fetch failed: %s",
+                     zak_error.toUtf8().constData());
+                write_response(socket, {
+                    {"ok", false},
+                    {"error", "zoom_zak_unavailable"},
+                    {"message", zak_error.isEmpty()
+                        ? QStringLiteral("Could not fetch Zoom ZAK.")
+                        : zak_error},
+                });
+                return;
+            }
+            tokens.user_zak = zak;
+            blog(LOG_INFO, "[obs-zoom-plugin] Control join fetched OAuth ZAK for Meeting SDK join");
+        }
 
         const bool ok =
             ZoomEngineClient::instance().start(settings.resolved_jwt_token()) &&

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -63,6 +63,13 @@ static constexpr int kThumbW = 80;
 static constexpr int kThumbH = 45;
 static constexpr int kRowH   = 50;
 
+static std::string redacted_tail(const std::string &value)
+{
+    if (value.empty()) return "empty";
+    if (value.size() <= 4) return "****";
+    return "****" + value.substr(value.size() - 4);
+}
+
 static QString plugin_binary_dir()
 {
 #if defined(Q_OS_WIN)
@@ -374,18 +381,29 @@ ZoomDock::ZoomDock(QWidget *parent)
     m_display_name->setPlaceholderText("Display name");
 
     m_join_token_type = new QComboBox(join_group);
-    m_join_token_type->addItem("OBF / on-behalf token", "on_behalf_token");
+    m_join_token_type->addItem("Auto Zoom sign-in / ZAK", "auto_zak");
     m_join_token_type->addItem("User ZAK", "user_zak");
     m_join_token_type->addItem("App privilege token", "app_privilege_token");
     m_join_token_type->setToolTip(
-        "External-account meetings can require a Zoom user attribution token.");
+        "Use Auto. App privilege tokens are only for raw media permission; "
+        "CoreVideo will still use Zoom sign-in/ZAK for the meeting join.");
 
     m_join_token = new QLineEdit(join_group);
-    m_join_token->setPlaceholderText("External meeting token (optional)");
+    m_join_token->setPlaceholderText("Automatic from Zoom sign-in");
     m_join_token->setEchoMode(QLineEdit::Password);
     m_join_token->setToolTip(
-        "Paste the OBF/on-behalf token, ZAK, or app privilege token for "
-        "meetings that reject anonymous external SDK joins.");
+        "Paste a user ZAK only when Zoom support provides one. Paste an app "
+        "privilege token only for raw media permission.");
+    m_join_token->setEnabled(false);
+    connect(m_join_token_type, &QComboBox::currentIndexChanged, this, [this]() {
+        const bool manual =
+            m_join_token_type &&
+            m_join_token_type->currentData().toString() != "auto_zak";
+        m_join_token->setEnabled(manual);
+        m_join_token->setPlaceholderText(
+            manual ? QStringLiteral("Paste ZAK or app privilege token")
+                   : QStringLiteral("Automatic from Zoom sign-in"));
+    });
 
     m_join_btn  = new QPushButton("Join",  join_group);
     m_leave_btn = new QPushButton("Leave", join_group);
@@ -958,8 +976,20 @@ void ZoomDock::on_join_clicked()
     tokens.user_zak = parsed.user_zak;
     tokens.app_privilege_token = parsed.app_privilege_token;
     const std::string typed_token = m_join_token->text().trimmed().toStdString();
-    if (!typed_token.empty() && m_join_token_type) {
-        const QString token_type = m_join_token_type->currentData().toString();
+    const QString token_type = m_join_token_type
+        ? m_join_token_type->currentData().toString()
+        : QStringLiteral("auto_zak");
+    const bool manual_token_mode = token_type != "auto_zak";
+    if (manual_token_mode && typed_token.empty() &&
+        tokens.on_behalf_token.empty() &&
+        tokens.user_zak.empty() &&
+        tokens.app_privilege_token.empty()) {
+        QMessageBox::warning(this, "Zoom Join Token",
+            "A manual token type was selected, but the token field is empty. "
+            "Use Auto Zoom sign-in / ZAK, or paste the selected token before joining.");
+        return;
+    }
+    if (!typed_token.empty()) {
         if (token_type == "user_zak") {
             tokens.user_zak = typed_token;
         } else if (token_type == "app_privilege_token") {
@@ -976,6 +1006,38 @@ void ZoomDock::on_join_clicked()
             "This CoreVideo build does not have Zoom Meeting SDK credentials "
             "configured. Rebuild with embedded SDK credentials or restore a "
             "valid SDK JWT before joining.");
+        return;
+    }
+
+    const bool needs_oauth_zak =
+        tokens.user_zak.empty() &&
+        tokens.on_behalf_token.empty();
+    blog(LOG_INFO,
+         "[obs-zoom-plugin] Zoom join token mode=%s zak_needed=%d typed_token=%d parsed_obf=%d parsed_zak=%d parsed_app=%d app_privilege_present=%d sdk_key=%s oauth_client_id=%s oauth_scopes=\"%s\"",
+         token_type.toUtf8().constData(),
+         needs_oauth_zak ? 1 : 0,
+         typed_token.empty() ? 0 : 1,
+         parsed.on_behalf_token.empty() ? 0 : 1,
+         parsed.user_zak.empty() ? 0 : 1,
+         parsed.app_privilege_token.empty() ? 0 : 1,
+         tokens.app_privilege_token.empty() ? 0 : 1,
+         redacted_tail(s.sdk_key).c_str(),
+         redacted_tail(s.oauth_client_id).c_str(),
+         s.oauth_scopes.c_str());
+    if (needs_oauth_zak &&
+        s.oauth_access_token.empty() &&
+        s.oauth_refresh_token.empty()) {
+        QString error;
+        if (!ZoomOAuthManager::instance().begin_authorization(this, &error)) {
+            QMessageBox::warning(this, "Zoom Authentication",
+                error.isEmpty()
+                    ? QStringLiteral("Sign in with Zoom before joining meetings that require owner/host context.")
+                    : error);
+            return;
+        }
+        start_pending_oauth_join();
+        QMessageBox::information(this, "Zoom Authentication",
+            "Zoom sign-in was opened in your browser. After authorization completes, CoreVideo will retry this join.");
         return;
     }
 
@@ -997,6 +1059,32 @@ void ZoomDock::on_join_clicked()
     m_join_thread = std::thread([self, alive, jwt, meeting_id, passcode,
                                  display_name, kind, webinar, join_generation,
                                  tokens]() mutable {
+        if (tokens.user_zak.empty() &&
+            tokens.on_behalf_token.empty()) {
+            std::string zak;
+            QString zak_error;
+            if (ZoomOAuthManager::instance().fetch_zak_blocking(zak, meeting_id, &zak_error)) {
+                tokens.user_zak = zak;
+                blog(LOG_INFO, "[obs-zoom-plugin] Zoom OAuth ZAK fetched for Meeting SDK join");
+            } else {
+                blog(LOG_WARNING, "[obs-zoom-plugin] Zoom OAuth ZAK fetch failed: %s",
+                     zak_error.toUtf8().constData());
+                QMetaObject::invokeMethod(self, [self, alive, zak_error, join_generation]() {
+                    if (!alive->load(std::memory_order_acquire)) return;
+                    if (self->m_join_generation.load(std::memory_order_acquire) != join_generation)
+                        return;
+                    self->m_join_in_progress.store(false, std::memory_order_release);
+                    ZoomEngineClient::instance().set_state(MeetingState::Failed);
+                    QMessageBox::warning(self, "Zoom Authentication",
+                        zak_error.isEmpty()
+                            ? QStringLiteral("Could not fetch Zoom ZAK. Sign in with Zoom and try again.")
+                            : zak_error);
+                    self->update_state_indicator();
+                }, Qt::QueuedConnection);
+                return;
+            }
+        }
+
         const bool started = ZoomEngineClient::instance().start(jwt);
         const bool still_current =
             self->m_join_generation.load(std::memory_order_acquire) == join_generation;

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -47,8 +47,10 @@ static std::string zoom_error_message(const QJsonObject &obj)
 
     if (msg == "meeting_failed") {
         if (code == 63) {
-            return "Zoom rejected the join: external meetings require a published "
-                   "Meeting SDK app or Zoom approval. (63 "
+            return "Zoom rejected the join: the signed-in Zoom user/ZAK was "
+                   "sent, but this external meeting still requires the "
+                   "Meeting SDK app/client ID to be published or approved by "
+                   "Zoom for that host account. (63 "
                    "MEETING_FAIL_UNABLE_TO_JOIN_EXTERNAL_MEETING)";
         }
         if (code == 505) {

--- a/src/zoom-oauth.cpp
+++ b/src/zoom-oauth.cpp
@@ -386,8 +386,12 @@ bool ZoomOAuthManager::refresh_access_token_blocking(QString *error)
     return parse_token_response(result.response, error);
 }
 
-bool ZoomOAuthManager::fetch_zak_blocking(std::string &zak, QString *error)
+bool ZoomOAuthManager::fetch_zak_blocking(std::string &zak,
+                                          const std::string &meeting_id,
+                                          QString *error)
 {
+    Q_UNUSED(meeting_id);
+
     ZoomPluginSettings s = ZoomPluginSettings::load();
     if (s.oauth_access_token.empty() || s.oauth_client_id.empty())
         return false;
@@ -409,10 +413,10 @@ bool ZoomOAuthManager::fetch_zak_blocking(std::string &zak, QString *error)
     QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
     loop.exec();
 
-    const QByteArray response = reply->readAll();
-    const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    const QNetworkReply::NetworkError net_error = reply->error();
-    const QString net_error_string = reply->errorString();
+    QByteArray response = reply->readAll();
+    int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    QNetworkReply::NetworkError net_error = reply->error();
+    QString net_error_string = reply->errorString();
     reply->deleteLater();
 
     if (net_error != QNetworkReply::NoError || status < 200 || status >= 300) {

--- a/src/zoom-oauth.h
+++ b/src/zoom-oauth.h
@@ -16,7 +16,9 @@ public:
     bool handle_redirect_url(const QString &url, QString *error = nullptr);
     bool register_url_scheme(QString *error = nullptr);
     bool refresh_access_token_blocking(QString *error = nullptr);
-    bool fetch_zak_blocking(std::string &zak, QString *error = nullptr);
+    bool fetch_zak_blocking(std::string &zak,
+                            const std::string &meeting_id = {},
+                            QString *error = nullptr);
 
 private:
     explicit ZoomOAuthManager(QObject *parent = nullptr);

--- a/src/zoom-osc-server.cpp
+++ b/src/zoom-osc-server.cpp
@@ -268,8 +268,7 @@ void ZoomOscServer::dispatch(const QString &address,
         tokens.app_privilege_token = parsed.app_privilege_token;
         const bool needs_oauth_zak =
             tokens.user_zak.empty() &&
-            tokens.on_behalf_token.empty() &&
-            tokens.app_privilege_token.empty();
+            tokens.on_behalf_token.empty();
         const ZoomPluginSettings settings = ZoomPluginSettings::load();
         if (needs_oauth_zak &&
             settings.oauth_access_token.empty() &&
@@ -281,7 +280,7 @@ void ZoomOscServer::dispatch(const QString &address,
         if (needs_oauth_zak) {
             std::string zak;
             QString zak_error;
-            if (ZoomOAuthManager::instance().fetch_zak_blocking(zak, &zak_error))
+            if (ZoomOAuthManager::instance().fetch_zak_blocking(zak, parsed.meeting_id, &zak_error))
                 tokens.user_zak = zak;
             else {
                 if (zak_error.isEmpty())


### PR DESCRIPTION
## Summary

- Removes OBF from the normal OBS join UI and makes Auto Zoom sign-in / ZAK the default path.
- Ensures app privilege tokens do not replace the authenticated user ZAK for external meeting joins.
- Fetches ZAK directly from `/users/me/zak` to avoid unnecessary `user:read:token` scope churn while Marketplace approval is pending.
- Improves diagnostics and the Zoom error 63 message so approval/client-ID issues are clearer.

## Validation

- Built `obs-zoom-plugin` and `ZoomObsEngine` with CMake/NMake.
- Ran `ctest --test-dir build-nmake -C Release --output-on-failure -R 'CoreVideo(Sidecar|Join|OAuth|Settings|Obs)'`.
- Applied on top of latest `origin/main` (`9ce4522`) with no merge conflicts.