### PR TITLE
Add unit tests for reconnect/parsing logic (#109)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,28 @@ if(BUILD_TESTING)
     )
     add_test(NAME CoreVideoSpeakerDirector
              COMMAND CoreVideoSpeakerDirectorTest)
+
+    add_executable(CoreVideoJoinInputTest
+        tests/join-input-test.cpp
+        src/obs-utils.cpp
+    )
+    target_include_directories(CoreVideoJoinInputTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoJoinInput
+             COMMAND CoreVideoJoinInputTest)
+
+    # Line-oriented IPC helpers use POSIX read()/write()/pipe(); skip on Windows.
+    if(NOT WIN32)
+        add_executable(CoreVideoIpcLineIoTest
+            tests/ipc-line-io-test.cpp
+        )
+        target_include_directories(CoreVideoIpcLineIoTest PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/src"
+        )
+        add_test(NAME CoreVideoIpcLineIo
+                 COMMAND CoreVideoIpcLineIoTest)
+    endif()
 endif()
 
 set(CPACK_GENERATOR                 "ZIP")

--- a/tests/ipc-line-io-test.cpp
+++ b/tests/ipc-line-io-test.cpp
@@ -1,0 +1,152 @@
+// Tests for the line-oriented IPC helpers in engine-ipc.h
+// (ipc_read_line / ipc_write_line). POSIX-only: uses a real pipe pair.
+
+#include "engine-ipc.h"
+
+#include <iostream>
+#include <string>
+#include <unistd.h>
+
+static int failures = 0;
+
+static void fail(const char *message)
+{
+    std::cerr << "FAIL: " << message << "\n";
+    ++failures;
+}
+
+// Write raw bytes into the write end of a fresh pipe, then return the read fd.
+struct Pipe {
+    int read_fd  = -1;
+    int write_fd = -1;
+    ~Pipe()
+    {
+        if (read_fd >= 0)  close(read_fd);
+        if (write_fd >= 0) close(write_fd);
+    }
+};
+
+static bool make_pipe(Pipe &p)
+{
+    int fds[2];
+    if (pipe(fds) != 0) return false;
+    p.read_fd  = fds[0];
+    p.write_fd = fds[1];
+    return true;
+}
+
+static void write_raw(int fd, const std::string &data)
+{
+    const char *ptr = data.c_str();
+    size_t rem = data.size();
+    while (rem > 0) {
+        ssize_t n = write(fd, ptr, rem);
+        if (n <= 0) break;
+        ptr += static_cast<size_t>(n);
+        rem -= static_cast<size_t>(n);
+    }
+}
+
+int main()
+{
+    // --- Basic single line, newline terminated ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        write_raw(p.write_fd, "hello world\n");
+        std::string line;
+        if (!ipc_read_line(p.read_fd, line)) fail("expected to read a line");
+        if (line != "hello world") fail("line content mismatch");
+    }
+
+    // --- Multiple lines read sequentially ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        write_raw(p.write_fd, "first\nsecond\nthird\n");
+        std::string line;
+        if (!ipc_read_line(p.read_fd, line) || line != "first")  fail("first line wrong");
+        if (!ipc_read_line(p.read_fd, line) || line != "second") fail("second line wrong");
+        if (!ipc_read_line(p.read_fd, line) || line != "third")  fail("third line wrong");
+    }
+
+    // --- Empty line is valid and returns true ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        write_raw(p.write_fd, "\nnext\n");
+        std::string line = "garbage";
+        if (!ipc_read_line(p.read_fd, line)) fail("empty line should still return true");
+        if (!line.empty()) fail("empty line should clear the output string");
+        if (!ipc_read_line(p.read_fd, line) || line != "next") fail("line after empty wrong");
+    }
+
+    // --- EOF without trailing newline returns false (partial data discarded) ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        write_raw(p.write_fd, "no-newline");
+        close(p.write_fd);
+        p.write_fd = -1; // signal EOF to reader
+        std::string line;
+        if (ipc_read_line(p.read_fd, line)) fail("EOF without newline should return false");
+    }
+
+    // --- Immediate EOF returns false ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        close(p.write_fd);
+        p.write_fd = -1;
+        std::string line;
+        if (ipc_read_line(p.read_fd, line)) fail("immediate EOF should return false");
+    }
+
+    // --- Over-long line is rejected (returns false once max_len exceeded) ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        const size_t max_len = 8;
+        // Write more than max_len bytes with no newline within the limit.
+        write_raw(p.write_fd, std::string(64, 'x') + "\n");
+        close(p.write_fd);
+        p.write_fd = -1;
+        std::string line;
+        if (ipc_read_line(p.read_fd, line, max_len))
+            fail("line exceeding max_len should be rejected");
+    }
+
+    // --- A line exactly at the limit followed by newline is accepted ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        const size_t max_len = 5;
+        // 5 chars then newline: the size check fires only when out.size() >= max_len
+        // *before* appending, so a 5-char payload is the largest accepted line.
+        write_raw(p.write_fd, "abcde\n");
+        std::string line;
+        if (!ipc_read_line(p.read_fd, line, max_len))
+            fail("line of exactly max_len should be accepted");
+        if (line != "abcde") fail("max-length line content mismatch");
+    }
+
+    // --- Round-trip: ipc_write_line output is read back by ipc_read_line ---
+    {
+        Pipe p;
+        if (!make_pipe(p)) { fail("pipe() failed"); return 1; }
+        ipc_write_line(p.write_fd, "join 12345");
+        ipc_write_line(p.write_fd, "quit");
+        std::string line;
+        if (!ipc_read_line(p.read_fd, line) || line != "join 12345")
+            fail("round-trip first message wrong");
+        if (!ipc_read_line(p.read_fd, line) || line != "quit")
+            fail("round-trip second message wrong");
+    }
+
+    if (failures == 0) {
+        std::cout << "All IPC line I/O tests passed.\n";
+        return 0;
+    }
+    std::cerr << failures << " test(s) failed.\n";
+    return 1;
+}

