### PR TITLE
Fix Windows CI: skip package validation when Zoom SDK is absent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,11 +203,14 @@ jobs:
                 -ExpectedOAuthClientId y6sIWSwiTZe1JygMx4C9EQ `
                 -ExpectedMeetingSdkPublicAppKey y6sIWSwiTZe1JygMx4C9EQ
           } else {
-              .\scripts\Test-CoreVideoPackage.ps1 `
-                -PackageRoot install `
-                -ExpectedOAuthClientId y6sIWSwiTZe1JygMx4C9EQ `
-                -ExpectedMeetingSdkPublicAppKey y6sIWSwiTZe1JygMx4C9EQ
-              Write-Warning "Windows artifact is validation-only; it does not include zoom-runtime\sdk.dll."
+              # Without the Zoom SDK secret the plugin is configured
+              # COREVIDEO_BUILD_PLUGIN=OFF (its sources include the Zoom SDK
+              # headers and cannot compile without them), so obs-zoom-plugin.dll
+              # and the OAuth helper are not built. Package validation requires
+              # those artifacts, so skip it here — this no-SDK job validates
+              # compilation and unit tests only. Full package validation runs
+              # on the SDK-present (FullRuntime) build path above.
+              Write-Warning "Skipping package validation: no Zoom SDK, so the plugin is not built. This job validates compilation and unit tests only."
           }
           Compress-Archive -Path install\* -DestinationPath CoreVideo-Windows-x64.zip
           $hash = (Get-FileHash -LiteralPath CoreVideo-Windows-x64.zip -Algorithm SHA256).Hash


### PR DESCRIPTION
## Problem

The **Windows x64** job has been failing on every pull request (and on `main`) at the `Package as ZIP` step — **after** a clean compile and a passing `ctest` (8/8). The error:

```
Release package is incomplete. Missing: obs-plugins\64bit\obs-zoom-plugin.dll
```

Root cause: PR CI has no Zoom SDK secret, so the Windows job configures with `-DCOREVIDEO_BUILD_PLUGIN=OFF`. The plugin sources include the Zoom SDK headers (`zoom_sdk.h`, meeting/auth/rawdata services) and cannot compile without them, so `obs-zoom-plugin.dll` and the OAuth callback helper are never built. But `Test-CoreVideoPackage.ps1` lists those artifacts in its **always-required** set, so the no-SDK validation path always fails.

This blocked every open PR's Windows check regardless of the PR's contents.

## Fix

Skip package validation on the no-SDK path (the artifacts it checks aren't built there). Full package validation is unchanged on the SDK-present (`FullRuntime`) release build. The no-SDK Windows job continues to validate compilation + unit tests.

This is a one-step change in `.github/workflows/build.yml`; YAML validated locally.

## Impact

Unblocks Windows CI for all PRs. Recommend merging this first; the other open PRs go green on Windows once rebased on the updated `main`.

https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBgLWK55PHN83g4225H3kf)_