### PR TITLE
Add IPC heartbeat to detect a hung Zoom engine (#106)

### DIFF
--- a/engine/src/engine-writer.h
+++ b/engine/src/engine-writer.h
@@ -25,10 +25,11 @@ inline std::mutex &mtx()
 inline void init(IpcFd e2p) { fd() = e2p; }
 
 // Serialised write — safe to call from any thread.
-inline void write(const std::string &msg)
+// Returns false on I/O error or short write.
+inline bool write(const std::string &msg)
 {
     std::lock_guard<std::mutex> lk(mtx());
-    ipc_write_line(fd(), msg);
+    return ipc_write_line(fd(), msg);
 }
 
 } // namespace EngineIpc

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -39,7 +39,9 @@
 #include <algorithm>
 #include <string>
 #include <atomic>
+#include <chrono>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 static std::string redacted_tail(const std::string &value)
@@ -1120,6 +1122,17 @@ int main()
     std::atomic<bool> running{true};
     std::string line;
 
+    // Heartbeat: emit a ping every ~2s so the plugin can detect a hung-but-alive
+    // engine (process running, pipe silent). Stop the loop if a write fails.
+    std::thread heartbeat([&running]() {
+        while (running.load(std::memory_order_acquire)) {
+            for (int i = 0; i < 20 && running.load(std::memory_order_acquire); ++i)
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (!running.load(std::memory_order_acquire)) break;
+            if (!EngineIpc::write(R"({"cmd":"ping"})")) break;
+        }
+    });
+
     while (running) {
 #if defined(WIN32)
         if (!ipc_read_line_with_message_pump(p2e, line)) break;
@@ -1309,6 +1322,10 @@ int main()
             }
         }
     }
+
+    // Stop the heartbeat before tearing down the SDK / IPC.
+    running.store(false, std::memory_order_release);
+    if (heartbeat.joinable()) heartbeat.join();
 
     if (meeting_svc) meeting_svc->Leave(ZOOMSDK::LEAVE_MEETING);
     share_engine.detach();

--- a/src/engine-ipc.h
+++ b/src/engine-ipc.h
@@ -176,20 +176,24 @@ static inline bool ipc_read_line(IpcFd fd, std::string &out,
 #endif
 }
 
-static inline void ipc_write_line(IpcFd fd, const std::string &msg)
+// Returns false on I/O error or short write.
+static inline bool ipc_write_line(IpcFd fd, const std::string &msg)
 {
     std::string out = msg + "\n";
 #if defined(WIN32)
-    DWORD written;
-    WriteFile(fd, out.c_str(), static_cast<DWORD>(out.size()), &written, nullptr);
+    DWORD written = 0;
+    if (!WriteFile(fd, out.c_str(), static_cast<DWORD>(out.size()), &written, nullptr))
+        return false;
+    return written == out.size();
 #else
     const char *p   = out.c_str();
     size_t      rem = out.size();
     while (rem > 0) {
         ssize_t n = write(fd, p, rem);
-        if (n <= 0) break;
+        if (n <= 0) return false;
         p   += static_cast<size_t>(n);
         rem -= static_cast<size_t>(n);
     }
+    return true;
 #endif
 }

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -243,6 +243,9 @@ bool ZoomEngineClient::start(const std::string &jwt_token,
         return false;
     }
 
+    // Seed the heartbeat clock so a freshly connected engine isn't immediately
+    // considered stale before its first line arrives.
+    m_last_rx_ms.store(os_gettime_ns() / 1000000ULL, std::memory_order_release);
     m_running.store(true, std::memory_order_release);
     m_reader  = std::thread([this]() { reader_loop(); });
     m_monitor = std::thread([this]() { monitor_loop(); });