--- a/tests/join-input-test.cpp
+++ b/tests/join-input-test.cpp
@@ -1,0 +1,128 @@
+// Tests for the Zoom join-input parsing helpers in obs-utils.cpp
+// (zoom_join_utils::parse_join_input / is_valid_meeting_id). Pure, no Qt/OBS.
+
+#include "obs-utils.h"
+
+#include <iostream>
+#include <string>
+
+using zoom_join_utils::parse_join_input;
+using zoom_join_utils::is_valid_meeting_id;
+
+static int failures = 0;
+
+static void check(bool ok, const char *message)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+int main()
+{
+    // --- is_valid_meeting_id ---
+    check(is_valid_meeting_id("1234567890"), "plain digits should be valid");
+    check(is_valid_meeting_id("123 456 7890"), "spaces should be stripped and accepted");
+    check(is_valid_meeting_id("123-456-7890"), "dashes should be stripped and accepted");
+    check(is_valid_meeting_id("  88 99-00  "), "leading/trailing whitespace ok");
+    check(!is_valid_meeting_id(""), "empty string is invalid");
+    check(!is_valid_meeting_id("   "), "whitespace-only string is invalid");
+    check(!is_valid_meeting_id("12a45"), "letters are invalid");
+    check(!is_valid_meeting_id("- -"), "only separators is invalid (no digits)");
+
+    // --- Raw meeting ID forms ---
+    {
+        auto r = parse_join_input("1234567890");
+        check(r.meeting_id == "1234567890", "raw digits meeting id");
+        check(r.passcode.empty(), "raw id has no passcode");
+    }
+    {
+        auto r = parse_join_input("  123 456 7890 ");
+        check(r.meeting_id == "1234567890", "raw id with spaces normalized");
+    }
+    {
+        auto r = parse_join_input("123-456-7890");
+        check(r.meeting_id == "1234567890", "raw id with dashes normalized");
+    }
+    {
+        auto r = parse_join_input("not-a-meeting");
+        check(r.meeting_id.empty(), "non-numeric raw input yields empty id");
+    }
+    {
+        auto r = parse_join_input("");
+        check(r.meeting_id.empty(), "empty input yields empty id");
+    }
+
+    // --- /j/ URL form with pwd ---
+    {
+        auto r = parse_join_input("https://zoom.us/j/123456789?pwd=secretpass");
+        check(r.meeting_id == "123456789", "/j/ url meeting id");
+        check(r.passcode == "secretpass", "/j/ url passcode");
+    }
+
+    // --- /wc/ join URL ---
+    {
+        auto r = parse_join_input("https://zoom.us/wc/987654321/join?pwd=abc123");
+        check(r.meeting_id == "987654321", "/wc/ url meeting id");
+        check(r.passcode == "abc123", "/wc/ url passcode");
+    }
+
+    // --- /s/ URL form ---
+    {
+        auto r = parse_join_input("https://zoom.us/s/555000111");
+        check(r.meeting_id == "555000111", "/s/ url meeting id");
+        check(r.passcode.empty(), "/s/ url without pwd has no passcode");
+    }
+
+    // --- zoommtg deep link with confno fallback ---
+    {
+        auto r = parse_join_input("zoommtg://zoom.us/join?confno=222333444&pwd=zzz");
+        check(r.meeting_id == "222333444", "confno fallback meeting id");
+        check(r.passcode == "zzz", "deep-link passcode");
+    }
+
+    // --- URL-encoded passcode is decoded ---
+    {
+        auto r = parse_join_input("https://zoom.us/j/12345?pwd=a%20b%2Bc");
+        check(r.meeting_id == "12345", "encoded url meeting id");
+        check(r.passcode == "a b+c", "url-decoded passcode (%20 -> space, %2B -> +)");
+    }
+
+    // --- '+' decodes to space in query values ---
+    {
+        auto r = parse_join_input("https://zoom.us/j/12345?password=hello+world");
+        check(r.passcode == "hello world", "plus decodes to space; 'password' key honored");
+    }
+
+    // --- Auth token query params are extracted ---
+    {
+        auto r = parse_join_input(
+            "https://zoom.us/j/777?pwd=p&zak=ZAKTOKEN&obf=OBFTOKEN"
+            "&app_privilege_token=APPTOK");
+        check(r.meeting_id == "777", "token url meeting id");
+        check(r.passcode == "p", "token url passcode");
+        check(r.user_zak == "ZAKTOKEN", "zak token extracted");
+        check(r.on_behalf_token == "OBFTOKEN", "on-behalf token extracted");
+        check(r.app_privilege_token == "APPTOK", "app privilege token extracted");
+    }
+
+    // --- Path marker takes precedence over confno fallback ---
+    {
+        auto r = parse_join_input("https://zoom.us/j/111?confno=999");
+        check(r.meeting_id == "111", "path /j/ id wins over confno query fallback");
+    }
+
+    // --- Key matching is case-insensitive ---
+    {
+        auto r = parse_join_input("https://zoom.us/j/42?PWD=Mixed");
+        check(r.passcode == "Mixed", "uppercase PWD key is recognized");
+    }
+
+    if (failures == 0) {
+        std::cout << "All join-input parsing tests passed.\n";
+        return 0;
+    }
+    std::cerr << failures << " test(s) failed.\n";
+    return 1;
+}


