### PR TITLE
docs: Explore Spout/Syphon GPU texture sharing for high-density video feeds

### DIFF
--- a/docs/CORE_PLUGIN_FUNCTIONALITY.md
+++ b/docs/CORE_PLUGIN_FUNCTIONALITY.md
@@ -19,6 +19,13 @@ and forwards the same copied buffer to optional plugin-side services such as ISO
 recording. This keeps the engine minimal and makes OBS/plugin features easier to
 test independently from the Zoom SDK.
 
+**Current limitation (high feed counts):** All video frames travel as CPU I420
+through shared memory. At 8+ concurrent 1080p sources this creates substantial
+memory bandwidth pressure due to multiple per-subscription copies. See
+[ROADMAP.md](ROADMAP.md) (Large-meeting capacity guidance) for exploration of
+GPU texture sharing (Spout on Windows, Syphon on macOS) as a lower-CPU
+alternative transport in the future.
+
 ## What It Looks Like in OBS
 
 The CoreVideo plugin is operated from inside OBS. These diagrams mirror the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -184,6 +184,15 @@ Templates scale to eight slots out of the box. Beyond that, the Zoom
 SDK's raw-data callback patterns deserve real stress tests and a
 documented capacity envelope.
 
+**Exploratory:** Investigate GPU texture sharing frameworks (Spout on Windows,
+Syphon on macOS) as an optional alternative transport for video frames.
+Current design relies on CPU I420 shared memory + per-subscription copies,
+which creates significant memory bandwidth pressure at 8+ 1080p feeds.
+A Spout-based path could allow the engine to upload frames once and let
+OBS consume them as native GPU textures, dramatically lowering CPU cost
+for high-density productions (at the cost of added platform-specific code
+and a new optional dependency).
+
 ---
 
 ## Non-goals


### PR DESCRIPTION
## Summary

Adds a note under the existing "Large-meeting capacity guidance" item (and a clarifying paragraph in the core functionality guide) about exploring GPU texture sharing frameworks as a future way to reduce CPU/memory bandwidth pressure when running many concurrent 1080p+ feeds.

### Context

Current design uses named shared memory carrying CPU I420 frames. Every active OBS source subscribed to a participant causes additional full-frame copies in the engine. At 8+ 1080p sources this becomes a significant local compute cost, even when Zoom bandwidth is not the limiter.

### Proposed Direction

Investigate Spout (Windows) and Syphon (macOS) as an optional alternative transport:
- Engine uploads frames to GPU once and registers a Spout/Syphon sender.
- OBS side can consume native GPU textures (via existing Spout plugins or a dedicated receiver source).
- This would keep the current JSON IPC + shared memory path for control/metadata while moving the heavy pixel data to a zero-copy GPU path where possible.

This is marked as exploratory in the "Later" section because it adds platform-specific code and complexity.