### PR TITLE
Make Zoom OAuth a build-time Marketplace integration (public PKCE only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Guide: **[Core Plugin Guide & Examples ->](https://corevideo.iamfatness.us/core-
 - **Output profiles** - save and load named participant-to-source mappings as JSON files
 - **Output manager dock** - dockable OBS panel and API for viewing and reconfiguring all sources at runtime
 - **JWT generation** - CoreVideo generates Meeting SDK JWTs locally from key+secret; manual override available
-- **Zoom OAuth PKCE** - user-level OAuth 2.0 with PKCE for attributed joins and Marketplace compliance; fetches a short-lived ZAK via `GET /v2/users/me/zak`; `corevideo://` custom URL scheme with platform callback helpers (`CoreVideoOAuthCallback.exe` / `.app`); DPAPI token protection on Windows; confidential client mode supported
+- **Zoom OAuth PKCE** - user-level OAuth 2.0 with PKCE (public client, no secret) for attributed joins and Marketplace compliance; the Public Client ID is baked in at build time via `ZOOM_EMBED_OAUTH_CLIENT_ID`; fetches a short-lived ZAK via `GET /v2/users/me/token?type=zak`; `corevideo://` custom URL scheme with platform callback helpers (`CoreVideoOAuthCallback.exe` / `.app`); DPAPI token protection on Windows
 - **SDK 5.17.x and 7.x** - auto-detects flat and subfolder header layouts
 - **Hardened security** - constant-time token comparison, validated IPC input, sanitised participant IDs, SIGPIPE handling
 - **Modern UI** - CoreVideo stylesheet with dark theme, animated `CvStatusDot`, `CvBanner` first-run notices, and button role variants (primary / danger)
@@ -178,22 +178,28 @@ To verify an already-created scene graph without creating or modifying sources:
 .\scripts\obs-scene-smoke-test.ps1 -AuditOnly -SceneName "CoreVideo Smoke Test"
 ```
 
-5. **Set up OAuth (for Marketplace / external-account joins)** - in the Settings dialog, enter your OAuth Client ID, set the Redirect URI to `corevideo://oauth/callback`, click **Register corevideo:// URL Scheme**, then click **Authorize with Zoom**. See [`docs/ZOOM_MARKETPLACE_OAUTH.md`](docs/ZOOM_MARKETPLACE_OAUTH.md) for the full walkthrough.
+5. **Set up OAuth (for Marketplace / external-account joins)** - publishers configure this once at build time with `-DZOOM_EMBED_OAUTH_CLIENT_ID=<your_public_client_id>`. End users just open the Settings dialog and click **Sign in with Zoom**. See [`docs/ZOOM_MARKETPLACE_OAUTH.md`](docs/ZOOM_MARKETPLACE_OAUTH.md) for the full walkthrough.
 
 6. **Join once, then assign outputs** - use the CoreVideo dock or the TCP/OSC control APIs to join the meeting once per OBS session. Then add **Zoom Participant**, **Zoom Participant Audio**, **Zoom Share**, or **Zoom Interpretation Audio** sources and assign them to participants or dynamic roles.
 
 ## Zoom OAuth PKCE
 
-CoreVideo supports user-level OAuth 2.0 with PKCE for attributed meeting joins and Zoom App Marketplace compliance. This is required when joining meetings hosted by accounts other than the SDK account.
+CoreVideo uses user-level OAuth 2.0 with PKCE (public client, no secret) for attributed meeting joins and Zoom App Marketplace compliance. This is required when joining meetings hosted by accounts other than the SDK account. Confidential OAuth is intentionally not supported at runtime: a desktop binary can't hide a client secret.
+
+### Build-time configuration (publisher, one-time)
+Pass the Marketplace app's Public Client ID at CMake configure time:
+```
+cmake -B build -DZOOM_EMBED_OAUTH_CLIENT_ID=<your_public_client_id> ...
+```
+The value is compiled into `kEmbeddedOAuthClientId` and used as the default for every install of that build. There is no UI for entering it.
 
 ### Flow
-1. In **Tools -> Zoom Plugin Settings**, enter the OAuth Client ID (and optionally Client Secret for confidential/test apps). Set Redirect URI to `corevideo://oauth/callback`.
-2. Click **Register corevideo:// URL Scheme** - registers the scheme in the OS so the callback helper can intercept the redirect.
-3. Click **Authorize with Zoom** - opens the browser with a PKCE authorization request (S256 code challenge, high-entropy verifier, state CSRF token).
-4. Zoom redirects to `corevideo://oauth/callback?code=...&state=...`.
-5. `CoreVideoOAuthCallback.exe` (Windows) or `CoreVideoOAuthCallback.app` (macOS) forwards the URL to the plugin via the TCP control server (`oauth_callback` command).
-6. The plugin verifies state, exchanges the code at `https://zoom.us/oauth/token`, and persists access + refresh tokens. On Windows, tokens are DPAPI-protected before storage.
-7. Before each meeting join, CoreVideo refreshes the token if needed and fetches a ZAK from `GET /v2/users/me/zak`. The ZAK is passed into the SDK `JoinParam4WithoutLogin`.
+1. In **Tools -> Zoom Plugin Settings**, click **Authorize with Zoom** (no IDs to enter). The plugin registers the `corevideo://` URL scheme automatically on first use.
+2. The browser opens with a PKCE authorization request (S256 code challenge, high-entropy verifier, state CSRF token).
+3. Zoom redirects to `corevideo://oauth/callback?code=...&state=...`.
+4. `CoreVideoOAuthCallback.exe` (Windows) or `CoreVideoOAuthCallback.app` (macOS) forwards the URL to the plugin via the TCP control server (`oauth_callback` command).
+5. The plugin verifies state, posts to `https://zoom.us/oauth/token` with `client_id`, `code`, `redirect_uri`, and `code_verifier` (no Authorization header, no secret), and persists access + refresh tokens. On Windows, tokens are DPAPI-protected before storage.
+6. Before each meeting join, CoreVideo refreshes the token if needed and fetches a ZAK from `GET /v2/users/me/token?type=zak`. The ZAK is passed into the SDK `JoinParam4WithoutLogin`.
 
 See [`docs/ZOOM_MARKETPLACE_OAUTH.md`](docs/ZOOM_MARKETPLACE_OAUTH.md) for the full setup guide and security notes.
 

--- a/docs/ZOOM_MARKETPLACE_OAUTH.md
+++ b/docs/ZOOM_MARKETPLACE_OAUTH.md
@@ -1,81 +1,88 @@
 # Zoom Marketplace OAuth setup
 
 CoreVideo uses a Zoom Meeting SDK JWT to initialize the Meeting SDK helper and
-uses a user-level OAuth token to fetch a short-lived ZAK for attributed joins.
-This is needed for external-account meetings and Marketplace review.
+uses a user-level OAuth token (Authorization Code + PKCE, public client) to
+fetch a short-lived ZAK for attributed joins. This is needed for external-
+account meetings and Marketplace review.
 
-## Zoom Marketplace app
+Public PKCE is the only OAuth mode CoreVideo supports at runtime: a desktop
+binary cannot keep a client secret, so confidential OAuth is intentionally
+not available.
+
+## Zoom Marketplace app (publisher, one-time)
 
 1. Create a **General** app in the Zoom App Marketplace.
-2. Enable **User-managed** OAuth.
-3. Choose the OAuth client mode that matches the Marketplace app:
-   - **Confidential OAuth**: use the app's OAuth Client ID and Client Secret.
-   - **Public PKCE OAuth**: use the app's OAuth Client ID with PKCE and no
-     secret. CoreVideo uses the single Client ID for both modes; the checkbox
-     in settings decides whether a secret is also required.
-4. Add this Redirect URL:
+2. Enable **User-managed** OAuth and configure the app as a **Public Client**
+   (PKCE, no client secret).
+3. Add this Redirect URL:
    `corevideo://oauth/callback`
-5. Add the same value to the OAuth allow list:
+4. Add the same value to the OAuth allow list:
    `corevideo://oauth/callback`
-6. Add the minimum scopes needed for the first version:
+5. Add the minimum scopes used by the build:
    `user:read:zak`
    `user:read:user`
-7. Keep the Meeting SDK credentials configured for SDK authentication. OAuth
+6. Keep the Meeting SDK credentials configured for SDK authentication. OAuth
    credentials are separate from Meeting SDK credentials.
 
-## Local OBS setup
+## Embedding the Public Client ID into the build (publisher)
 
-1. Build and install CoreVideo.
+The OAuth Public Client ID is part of the published app's identity, not a
+per-user setting. CoreVideo bakes it in at compile time:
+
+```
+cmake -B build -DZOOM_EMBED_OAUTH_CLIENT_ID=<your_public_client_id> ...
+```
+
+In CI, pass the value as a GitHub Actions secret so it never lands in the
+source tree. The value is written into `kEmbeddedOAuthClientId` (see
+`src/zoom-credentials.h.in`) and read by `ZoomPluginSettings::load()` as the
+default for `oauth_client_id`.
+
+Developers can override the embedded value for local testing by adding an
+`OAuthClientId=...` entry under `[ZoomPlugin]` in OBS `global.ini`. There is
+no UI for this; it exists only as a development escape hatch.
+
+## End-user sign-in
+
+1. Install a CoreVideo build that has the Public Client ID embedded.
 2. Open OBS, then open **Tools > Zoom Plugin Settings**.
-3. Enter the OAuth Client ID from the Zoom Marketplace app, or paste Zoom's
-   test authorization URL into **Authorization URL**. If the URL contains
-   `client_id`, CoreVideo can infer and store it.
-4. If the Zoom app is configured as a confidential OAuth client, enable **Use
-   Client Secret for confidential OAuth** and enter the OAuth Client Secret. If
-   the app is configured as public PKCE, leave that checkbox unchecked; the
-   Client Secret field is disabled in that mode and only the Client ID is
-   required.
-5. Keep Redirect URI set to `corevideo://oauth/callback`.
-6. Click **Register corevideo:// URL Scheme**. On Windows this registers:
-   `HKCU\Software\Classes\corevideo\shell\open\command`
-   to launch `CoreVideoOAuthCallback.exe`.
-   On macOS this registers the bundled `CoreVideoOAuthCallback.app` with
-   Launch Services.
-7. Click **Authorize with Zoom** and approve the app in the browser.
-8. Return to OBS. The callback helper forwards the URL to the plugin over
-   `127.0.0.1:19870` using the `oauth_callback` command.
+3. In the **Zoom Account** section click **Sign in with Zoom** and approve the
+   app in the browser. There are no Client ID, Client Secret, or
+   Authorization URL fields to configure — the build already knows.
+4. The callback helper (`CoreVideoOAuthCallback.exe` on Windows,
+   `CoreVideoOAuthCallback.app` on macOS) is registered for the
+   `corevideo://` URL scheme the first time you click Sign in and forwards the
+   redirect to the running plugin on `127.0.0.1:<ControlServerPort>` (default
+   `19870`).
 
 ## Runtime flow
 
 1. CoreVideo generates a high-entropy `code_verifier`, derives an S256
-   `code_challenge`, starts from Zoom's configured authorization URL if one is
-   present, and injects the PKCE parameters it must control.
+   `code_challenge`, and opens the system browser at
+   `https://zoom.us/oauth/authorize` with the embedded Public Client ID,
+   `redirect_uri=corevideo://oauth/callback`, scopes, `state`,
+   `code_challenge`, and `code_challenge_method=S256`.
 2. Zoom redirects to `corevideo://oauth/callback?...`.
-3. `CoreVideoOAuthCallback.exe` forwards that callback to the running OBS
-   plugin. On macOS, `CoreVideoOAuthCallback.app` performs the same forwarding.
-   The helper reads the configured CoreVideo control-server port from the OBS
-   global config and falls back to `19870`.
-4. The plugin verifies `state`, exchanges the authorization code at
-   `https://zoom.us/oauth/token`, and stores access/refresh tokens. For public
-   PKCE apps, leave **Use Client Secret for confidential OAuth** unchecked so
-   CoreVideo sends the public-client token request. For confidential OAuth apps,
-   enable that checkbox, enter the OAuth Client Secret, and CoreVideo sends
-   HTTP Basic auth as `base64(client_id:secret)`.
-5. Before joining, the plugin refreshes the access token if needed and calls:
-   `GET https://api.zoom.us/v2/users/me/zak`
+3. The callback helper forwards that URL to the plugin's control server.
+4. The plugin verifies `state`, posts to `https://zoom.us/oauth/token` with
+   `grant_type=authorization_code`, the `code`, the `redirect_uri`, the
+   `code_verifier`, and the Public Client ID as a form field (no Authorization
+   header, no client secret), and stores access/refresh tokens.
+5. Before joining a meeting, the plugin refreshes the access token if needed
+   (same PKCE-style refresh request, `client_id` in the form body) and calls
+   `GET https://api.zoom.us/v2/users/me/token?type=zak`.
 6. The returned ZAK is passed into the Meeting SDK `JoinParam4WithoutLogin`
    as `userZAK`.
 
 ## Security notes
 
-- PKCE is used for the browser authorization flow in both supported OAuth
-  modes.
-- Windows token storage uses DPAPI before writing tokens into OBS global config.
-- If the optional OAuth Client Secret is configured on Windows, it is also
-  DPAPI-protected before writing to OBS global config.
-- For broad distribution, prefer a managed configuration path over asking every
-  operator to choose OAuth mode manually. The published Marketplace app's OAuth
-  mode should drive the shipped default.
+- PKCE (S256) is used on every authorization. The verifier is generated from
+  the platform CSPRNG.
+- No client secret is shipped in the binary. The settings dialog does not
+  expose Client ID, Client Secret, or Authorization URL fields, so users
+  cannot misconfigure the integration.
+- Windows token storage uses DPAPI before writing tokens into OBS global
+  config.
 - Refresh tokens are rotated; always persist the latest refresh token Zoom
   returns.
 - Windows builds must ship Qt's TLS backend plugins, especially the Schannel
@@ -84,15 +91,16 @@ This is needed for external-account meetings and Marketplace review.
 - The URL callback command bypasses the local control-server token, but the
   OAuth `state` and one-time verifier are still required before any token
   exchange occurs.
-- Do not log access tokens, refresh tokens, ZAKs, authorization codes, or PKCE
-  verifiers.
+- Do not log access tokens, refresh tokens, ZAKs, authorization codes, or
+  PKCE verifiers.
 
 ## Marketplace review checklist
 
 - Explain that CoreVideo joins meetings as an OBS capture/ISO recording tool.
 - Request only the scopes used by the build.
 - Provide test credentials and a test meeting hosted outside the app account.
-- Document the visible in-product OAuth sign-in and uninstall/disconnect path.
+- Document the visible in-product OAuth sign-in and uninstall/disconnect
+  path.
 - Make sure the Marketplace listing explains when meeting audio/video is
   captured, where it is processed, and that raw media stays local unless OBS
   outputs it.

--- a/src/zoom-oauth.cpp
+++ b/src/zoom-oauth.cpp
@@ -69,14 +69,6 @@ QString ZoomOAuthManager::form_encode(const QMap<QString, QString> &fields)
     return query.toString(QUrl::FullyEncoded);
 }
 
-static QByteArray oauth_basic_auth(const QString &client_id,
-                                   const QString &client_secret)
-{
-    if (client_secret.isEmpty())
-        return {};
-    return "Basic " + (client_id + ":" + client_secret).toUtf8().toBase64();
-}
-
 static std::string redacted_tail(const QString &value)
 {
     if (value.isEmpty()) return "(empty)";
@@ -109,15 +101,10 @@ bool ZoomOAuthManager::begin_authorization(QWidget *parent, QString *error)
     QUrlQuery query(url);
     const QString client_id = QString::fromStdString(s.oauth_client_id);
     if (client_id.isEmpty()) {
-        if (error)
-            *error = "Enter the Zoom OAuth Client ID first.";
-        return false;
-    }
-    if (s.oauth_use_client_secret && s.oauth_client_secret.empty()) {
         if (error) {
-            *error = "Confidential OAuth is enabled but no Client Secret is "
-                     "set. Either enter the Client Secret or switch to Public "
-                     "Client OAuth (PKCE, no secret).";
+            *error = "CoreVideo was built without an embedded Zoom OAuth "
+                     "client ID. Rebuild with ZOOM_EMBED_OAUTH_CLIENT_ID set "
+                     "to the Marketplace app's Public Client ID.";
         }
         return false;
     }
@@ -149,9 +136,8 @@ bool ZoomOAuthManager::begin_authorization(QWidget *parent, QString *error)
     }
 
     blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom OAuth authorization started client_id=%s public_mode=%d",
-         redacted_tail(client_id).c_str(),
-         s.oauth_use_client_secret ? 0 : 1);
+         "[obs-zoom-plugin] Zoom OAuth authorization started (public PKCE) client_id=%s",
+         redacted_tail(client_id).c_str());
 
     if (parent) {
         QMessageBox::information(parent, "Zoom OAuth",
@@ -192,8 +178,7 @@ bool ZoomOAuthManager::parse_token_response(const QByteArray &body, QString *err
 }
 
 static QString oauth_error_message(const QByteArray &body,
-                                   const QString &fallback,
-                                   bool using_client_secret)
+                                   const QString &fallback)
 {
     QJsonParseError parse_error;
     const QJsonDocument doc = QJsonDocument::fromJson(body, &parse_error);
@@ -202,17 +187,10 @@ static QString oauth_error_message(const QByteArray &body,
         const QString oauth_error = obj.value("error").toString();
         const QString reason = obj.value("reason").toString();
         if (oauth_error == "invalid_client") {
-            if (using_client_secret) {
-                return "Zoom rejected the OAuth client credentials. For "
-                       "confidential OAuth, verify the regular Client ID and "
-                       "Client Secret from the same Zoom Marketplace app, then "
-                       "save settings and authorize again.";
-            }
-            return "Zoom rejected the OAuth client. For public PKCE, enable "
-                   "Use Public Client OAuth in the Zoom Marketplace app and "
-                   "use the separate Public Client ID, not the regular Client "
-                   "ID. If you intentionally use a confidential client, enable "
-                   "Use Client Secret in CoreVideo and re-enter the client secret.";
+            return "Zoom rejected the OAuth client. The Public Client ID this "
+                   "build of CoreVideo was compiled with does not match an "
+                   "active Marketplace app, or the Marketplace app is not "
+                   "configured for Public Client OAuth (PKCE).";
         }
         if (!reason.isEmpty())
             return reason;
@@ -313,27 +291,18 @@ bool ZoomOAuthManager::handle_redirect_url(const QString &url, QString *error)
     const QString client_id = m_pending_client_id.isEmpty()
         ? QString::fromStdString(s.oauth_client_id)
         : m_pending_client_id;
-    const QString client_secret = s.oauth_use_client_secret
-        ? QString::fromStdString(s.oauth_client_secret)
-        : QString();
     QNetworkAccessManager manager;
     QMap<QString, QString> fields = {
         {"grant_type", "authorization_code"},
         {"code", code},
         {"redirect_uri", QString::fromStdString(s.oauth_redirect_uri)},
         {"code_verifier", m_pending_verifier},
+        {"client_id", client_id},
     };
 
-    OAuthTokenAttemptResult result;
-    if (!s.oauth_use_client_secret) {
-        blog(LOG_INFO,
-             "[obs-zoom-plugin] Zoom OAuth public token exchange with client_id form field");
-        fields.insert("client_id", client_id);
-        result = post_token_request(manager, fields, {});
-    } else {
-        result = post_token_request(
-            manager, fields, oauth_basic_auth(client_id, client_secret));
-    }
+    blog(LOG_INFO,
+         "[obs-zoom-plugin] Zoom OAuth public token exchange (PKCE)");
+    OAuthTokenAttemptResult result = post_token_request(manager, fields, {});
 
     m_pending_state.clear();
     m_pending_verifier.clear();
@@ -342,8 +311,7 @@ bool ZoomOAuthManager::handle_redirect_url(const QString &url, QString *error)
     if (!token_attempt_succeeded(result)) {
         if (error) {
             *error = "Zoom token exchange failed: " +
-                     oauth_error_message(result.response, result.net_error_string,
-                                         s.oauth_use_client_secret);
+                     oauth_error_message(result.response, result.net_error_string);
         }
         blog(LOG_WARNING, "[obs-zoom-plugin] Zoom OAuth token exchange failed: status=%d network=%d error=%s",
              result.status, static_cast<int>(result.net_error),
@@ -370,27 +338,17 @@ bool ZoomOAuthManager::refresh_access_token_blocking(QString *error)
 
     QNetworkAccessManager manager;
     const QString client_id = QString::fromStdString(s.oauth_client_id);
-    const QString client_secret = s.oauth_use_client_secret
-        ? QString::fromStdString(s.oauth_client_secret)
-        : QString();
     QMap<QString, QString> fields = {
         {"grant_type", "refresh_token"},
         {"refresh_token", QString::fromStdString(s.oauth_refresh_token)},
+        {"client_id", client_id},
     };
-    OAuthTokenAttemptResult result;
-    if (!s.oauth_use_client_secret) {
-        fields.insert("client_id", client_id);
-        result = post_token_request(manager, fields, {});
-    } else {
-        result = post_token_request(
-            manager, fields, oauth_basic_auth(client_id, client_secret));
-    }
+    OAuthTokenAttemptResult result = post_token_request(manager, fields, {});
 
     if (!token_attempt_succeeded(result)) {
         if (error) {
             *error = "Zoom token refresh failed: " +
-                     oauth_error_message(result.response, result.net_error_string,
-                                         s.oauth_use_client_secret);
+                     oauth_error_message(result.response, result.net_error_string);
         }
         if (!result.response.isEmpty()) {
             blog(LOG_WARNING, "[obs-zoom-plugin] Zoom OAuth token refresh response: %s",

--- a/src/zoom-settings-dialog.cpp
+++ b/src/zoom-settings-dialog.cpp
@@ -40,29 +40,14 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     m_control_token_edit->setPlaceholderText("Leave blank to allow unauthenticated access");
 
     // ── Zoom Account (OAuth) ──────────────────────────────────────────────────
+    // The OAuth client identifier is published Marketplace metadata, baked
+    // into the build at compile time. Nothing about the OAuth flow is user-
+    // configurable here on purpose: end users only see Sign in / Refresh /
+    // Sign out so they cannot misconfigure the integration.
     m_oauth_authorize_btn = new QPushButton("Sign in with Zoom", this);
     m_oauth_refresh_btn = new QPushButton("Refresh", this);
     m_oauth_disconnect_btn = new QPushButton("Sign out", this);
     m_oauth_status_label = new QLabel(this);
-    m_oauth_public_client_cb = new QCheckBox("Use Public Client OAuth (PKCE, no secret)", this);
-    m_oauth_public_client_cb->setChecked(!s.oauth_use_client_secret);
-    m_oauth_client_id_edit = new QLineEdit(QString::fromStdString(s.oauth_client_id), this);
-    m_oauth_client_id_edit->setPlaceholderText("Zoom OAuth Client ID");
-    m_oauth_secret_edit = new QLineEdit(QString::fromStdString(s.oauth_client_secret), this);
-    m_oauth_secret_edit->setEchoMode(QLineEdit::Password);
-    m_oauth_secret_edit->setPlaceholderText("Required only for confidential OAuth");
-    auto sync_secret_enabled = [this]() {
-        const bool needs_secret = !m_oauth_public_client_cb->isChecked();
-        m_oauth_secret_edit->setEnabled(needs_secret);
-        m_oauth_secret_edit->setPlaceholderText(needs_secret
-            ? "Client Secret"
-            : "Not used in Public Client OAuth");
-    };
-    sync_secret_enabled();
-    connect(m_oauth_public_client_cb, &QCheckBox::toggled,
-            this, [sync_secret_enabled](bool) { sync_secret_enabled(); });
-    m_oauth_auth_url_edit = new QLineEdit(QString::fromStdString(s.oauth_authorization_url), this);
-    m_oauth_auth_url_edit->setPlaceholderText("Optional custom authorization URL");
     m_oauth_status_label->setWordWrap(true);
     m_oauth_status_label->setStyleSheet("QLabel { color: #7a8faa; font-size: 11px; }");
     m_oauth_authorize_btn->setProperty("role", "primary");
@@ -81,13 +66,6 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
 
     auto *oauth_layout = new QVBoxLayout;
     oauth_layout->setSpacing(8);
-    auto *oauth_form = new QFormLayout;
-    oauth_form->setSpacing(8);
-    oauth_form->addRow("", m_oauth_public_client_cb);
-    oauth_form->addRow(new QLabel("Client ID:", this), m_oauth_client_id_edit);
-    oauth_form->addRow(new QLabel("Client Secret:", this), m_oauth_secret_edit);
-    oauth_form->addRow(new QLabel("Authorization URL:", this), m_oauth_auth_url_edit);
-    oauth_layout->addLayout(oauth_form);
     oauth_layout->addWidget(m_oauth_status_label);
     oauth_layout->addLayout(oauth_button_row);
 
@@ -214,23 +192,6 @@ void ZoomSettingsDialog::onSave()
 bool ZoomSettingsDialog::saveSettings(bool close_dialog, bool restart_servers)
 {
     ZoomPluginSettings s = ZoomPluginSettings::load();
-    s.oauth_use_client_secret = !m_oauth_public_client_cb->isChecked();
-    s.oauth_client_id = m_oauth_client_id_edit->text().trimmed().toStdString();
-    s.oauth_client_secret =
-        m_oauth_secret_edit->text().trimmed().toStdString();
-    s.oauth_authorization_url =
-        m_oauth_auth_url_edit->text().trimmed().toStdString();
-    if (s.oauth_client_id.empty()) {
-        QMessageBox::warning(this, "Zoom OAuth",
-            "Enter the Zoom OAuth Client ID before signing in.");
-        return false;
-    }
-    if (s.oauth_use_client_secret && s.oauth_client_secret.empty()) {
-        QMessageBox::warning(this, "Zoom OAuth",
-            "Confidential OAuth is enabled but no Client Secret is set. "
-            "Enter the Client Secret or switch to Public Client OAuth.");
-        return false;
-    }
     s.control_server_port = static_cast<uint16_t>(m_control_port_spin->value());
     s.osc_server_port     = static_cast<uint16_t>(m_osc_port_spin->value());
     s.control_token       = m_control_token_edit->text().toStdString();

--- a/src/zoom-settings-dialog.h
+++ b/src/zoom-settings-dialog.h
@@ -27,10 +27,6 @@ private:
     QPushButton *m_oauth_authorize_btn  = nullptr;
     QPushButton *m_oauth_refresh_btn    = nullptr;
     QPushButton *m_oauth_disconnect_btn = nullptr;
-    QCheckBox *m_oauth_public_client_cb = nullptr;
-    QLineEdit *m_oauth_client_id_edit   = nullptr;
-    QLineEdit *m_oauth_secret_edit      = nullptr;
-    QLineEdit *m_oauth_auth_url_edit    = nullptr;
     QSpinBox  *m_control_port_spin      = nullptr;
     QSpinBox  *m_osc_port_spin          = nullptr;
     QLineEdit *m_control_token_edit     = nullptr;

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -89,12 +89,12 @@ ZoomPluginSettings ZoomPluginSettings::load()
     const char *meeting_sdk_public_app_key =
         config_get_string(cfg, SECTION, "MeetingSdkPublicAppKey");
     const char *jwt    = config_get_string(cfg, SECTION, "JwtToken");
+    // OAuthClientId is a dev-only override; production builds use the embedded
+    // ZOOM_EMBED_OAUTH_CLIENT_ID value. PublicClientId is a legacy key from
+    // earlier builds and is read once for migration, then cleared on save.
     const char *oauth_client_id = config_get_string(cfg, SECTION, "OAuthClientId");
     const char *oauth_legacy_public_client_id =
         config_get_string(cfg, SECTION, "PublicClientId");
-    const char *oauth_client_secret = config_get_string(cfg, SECTION, "OAuthClientSecret");
-    const int oauth_use_client_secret =
-        config_get_int(cfg, SECTION, "OAuthUseClientSecret");
     const char *oauth_authorization_url = config_get_string(cfg, SECTION, "OAuthAuthorizationUrl");
     const char *oauth_redirect_uri = config_get_string(cfg, SECTION, "OAuthRedirectUri");
     const char *oauth_scopes = config_get_string(cfg, SECTION, "OAuthScopes");
@@ -115,9 +115,6 @@ ZoomPluginSettings ZoomPluginSettings::load()
                             *meeting_sdk_public_app_key)
         ? meeting_sdk_public_app_key
         : "";
-    // Migration: earlier builds stored the public PKCE client id in a separate
-    // "PublicClientId" key. Collapse it into the single OAuthClientId field so
-    // users only have to manage one identifier.
     if (oauth_client_id && *oauth_client_id) {
         s.oauth_client_id = oauth_client_id;
     } else if (oauth_legacy_public_client_id && *oauth_legacy_public_client_id) {
@@ -125,8 +122,6 @@ ZoomPluginSettings ZoomPluginSettings::load()
     } else {
         s.oauth_client_id = kEmbeddedOAuthClientId;
     }
-    s.oauth_client_secret = unprotect_secret(oauth_client_secret);
-    s.oauth_use_client_secret = oauth_use_client_secret != 0;
     s.oauth_authorization_url = oauth_authorization_url ? oauth_authorization_url : "";
     if (oauth_redirect_uri && *oauth_redirect_uri)
         s.oauth_redirect_uri = oauth_redirect_uri;
@@ -253,12 +248,12 @@ void ZoomPluginSettings::save() const
                       sdk_public_app_key.c_str());
     config_set_string(cfg, SECTION, "JwtToken",          jwt_token.c_str());
     config_set_string(cfg, SECTION, "OAuthClientId",     oauth_client_id.c_str());
-    // Legacy key kept blank so older builds don't resurrect a stale value.
+    // Legacy keys cleared so older builds don't resurrect stale values. Public
+    // PKCE is the only supported runtime mode; secrets must never be shipped
+    // in a desktop binary.
     config_set_string(cfg, SECTION, "PublicClientId",    "");
-    config_set_string(cfg, SECTION, "OAuthClientSecret",
-                      protect_secret(oauth_client_secret).c_str());
-    config_set_int   (cfg, SECTION, "OAuthUseClientSecret",
-                      oauth_use_client_secret ? 1 : 0);
+    config_set_string(cfg, SECTION, "OAuthClientSecret", "");
+    config_set_int   (cfg, SECTION, "OAuthUseClientSecret", 0);
     config_set_string(cfg, SECTION, "OAuthAuthorizationUrl",
                       oauth_authorization_url.c_str());
     config_set_string(cfg, SECTION, "OAuthRedirectUri",  oauth_redirect_uri.c_str());

--- a/src/zoom-settings.h
+++ b/src/zoom-settings.h
@@ -7,9 +7,11 @@
 struct ZoomPluginSettings {
     std::string         sdk_key, sdk_secret, jwt_token;
     std::string         sdk_public_app_key;
+    // OAuth Public Client ID baked in at build time via ZOOM_EMBED_OAUTH_CLIENT_ID.
+    // Can be overridden by an OAuthClientId key in global.ini for development;
+    // not exposed in the UI because end users should never configure this.
     std::string         oauth_client_id;
-    std::string         oauth_client_secret;
-    bool                oauth_use_client_secret = false;
+    // Optional global.ini override for the Zoom authorization URL (dev/staging).
     std::string         oauth_authorization_url;
     std::string         oauth_redirect_uri = "corevideo://oauth/callback";
     std::string         oauth_scopes = "user:read:zak user:read:user";


### PR DESCRIPTION
Follow-up to #82.

## Summary
Best-practice PKCE for a published Marketplace app means:
- The OAuth Public Client ID is **published metadata**, baked in at build time, not a user-entered setting.
- Confidential OAuth is off the table at runtime because a desktop binary can't hide a client secret (and Marketplace review will reject it).
- End users only see **Sign in with Zoom / Refresh / Sign out** — there is nothing to misconfigure.

#82 collapsed the dialog to a single Client ID field, which still left the door open to mis-pasting the regular Client ID into a slot intended for the Public Client ID. This PR closes that door by removing the OAuth credential fields from the UI entirely.

## Changes
- **Settings dialog**: removed Client ID, Client Secret, "Use Client Secret" checkbox, and Authorization URL fields. The Zoom Account section is now just Sign in / Refresh / Sign out + status.
- **`zoom-oauth.cpp`**: always runs public PKCE. Dropped the confidential branch, the Basic-auth helper, and the dual-id bookkeeping. `client_id` always comes from `kEmbeddedOAuthClientId` (set via `-DZOOM_EMBED_OAUTH_CLIENT_ID=<public_client_id>` at CMake configure time).
- **Settings struct**: removed `oauth_use_client_secret` and `oauth_client_secret`. Legacy `OAuthClientSecret` and `OAuthUseClientSecret` keys are blanked on save so older builds can't resurrect stale values. `OAuthClientId` and `OAuthAuthorizationUrl` survive only as hidden dev overrides in `global.ini`.
- **Error messages**: `invalid_client` now says "this build's Public Client ID doesn't match an active Marketplace Public Client app" instead of pointing at non-existent UI fields.
- **Docs**: README and `docs/ZOOM_MARKETPLACE_OAUTH.md` rewritten around the publisher build-time workflow and the no-fields user sign-in.

## Test plan
- [ ] Configure: `cmake -DZOOM_EMBED_OAUTH_CLIENT_ID=<your_public_client_id> ...`
- [ ] Build on Windows; open **Tools > Zoom Plugin Settings** and confirm the Zoom Account section has only Sign in / Refresh / Sign out and a status label.
- [ ] First-run install (no embedded ID, no override) → Sign in shows the "rebuild with ZOOM_EMBED_OAUTH_CLIENT_ID" message.
- [ ] Happy path: Sign in with Zoom completes, tokens persist, ZAK fetch and external-account join both succeed.
- [ ] Restart OBS between Sign in and approval → callback shows the new "no active sign-in" message rather than a CSRF-looking error.
- [ ] Token refresh continues to work (refresh path also uses `client_id` in form body, no Basic auth).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9bFN183cWtjEeGsJBjzhR)_