### PR TITLE
build(windows): enable FFmpeg HW accel in CI; diagnose elsewhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,21 @@ jobs:
               Move-Item $inner.FullName third_party/zoom-sdk
           }
 
+      - name: Download FFmpeg (LGPL shared) for HW acceleration
+        shell: powershell
+        run: |
+          # BtbN publishes LGPL shared builds at a "latest" tag that's
+          # refreshed regularly. LGPL is required for binary redistribution.
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
+          Invoke-WebRequest $url -OutFile ffmpeg.zip
+          Expand-Archive ffmpeg.zip C:\ffmpeg-extract -Force
+          # Zip contains a single nested directory; promote it to C:\ffmpeg
+          $inner = Get-ChildItem C:\ffmpeg-extract -Directory | Select-Object -First 1
+          Move-Item $inner.FullName C:\ffmpeg
+          Write-Host "FFmpeg installed at C:\ffmpeg"
+          Get-ChildItem C:\ffmpeg\bin -Filter "*.dll" | Select-Object Name,Length |
+              Format-Table -AutoSize
+
       - name: Diagnose OBS SDK layout
         if: always()
         shell: powershell
@@ -146,6 +161,8 @@ jobs:
               -G "Visual Studio 17 2022" -A x64 `
               -DCMAKE_BUILD_TYPE=Release `
               -DZOOM_SDK_DIR=third_party/zoom-sdk `
+              -DENABLE_FFMPEG_HW_ACCEL=ON `
+              "-DFFMPEG_ROOT=C:/ffmpeg" `
               "-DCMAKE_PREFIX_PATH=$obsDir;$env:QT_ROOT_DIR" `
               "-DLibObs_DIR=$obsLibs" `
               "-Dobs-frontend-api_DIR=$obsFe" `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,36 @@ option(ENABLE_FFMPEG_HW_ACCEL
     OFF)
 
 if(ENABLE_FFMPEG_HW_ACCEL)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
-        libavfilter>=7
-        libavutil>=57
-    )
+    # Two ways to find FFmpeg:
+    #  (a) FFMPEG_ROOT pointing at a prebuilt dev tree with include/, lib/,
+    #      bin/ — used on Windows where pkg-config isn't standard.
+    #  (b) pkg-config (libavfilter / libavutil) — Linux + Homebrew on macOS.
+    if(DEFINED FFMPEG_ROOT AND EXISTS "${FFMPEG_ROOT}")
+        find_path(COREVIDEO_AVFILTER_INC libavfilter/avfilter.h
+            HINTS "${FFMPEG_ROOT}/include" REQUIRED NO_DEFAULT_PATH)
+        find_library(COREVIDEO_AVFILTER_LIB
+            NAMES avfilter avfilter-10 avfilter-9 avfilter-8
+            HINTS "${FFMPEG_ROOT}/lib" REQUIRED NO_DEFAULT_PATH)
+        find_library(COREVIDEO_AVUTIL_LIB
+            NAMES avutil avutil-59 avutil-58 avutil-57
+            HINTS "${FFMPEG_ROOT}/lib" REQUIRED NO_DEFAULT_PATH)
+        add_library(corevideo_ffmpeg INTERFACE)
+        target_include_directories(corevideo_ffmpeg INTERFACE
+            "${COREVIDEO_AVFILTER_INC}")
+        target_link_libraries(corevideo_ffmpeg INTERFACE
+            "${COREVIDEO_AVFILTER_LIB}" "${COREVIDEO_AVUTIL_LIB}")
+        set(COREVIDEO_FFMPEG_TARGET corevideo_ffmpeg)
+        set(COREVIDEO_FFMPEG_BIN_DIR "${FFMPEG_ROOT}/bin")
+        message(STATUS "FFmpeg HW accel: using FFMPEG_ROOT=${FFMPEG_ROOT}")
+    else()
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
+            libavfilter>=7
+            libavutil>=57
+        )
+        set(COREVIDEO_FFMPEG_TARGET PkgConfig::FFMPEG)
+        message(STATUS "FFmpeg HW accel: using pkg-config")
+    endif()
 endif()
 
 set(ZOOM_SDK_DIR "third_party/zoom-sdk" CACHE PATH "Zoom Meeting SDK directory")
@@ -196,8 +221,24 @@ if(COREVIDEO_BUILD_PLUGIN)
     endif()
 
     if(ENABLE_FFMPEG_HW_ACCEL)
-        target_link_libraries(obs-zoom-plugin PRIVATE PkgConfig::FFMPEG)
+        target_link_libraries(obs-zoom-plugin PRIVATE ${COREVIDEO_FFMPEG_TARGET})
         target_compile_definitions(obs-zoom-plugin PRIVATE COREVIDEO_HW_ACCEL)
