### PR TITLE
Engine SDK null-checks and reconnect jitter/session persistence (#108)

### DIFF
--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -894,14 +894,27 @@ public:
         case ZOOMSDK::MEETING_STATUS_INMEETING:
             EngineIpc::write( R"({"cmd":"joined"})");
             if (m_participants && m_meeting_svc && *m_meeting_svc) {
+                auto *part_ctrl = (*m_meeting_svc)->GetMeetingParticipantsController();
+                if (!part_ctrl) {
+                    // Without the participants controller we cannot build a
+                    // roster (GetParticipantsList/GetUserByUserID live on it);
+                    // surface it rather than silently attaching null.
+                    EngineIpc::write(
+                        R"({"cmd":"debug","stage":"participants_controller","code":-1})");
+                }
                 m_participants->attach(
-                    (*m_meeting_svc)->GetMeetingParticipantsController(),
+                    part_ctrl,
                     (*m_meeting_svc)->GetMeetingAudioController(),
                     (*m_meeting_svc)->GetMeetingVideoController());
             }
-            if (m_share_engine && m_meeting_svc && *m_meeting_svc)
-                m_share_engine->attach(
-                    (*m_meeting_svc)->GetMeetingShareController());
+            if (m_share_engine && m_meeting_svc && *m_meeting_svc) {
+                auto *share_ctrl = (*m_meeting_svc)->GetMeetingShareController();
+                if (!share_ctrl) {
+                    EngineIpc::write(
+                        R"({"cmd":"debug","stage":"share_controller","code":-1})");
+                }
+                m_share_engine->attach(share_ctrl);
+            }
             break;
         case ZOOMSDK::MEETING_STATUS_DISCONNECTING:
         case ZOOMSDK::MEETING_STATUS_ENDED:

--- a/src/zoom-reconnect.cpp
+++ b/src/zoom-reconnect.cpp
@@ -5,6 +5,7 @@
 #include "zoom-settings.h"
 #include <obs-module.h>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 
 ZoomReconnectManager &ZoomReconnectManager::instance()
@@ -14,6 +15,8 @@ ZoomReconnectManager &ZoomReconnectManager::instance()
 }
 
 ZoomReconnectManager::ZoomReconnectManager()
+    : m_rng(static_cast<std::mt19937::result_type>(
+          std::chrono::steady_clock::now().time_since_epoch().count()))
 {
     m_timer = std::thread([this]() { timer_loop(); });
 }
@@ -85,7 +88,14 @@ int ZoomReconnectManager::compute_delay_locked(int attempt) const
 {
     double delay = m_policy.base_delay_ms *
                    std::pow(static_cast<double>(m_policy.backoff_multiplier), attempt);
-    return static_cast<int>(std::min(delay, static_cast<double>(m_policy.max_delay_ms)));
+    delay = std::min(delay, static_cast<double>(m_policy.max_delay_ms));
+    // Apply randomized jitter in [0.8, 1.2] so simultaneous recoveries do not
+    // thunder against the broker/SDK at the same instant. The cap is applied
+    // before jitter; clamp again afterwards so the result never exceeds it.
+    std::uniform_real_distribution<double> jitter(0.8, 1.2);
+    delay *= jitter(m_rng);
+    delay = std::min(delay, static_cast<double>(m_policy.max_delay_ms));
+    return static_cast<int>(delay);
 }
 
 int ZoomReconnectManager::next_retry_ms() const

--- a/src/zoom-reconnect.h
+++ b/src/zoom-reconnect.h
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <random>
 #include <string>
 #include <thread>
 
@@ -79,6 +80,10 @@ private:
     std::string                 m_display_name;
     MeetingKind                 m_kind = MeetingKind::Meeting;
     ZoomJoinAuthTokens          m_tokens;
+
+    // Seeded once at construction; only touched under m_mtx (via
+    // compute_delay_locked), so a single non-atomic generator is sufficient.
+    mutable std::mt19937        m_rng;
 
     std::atomic<bool>           m_recovering{false};
     std::atomic<int>            m_attempt{0};


### PR DESCRIPTION
Crash-safety and reconnect polish for #108. Three items:

**1. SDK null checks (`engine/src/main.cpp`)**
- Newly changed: on `MEETING_STATUS_INMEETING`, the meeting-service getters `GetMeetingParticipantsController()` and `GetMeetingShareController()` are now captured into locals and null-checked before being attached, emitting a `debug` event (`participants_controller` / `share_controller`, code -1) when null instead of silently attaching a null pointer.
- Already handled (left as-is): the roster getters `GetParticipantsList()` / `GetUserByUserID()` in `rebuild_roster()` and `user_to_info()` already guard their results; the recording / live-stream / raw-archiving controller getters (raw-media start/stop, meeting end) were already null-checked.

**2. Reconnect jitter (`src/zoom-reconnect.{h,cpp}`)**
- Newly changed: `compute_delay_locked()` now multiplies the computed back-off by a random factor in [0.8, 1.2] so simultaneous recoveries do not thunder. A single `std::mt19937` is seeded once at construction and only touched under `m_mtx` (via `compute_delay_locked`). Base delay, multiplier, and the max-delay cap are unchanged; the cap is re-applied after jitter so the result never exceeds it.

**3. Session persistence for recovery (`src/zoom-engine-client.cpp`)**
- Verified, no code change needed. `store_session(jwt, meeting_id, passcode, display_name, kind, tokens incl. ZAK)` runs on every `join()`, and `m_pending_*` are retained for the in-flight join. The stored recovery params are cleared only by `clear_session()`, which is reached exclusively from `ZoomEngineClient::stop()` — a deliberate user leave/stop (recovery_cancel, dock cancel button, OSC/control-server leave, plugin shutdown). No passive "control UI closed" path clears them, so a reconnect can proceed after the control UI is closed. Documented here rather than changed.

CI validates compilation (engine/plugin are not built locally).

https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf)_