### PR TITLE
Collapse Zoom PKCE token exchange to a single RFC 7636 request

### DIFF
--- a/src/zoom-oauth.cpp
+++ b/src/zoom-oauth.cpp
@@ -249,89 +249,19 @@ static bool token_attempt_succeeded(const OAuthTokenAttemptResult &result)
         result.status >= 200 && result.status < 300;
 }
 
-static bool token_attempt_invalid_client(const OAuthTokenAttemptResult &result)
-{
-    QJsonParseError parse_error;
-    const QJsonDocument doc = QJsonDocument::fromJson(result.response,
-                                                      &parse_error);
-    if (parse_error.error != QJsonParseError::NoError || !doc.isObject())
-        return false;
-    return doc.object().value("error").toString() == "invalid_client";
-}
-
-static QByteArray public_client_basic_auth(const QString &client_id)
-{
-    if (client_id.isEmpty())
-        return {};
-    return QByteArray("Basic ") + client_id.toUtf8().toBase64();
-}
-
-static QByteArray public_client_colon_basic_auth(const QString &client_id)
-{
-    if (client_id.isEmpty())
-        return {};
-    return QByteArray("Basic ") + (client_id.toUtf8() + ":").toBase64();
-}
-
 static OAuthTokenAttemptResult post_public_pkce_token_request(
     QNetworkAccessManager &manager,
     const QMap<QString, QString> &fields,
     const QString &oauth_client_id,
-    const QString &sdk_public_app_key,
     const char *operation)
 {
     QMap<QString, QString> body_fields = fields;
     body_fields.insert("client_id", oauth_client_id);
 
     blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom OAuth %s attempt=body_client_id client_id=%s",
+         "[obs-zoom-plugin] Zoom OAuth %s client_id=%s",
          operation, redacted_tail(oauth_client_id).c_str());
-    OAuthTokenAttemptResult result = post_token_request(manager, body_fields, {});
-    if (token_attempt_succeeded(result) || !token_attempt_invalid_client(result))
-        return result;
-
-    QMap<QString, QString> header_fields = fields;
-    header_fields.remove("client_id");
-    blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom OAuth %s retry=basic_public_client client_id=%s",
-         operation, redacted_tail(oauth_client_id).c_str());
-    result = post_token_request(manager, header_fields,
-                                public_client_basic_auth(oauth_client_id));
-    if (token_attempt_succeeded(result) || !token_attempt_invalid_client(result)) {
-        return result;
-    }
-
-    blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom OAuth %s retry=body_and_basic_public_client client_id=%s",
-         operation, redacted_tail(oauth_client_id).c_str());
-    result = post_token_request(manager, body_fields,
-                                public_client_basic_auth(oauth_client_id));
-    if (token_attempt_succeeded(result) || !token_attempt_invalid_client(result))
-        return result;
-
-    blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom OAuth %s retry=body_and_basic_public_client_colon client_id=%s",
-         operation, redacted_tail(oauth_client_id).c_str());
-    result = post_token_request(manager, body_fields,
-                                public_client_colon_basic_auth(oauth_client_id));
-    if (token_attempt_succeeded(result) || !token_attempt_invalid_client(result))
-        return result;
-
-    blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom OAuth %s retry=basic_public_client_colon client_id=%s",
-         operation, redacted_tail(oauth_client_id).c_str());
-    result = post_token_request(manager, header_fields,
-                                public_client_colon_basic_auth(oauth_client_id));
-    if (token_attempt_succeeded(result) || !token_attempt_invalid_client(result))
-        return result;
-
-    blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom OAuth %s retry=basic_meeting_public_app_key client_id=%s",
-         operation, redacted_tail(sdk_public_app_key).c_str());
-    if (sdk_public_app_key.isEmpty() || sdk_public_app_key == oauth_client_id)
-        return result;
-    return post_token_request(manager, header_fields,
-                              public_client_basic_auth(sdk_public_app_key));
+    return post_token_request(manager, body_fields, {});
 }
 
 bool ZoomOAuthManager::handle_redirect_url(const QString &url, QString *error)
@@ -388,9 +318,7 @@ bool ZoomOAuthManager::handle_redirect_url(const QString &url, QString *error)
     };
 
     OAuthTokenAttemptResult result = post_public_pkce_token_request(
-        manager, fields, client_id,
-        QString::fromStdString(s.sdk_public_app_key),
-        "public token exchange");
+        manager, fields, client_id, "public token exchange");
 
     m_pending_state.clear();
     m_pending_verifier.clear();
@@ -431,9 +359,7 @@ bool ZoomOAuthManager::refresh_access_token_blocking(QString *error)
         {"refresh_token", QString::fromStdString(s.oauth_refresh_token)},
     };
     OAuthTokenAttemptResult result = post_public_pkce_token_request(
-        manager, fields, client_id,
-        QString::fromStdString(s.sdk_public_app_key),
-        "public token refresh");
+        manager, fields, client_id, "public token refresh");
 
     if (!token_attempt_succeeded(result)) {
         if (error) {


### PR DESCRIPTION
## Summary

The public PKCE token exchange in `src/zoom-oauth.cpp` was trying six different auth-style variants before giving up:

1. `client_id` in form body, no `Authorization` header (RFC 7636 standard)
2. `Basic base64(client_id)` header only
3. Body `client_id` + `Basic base64(client_id)` header
4. Body `client_id` + `Basic base64(client_id:)` header
5. `Basic base64(client_id:)` header only
6. `Basic base64(sdk_public_app_key)` header fallback

That chain was grown incrementally (`88dfbe7` → `657d126` → `722f1ec`) while debugging the endpoint. Since `e86b4db` made this a build-time Marketplace public client, the standards-compliant variant — `client_id` in the form body with no `Authorization` header — is the one Zoom's public OAuth endpoint accepts. The fallbacks are dead weight that obscure the real flow.

## Changes

- Drop `public_client_basic_auth`, `public_client_colon_basic_auth`, and `token_attempt_invalid_client` helpers.
- Reduce `post_public_pkce_token_request` to a single `post_token_request` call (body `client_id`, no auth header).
- Drop the now-unused `sdk_public_app_key` parameter from both call sites (`handle_redirect_url`, `refresh_access_token_blocking`). The SDK public app key is still used elsewhere for the Meeting SDK JWT bypass; only its use as an OAuth fallback is removed.

Net: -78 / +4 lines.

## Test plan

- [ ] Build CoreVideo with `ZOOM_EMBED_OAUTH_CLIENT_ID` set.
- [ ] Run the Zoom OAuth flow end-to-end and confirm `Zoom OAuth public token exchange client_id=****xxxx` log line appears once and succeeds.
- [ ] Wait for access token to near expiry (or shorten in test) and confirm refresh exchange succeeds with one request.
- [ ] Verify a deliberately bad client ID surfaces the `invalid_client` error message rather than silently retrying.

---
_Generated by [Claude Code](https://claude.ai/code/session_015uhCXYzxJbxmSEAKGuFEP1)_