+        # Ship the FFmpeg runtime DLLs alongside the plugin on Windows so
+        # OBS's plugin loader can resolve avfilter / avutil / avcodec /
+        # swscale / swresample without polluting PATH.
+        if(WIN32 AND COREVIDEO_FFMPEG_BIN_DIR AND EXISTS "${COREVIDEO_FFMPEG_BIN_DIR}")
+            file(GLOB COREVIDEO_FFMPEG_DLLS "${COREVIDEO_FFMPEG_BIN_DIR}/*.dll")
+            if(COREVIDEO_FFMPEG_DLLS)
+                add_custom_command(TARGET obs-zoom-plugin POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        ${COREVIDEO_FFMPEG_DLLS}
+                        "$<TARGET_FILE_DIR:obs-zoom-plugin>"
+                    COMMENT "Copying FFmpeg runtime DLLs for obs-zoom-plugin")
+            endif()
+            install(DIRECTORY "${COREVIDEO_FFMPEG_BIN_DIR}/"
+                DESTINATION "obs-plugins/64bit"
+                FILES_MATCHING PATTERN "*.dll")
+        endif()
     endif()
 
     if(APPLE)

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -143,6 +143,11 @@ MODULE_EXPORT const char *obs_module_description(void)
 bool obs_module_load(void)
 {
     blog(LOG_INFO, "[obs-zoom-plugin] Loading plugin v%s", OBS_ZOOM_PLUGIN_VERSION);
+#ifdef COREVIDEO_HW_ACCEL
+    blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: enabled at build (FFmpeg)");
+#else
+    blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: disabled (built without ENABLE_FFMPEG_HW_ACCEL — CPU path only)");
+#endif
     configure_qt_plugin_paths();
 
 #if !defined(WIN32)

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -1014,6 +1014,7 @@ static obs_properties_t *zoom_source_get_properties(void *data)
     obs_property_t *hw = obs_properties_add_list(props, PROP_HW_ACCEL_MODE,
         obs_module_text("ZoomSource.HwAccelMode"),
         OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+#ifdef COREVIDEO_HW_ACCEL
     obs_property_list_add_int(hw, obs_module_text("ZoomSource.HwAccelGlobal"),  -1);
     obs_property_list_add_int(hw, obs_module_text("ZoomSource.HwAccelNone"),
                               static_cast<int>(HwAccelMode::None));
@@ -1027,6 +1028,17 @@ static obs_properties_t *zoom_source_get_properties(void *data)
                               static_cast<int>(HwAccelMode::VideoToolbox));
     obs_property_list_add_int(hw, obs_module_text("ZoomSource.HwAccelQsv"),
                               static_cast<int>(HwAccelMode::Qsv));
+#else
+    // Plugin compiled without ENABLE_FFMPEG_HW_ACCEL — no backend can run.
+    // Show a single read-only entry and disable the control so the operator
+    // doesn't pick a mode that will silently fall back to CPU.
+    obs_property_list_add_int(hw, "Unavailable (build without ENABLE_FFMPEG_HW_ACCEL)",
+                              static_cast<int>(HwAccelMode::None));
+    obs_property_set_enabled(hw, false);
+    obs_property_set_long_description(hw,
+        "Rebuild the plugin with -DENABLE_FFMPEG_HW_ACCEL=ON and FFmpeg "
+        "dev libraries present to enable hardware video conversion.");
+#endif
 
     obs_properties_add_button(props, "btn_refresh",
         obs_module_text("ZoomSource.RefreshParticipants"),


### PR DESCRIPTION
The released Windows binary was built with ENABLE_FFMPEG_HW_ACCEL=OFF, so HwVideoPipeline compiled as a stub and the Settings dropdown was correctly greyed out at "Disabled (CPU only)" — there was no way for the user to actually pick a backend.

CI now ships HW accel on Windows:

* CMakeLists gains an FFMPEG_ROOT fallback. When set, it uses find_path/find_library against a prebuilt dev tree (the path Windows takes) instead of pkg-config (which isn't standard there). Linux + macOS keep using pkg-config.

* Plugin link rule uses ${COREVIDEO_FFMPEG_TARGET} so either backend works. On Windows we also copy the FFmpeg runtime DLLs next to obs-zoom-plugin.dll (post-build for local runs, install rule for packaging) so OBS's loader resolves them without PATH games.

* Windows workflow grabs BtbN's LGPL-shared FFmpeg ("latest" tag — LGPL is required for redistribution), extracts to C:\ffmpeg, and passes -DENABLE_FFMPEG_HW_ACCEL=ON -DFFMPEG_ROOT=C:/ffmpeg.

Plus two diagnostic fixes that ship regardless of platform:

* Per-source HW Accel dropdown is now disabled (with a help tooltip) when COREVIDEO_HW_ACCEL isn't defined, matching the global Settings dialog. Stops operators from picking CUDA and getting silent CPU.

* Plugin load logs whether HW accel was compiled in. Lets us tell from an OBS log file alone whether the binary supports it.

macOS CI still has HW accel off — that's a separate follow-up needing brew ffmpeg + dylib bundling.

https://claude.ai/code/session_01LnArHejR82ozFukTJPmqfR