@@ -287,31 +290,90 @@ void ZoomEngineClient::stop_for_reconnect()
 
 void ZoomEngineClient::monitor_loop()
 {
-    // Wait for the engine process to exit.
+    // Poll until the engine process exits OR it stops responding (heartbeat
+    // timeout). A hung-but-alive engine (process up, pipe silent) would
+    // otherwise block reader_loop on ipc_read_line() forever and never recover.
+    constexpr uint64_t kHeartbeatTimeoutMs = 10000;
     int exit_code = 0;
-#if defined(WIN32)
-    if (m_process) {
-        WaitForSingleObject(static_cast<HANDLE>(m_process), INFINITE);
-        DWORD code = 0;
-        GetExitCodeProcess(static_cast<HANDLE>(m_process), &code);
-        exit_code = static_cast<int>(code);
-        CloseHandle(static_cast<HANDLE>(m_process));
-        m_process = nullptr;
-    }
-#else
-    if (m_pid > 0) {
-        int status = 0;
-        waitpid(m_pid, &status, 0);
-        exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
-        m_pid = -1;
-    }
-#endif
+    bool heartbeat_timeout = false;
 
-    // If m_running is still true the engine exited without being asked to.
+    while (m_running.load(std::memory_order_acquire)) {
+#if defined(WIN32)
+        if (m_process) {
+            DWORD waited = WaitForSingleObject(static_cast<HANDLE>(m_process), 1000);
+            if (waited == WAIT_OBJECT_0) {
+                DWORD code = 0;
+                GetExitCodeProcess(static_cast<HANDLE>(m_process), &code);
+                exit_code = static_cast<int>(code);
+                CloseHandle(static_cast<HANDLE>(m_process));
+                m_process = nullptr;
+                break;
+            }
+        } else {
+            break;
+        }
+#else
+        if (m_pid > 0) {
+            int status = 0;
+            pid_t r = waitpid(m_pid, &status, WNOHANG);
+            if (r == m_pid) {
+                exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+                m_pid = -1;
+                break;
+            }
+            if (r < 0) { // process already reaped / error
+                m_pid = -1;
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        } else {
+            break;
+        }
+#endif
+        // Engine is still alive — check that it is still talking to us. Only
+        // enforce the timeout once we're connected/in a meeting, where a
+        // steady heartbeat is expected.
+        const MeetingState st = m_state.load(std::memory_order_acquire);
+        if (m_running.load(std::memory_order_acquire) &&
+            (st == MeetingState::InMeeting || st == MeetingState::Joining)) {
+            const uint64_t now = os_gettime_ns() / 1000000ULL;
+            const uint64_t last = m_last_rx_ms.load(std::memory_order_acquire);
+            if (last != 0 && now > last && (now - last) > kHeartbeatTimeoutMs) {
+                heartbeat_timeout = true;
+                break;
+            }
+        }
+    }
+
+    // If m_running is still true the engine exited (or went silent) without
+    // being asked to.
     if (m_running.exchange(false, std::memory_order_acq_rel)) {
-        blog(LOG_ERROR,
-             "[obs-zoom-plugin] ZoomObsEngine exited unexpectedly (code %d)",
-             exit_code);
+        if (heartbeat_timeout) {
+            blog(LOG_ERROR,
+                 "[obs-zoom-plugin] ZoomObsEngine stopped responding (no IPC for >%llums)",
+                 static_cast<unsigned long long>(kHeartbeatTimeoutMs));
+            set_last_error("Zoom engine stopped responding");
+            // The process is hung but still alive — terminate and reap it so the
+            // recovery path starts from a clean slate, mirroring the crash case.
+#if defined(WIN32)
+            if (m_process) {
+                TerminateProcess(static_cast<HANDLE>(m_process), 1);
+                WaitForSingleObject(static_cast<HANDLE>(m_process), 3000);
+                CloseHandle(static_cast<HANDLE>(m_process));
+                m_process = nullptr;
+            }
+#else
+            if (m_pid > 0) {
+                kill(m_pid, SIGKILL);
+                waitpid(m_pid, nullptr, 0);
+                m_pid = -1;
+            }
+#endif
+        } else {
+            blog(LOG_ERROR,
+                 "[obs-zoom-plugin] ZoomObsEngine exited unexpectedly (code %d)",
+                 exit_code);
+        }
         disconnect_ipc(); // unblocks reader_loop so it exits cleanly
 
         // If the user is in the middle of leaving / stopping, don't try to recover —
@@ -322,9 +384,11 @@ void ZoomEngineClient::monitor_loop()
         }
 
         RecoveryReason reason = RecoveryReason::EngineCrash;
-        if (exit_code == 2) reason = RecoveryReason::AuthFailure;
-        else if (exit_code == 3) reason = RecoveryReason::SdkError;
-        else if (exit_code == 4) reason = RecoveryReason::LicenseError;
+        if (!heartbeat_timeout) {
+            if (exit_code == 2) reason = RecoveryReason::AuthFailure;
+            else if (exit_code == 3) reason = RecoveryReason::SdkError;
+            else if (exit_code == 4) reason = RecoveryReason::LicenseError;
+        }
 
         m_state.store(MeetingState::Recovering, std::memory_order_release);
         ZoomReconnectManager::instance().trigger(reason);
@@ -568,11 +632,18 @@ void ZoomEngineClient::reader_loop()
 
 void ZoomEngineClient::handle_event(const std::string &line)
 {
+    // Record receipt of any line so monitor_loop() can detect a silent engine.
+    m_last_rx_ms.store(os_gettime_ns() / 1000000ULL, std::memory_order_release);
+
     const QJsonDocument doc = QJsonDocument::fromJson(QByteArray::fromStdString(line));
     if (!doc.isObject()) return;
     const QJsonObject obj = doc.object();
     const QString cmd = obj.value("cmd").toString();
 
+    if (cmd == "ping") {
+        // Heartbeat from the engine — the timestamp update above is all we need.
+        return;
+    }
     if (cmd == "ready") {
         blog(LOG_INFO, "[obs-zoom-plugin] Zoom engine ready");
         return;

--- a/src/zoom-engine-client.h
+++ b/src/zoom-engine-client.h
@@ -107,6 +107,9 @@ private:
     std::atomic<bool> m_authenticated{false};
     std::atomic<bool> m_media_active{false};
     std::atomic<MeetingState> m_state{MeetingState::Idle};
+    // Wall-clock ms (os_gettime_ns()/1e6) of the last line received from the
+    // engine. Used by monitor_loop() to detect a hung-but-alive engine.
+    std::atomic<uint64_t> m_last_rx_ms{0};
     uint32_t m_active_speaker_id = 0;
     std::vector<ParticipantInfo> m_roster;
     std::unordered_map<std::string, SourceCallbacks> m_sources;


### PR DESCRIPTION
## Problem

A hung-but-alive Zoom engine (process still running but the IPC pipe gone silent) was undetectable. The plugin's reader thread blocks forever on `ipc_read_line()` with no timeout, and `monitor_loop()` only reacted to full process death — so a wedged engine never triggered the existing reconnect path.

## Change

**Engine (`engine/src/main.cpp`)**
- Spawns a small heartbeat thread that emits `{"cmd":"ping"}` every ~2s while running, and joins it cleanly before SDK/IPC teardown (`CleanUPSDK`).
- The loop stops if a write fails.

**IPC helpers (`src/engine-ipc.h`, `engine/src/engine-writer.h`)**
- `ipc_write_line()` and `EngineIpc::write()` now return `bool` (false on I/O error / short write) so the heartbeat loop can stop when the pipe is broken. Backward compatible — existing callers ignore the return value.

**Plugin (`src/zoom-engine-client.{h,cpp}`)**
- New `std::atomic<uint64_t> m_last_rx_ms`, updated at the top of `handle_event()` for every received line (via `os_gettime_ns()/1e6`).
- `cmd=="ping"` is handled as a no-op heartbeat (the timestamp update is the point).
- `monitor_loop()` now polls (1s) instead of blocking indefinitely. While the session is active (`Joining`/`InMeeting`), if no line has been received for >10s it logs an error, sets `last_error` to "Zoom engine stopped responding", terminates the hung process, and triggers the same `ZoomReconnectManager` recovery path used for a detected crash.
- The receive clock is seeded when the connection is established so a fresh engine isn't immediately considered stale.

## Notes
- Completes #106 alongside PR #111.
- Cannot be built locally (no Zoom SDK/Qt/OBS); compilation is validated by CI.

https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf)_