### PR DESCRIPTION
Adds standalone unit tests for previously-untested pure logic, following the existing test pattern (plain C++ `main()`, non-zero return on failure, simple check helpers, linking only the minimal source). Closes part of #109.

## Tests added

- **`tests/join-input-test.cpp`** (`CoreVideoJoinInput`) — exercises `zoom_join_utils::parse_join_input` and `is_valid_meeting_id` from `src/obs-utils.cpp`: raw meeting IDs with spaces/dashes, `/j/`, `/wc/`, `/s/` URL forms, `zoommtg://` confno fallback, URL-decoding of the passcode (`%20`/`%2B` and `+`), auth-token query params (`zak`/`obf`/`app_privilege_token`), path-marker precedence over `confno`, and case-insensitive query keys. Links `src/obs-utils.cpp`.
- **`tests/ipc-line-io-test.cpp`** (`CoreVideoIpcLineIo`) — exercises `ipc_read_line` / `ipc_write_line` from `engine-ipc.h` over a real POSIX pipe: single/multi/empty lines, EOF without trailing newline, over-long line rejection, `max_len` boundary, and a write/read round trip. POSIX-only, so registered under `if(NOT WIN32)`.

Both registered in `CMakeLists.txt` `BUILD_TESTING` via `add_executable` + `add_test`, mirroring the existing entries.

## Local pass output

```
$ g++ -std=c++17 -Isrc -Wall -Wextra tests/ipc-line-io-test.cpp -o /tmp/ipc-test && /tmp/ipc-test
All IPC line I/O tests passed.
ipc exit=0
$ g++ -std=c++17 -Isrc -Wall -Wextra tests/join-input-test.cpp src/obs-utils.cpp -o /tmp/join-test && /tmp/join-test
All join-input parsing tests passed.
join exit=0
```

## Not testable standalone

The `ZoomReconnectManager` back-off math (`compute_delay_locked`) and the generation-counter / cancellation logic were the primary target but are **not** unit-testable standalone: the relevant methods are private, and `src/zoom-reconnect.cpp` includes `obs-module.h` plus Qt and SDK headers (via `zoom-engine-client.h`, `zoom-oauth.h`, etc.), so the translation unit cannot be compiled or linked without the full OBS/Qt toolchain. Per the issue guidance, no production code was modified to force testability. The JSON parsing helpers in `zoom-control-server.cpp` / `zoom-osc-server.cpp` are likewise Qt-bound (`QJsonObject` / `QByteArray`) and `static`, and `oauth-callback-helper.cpp`'s string helpers are Windows-only (`<windows.h>`) and `static`. The clean, Qt/OBS-free pure logic actually reachable was the join-input parser and the IPC line helpers, which is what this PR covers.

https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf)_