### PR TITLE
Stage standalone iamfatness.us landing site (for IamfatnessWebsite repo)

### DIFF
--- a/iamfatness-website/.github/workflows/deploy-site.yml
+++ b/iamfatness-website/.github/workflows/deploy-site.yml
@@ -1,0 +1,53 @@
+name: Deploy Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "public/**"
+      - "site-worker.js"
+      - "wrangler.jsonc"
+      - ".github/workflows/deploy-site.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-site
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy iamfatness.us
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Validate Cloudflare configuration
+        id: cloudflare_config
+        shell: bash
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            {
+              echo "Cloudflare deploy skipped."
+              echo
+              echo "Set CLOUDFLARE_API_TOKEN as a repository secret and"
+              echo "CLOUDFLARE_ACCOUNT_ID as either a repository secret or variable"
+              echo "to enable deployment to iamfatness.us."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "deploy_enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "deploy_enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Workers
+        if: steps.cloudflare_config.outputs.deploy_enabled == 'true'
+        run: npx wrangler@latest deploy

--- a/iamfatness-website/.gitignore
+++ b/iamfatness-website/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+.dev.vars
+*.log
+.DS_Store

--- a/iamfatness-website/README.md
+++ b/iamfatness-website/README.md
@@ -1,0 +1,85 @@
+# iamfatness.us
+
+Umbrella landing site for **iamfatness.us** — the front door that introduces the
+studio and links out to each product on its own subdomain:
+
+- **CoreVideo** → https://corevideo.iamfatness.us/ (OBS plugin + CoreVideo Pro)
+- **Resonance** → https://resonance.iamfatness.us/ (DJ-style music player / EQ)
+
+> ⚠️ **Staging note:** This folder currently lives on a branch of the
+> `CoreVideo` repo only as a delivery mechanism. It is **destined for the
+> standalone `iamfatness/IamfatnessWebsite` repo** and is not meant to be merged
+> into CoreVideo. See [Moving this into IamfatnessWebsite](#moving-this-into-iamfatnesswebsite).
+
+## What this is
+
+A tiny, dependency-free static site served by a Cloudflare Worker, mirroring the
+deployment pattern already used by `corevideo.iamfatness.us` and
+`resonance.iamfatness.us`:
+
+```
+public/            Static site (served by the Worker's ASSETS binding)
+  index.html       Landing page
+  404.html         Custom not-found page
+  assets/site.css  Brand styling (dark cyan/blue, matches CoreVideo)
+  CNAME            iamfatness.us
+site-worker.js     Worker: static assets + security headers + trailing slash + 404
+wrangler.jsonc     Worker config + routes for iamfatness.us and www.iamfatness.us
+.github/workflows/deploy-site.yml   Deploy on push to main (or manual dispatch)
+```
+
+There is no build step — `public/` is served as-is.
+
+## Local preview
+
+```sh
+npm install
+npm run dev      # wrangler dev
+```
+
+## Deploy
+
+Deployment goes to the Cloudflare Worker named `iamfatness-website`, bound to the
+routes `iamfatness.us/*` and `www.iamfatness.us/*` in the `iamfatness.us` zone.
+
+The `Deploy Site` GitHub Actions workflow runs on pushes to `main` that touch the
+site, and can be triggered manually. It requires two repository secrets/vars:
+
+- `CLOUDFLARE_API_TOKEN` (secret) — permission to deploy Worker scripts + assets
+- `CLOUDFLARE_ACCOUNT_ID` (secret or variable)
+
+Manual deploy:
+
+```sh
+npm install
+npm run deploy   # wrangler deploy
+```
+
+## Moving this into IamfatnessWebsite
+
+The session that created this could not push to `iamfatness/IamfatnessWebsite`
+(it wasn't in that session's repo scope). To publish it:
+
+**Option A — use the helper script** (from inside this folder):
+
+```sh
+./push-to-website-repo.sh git@github.com:iamfatness/IamfatnessWebsite.git main
+```
+
+It clones the website repo, copies everything here (except the script itself and
+build artifacts) into it, commits, and pushes.
+
+**Option B — do it by hand:**
+
+```sh
+git clone git@github.com:iamfatness/IamfatnessWebsite.git
+rsync -a --exclude '.git/' --exclude 'node_modules/' \
+  --exclude 'push-to-website-repo.sh' iamfatness-website/ IamfatnessWebsite/
+cd IamfatnessWebsite && git add -A && git commit -m "Add iamfatness.us landing site" && git push
+```
+
+After pushing, set the two Cloudflare secrets and run **Deploy Site**, then point
+the `iamfatness.us` zone's route at the `iamfatness-website` Worker.
+
+Once the site is live and verified, the `iamfatness-website/` folder can be
+deleted from the CoreVideo branch (it was only ever staging).

--- a/iamfatness-website/package.json
+++ b/iamfatness-website/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "iamfatness-website",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Umbrella landing site for iamfatness.us",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4"
+  }
+}

--- a/iamfatness-website/public/404.html
+++ b/iamfatness-website/public/404.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page not found | iamfatness</title>
+  <link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="/"><span class="brand-mark" aria-hidden="true"></span><span>iamfatness</span></a>
+    <nav>
+      <a href="https://corevideo.iamfatness.us/">CoreVideo</a>
+      <a href="https://resonance.iamfatness.us/">Resonance</a>
+      <a href="https://github.com/iamfatness">GitHub</a>
+    </nav>
+  </header>
+  <main class="content">
+    <section class="hero">
+      <p class="eyebrow">404</p>
+      <h1>That page wandered off.</h1>
+      <p class="lede">The page you were looking for isn't here. Head back home or jump straight to one of the products.</p>
+      <div class="hero-actions">
+        <a class="button primary" href="/">Back home</a>
+        <a class="button" href="https://corevideo.iamfatness.us/">CoreVideo</a>
+        <a class="button" href="https://resonance.iamfatness.us/">Resonance</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/iamfatness-website/public/CNAME
+++ b/iamfatness-website/public/CNAME
@@ -1,0 +1,1 @@
+iamfatness.us

--- a/iamfatness-website/public/assets/site.css
+++ b/iamfatness-website/public/assets/site.css
@@ -1,0 +1,212 @@
+:root {
+  color-scheme: dark;
+  --bg: #070914;
+  --bg-2: #101528;
+  --panel: rgba(14, 18, 35, 0.88);
+  --text: #f7faff;
+  --muted: #9daac2;
+  --line: rgba(125, 239, 255, 0.18);
+  --cyan: #22e7e8;
+  --blue: #2aa8ff;
+}
+
+* { box-sizing: border-box; }
+html { min-height: 100%; }
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 28% 18%, rgba(34, 231, 232, 0.16), transparent 26rem),
+    radial-gradient(circle at 82% 72%, rgba(42, 168, 255, 0.12), transparent 30rem),
+    linear-gradient(145deg, var(--bg), var(--bg-2));
+  color: var(--text);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 42px 42px;
+  mask-image: linear-gradient(to bottom, black, transparent 78%);
+}
+
+a { color: var(--cyan); text-decoration-thickness: 1px; text-underline-offset: 3px; }
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px clamp(20px, 5vw, 56px);
+  border-bottom: 1px solid var(--line);
+  background: rgba(7, 9, 20, 0.82);
+  backdrop-filter: blur(16px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text);
+  font-weight: 750;
+  font-size: 20px;
+  text-decoration: none;
+}
+.brand-mark {
+  position: relative;
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--cyan), var(--blue));
+  box-shadow: 0 0 24px rgba(34, 231, 232, 0.35);
+}
+.brand-mark::before {
+  content: "";
+  position: absolute;
+  inset: 7px 8px;
+  background: #07101c;
+  border-radius: 50%;
+}
+.brand-mark::after {
+  content: "";
+  position: absolute;
+  left: 13px;
+  top: 9px;
+  width: 0;
+  height: 0;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  border-left: 11px solid var(--cyan);
+  filter: drop-shadow(0 0 6px rgba(34, 231, 232, 0.75));
+}
+nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+nav a {
+  color: var(--muted);
+  font-size: 14px;
+  text-decoration: none;
+}
+nav a:hover { color: var(--text); }
+
+.content {
+  width: min(1120px, calc(100% - 40px));
+  margin: 42px auto 56px;
+  flex: 1 0 auto;
+}
+
+.hero {
+  max-width: 760px;
+  margin: clamp(24px, 6vw, 72px) 0 clamp(40px, 8vw, 88px);
+}
+.eyebrow {
+  margin: 0 0 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--cyan);
+}
+.hero h1 {
+  margin: 0 0 18px;
+  font-size: clamp(32px, 6vw, 56px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+}
+.lede {
+  margin: 0 0 28px;
+  font-size: clamp(16px, 2.2vw, 19px);
+  color: var(--muted);
+}
+.hero-actions,
+.product-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 18px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+}
+.button:hover { border-color: var(--cyan); transform: translateY(-1px); }
+.button.primary {
+  background: linear-gradient(135deg, var(--cyan), var(--blue));
+  border-color: transparent;
+  color: #04121b;
+}
+
+.products {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 22px;
+}
+.product-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: clamp(22px, 3vw, 32px);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.product-tag {
+  align-self: flex-start;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cyan);
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+}
+.product-card h2 {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  letter-spacing: -0.01em;
+}
+.product-card p {
+  margin: 0;
+  color: var(--muted);
+}
+.product-actions { margin-top: auto; padding-top: 6px; }
+
+.site-footer {
+  flex-shrink: 0;
+  padding: 24px clamp(20px, 5vw, 56px);
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+@media (max-width: 560px) {
+  nav { gap: 12px; }
+  nav a { font-size: 13px; }
+}

--- a/iamfatness-website/public/index.html
+++ b/iamfatness-website/public/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>iamfatness | Independent tools for live production and music</title>
+  <meta name="description" content="iamfatness builds independent, local-first tools for creators: CoreVideo for live Zoom production in OBS, and Resonance, a DJ-style music player and EQ workbench.">
+  <meta name="theme-color" content="#070914">
+  <meta property="og:title" content="iamfatness">
+  <meta property="og:description" content="Independent, local-first tools for live production and music.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://iamfatness.us/">
+  <link rel="canonical" href="https://iamfatness.us/">
+  <link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="/"><span class="brand-mark" aria-hidden="true"></span><span>iamfatness</span></a>
+    <nav>
+      <a href="#products">Products</a>
+      <a href="https://corevideo.iamfatness.us/">CoreVideo</a>
+      <a href="https://resonance.iamfatness.us/">Resonance</a>
+      <a href="https://github.com/iamfatness">GitHub</a>
+    </nav>
+  </header>
+
+  <main class="content">
+    <section class="hero">
+      <p class="eyebrow">Independent software studio</p>
+      <h1>Local-first tools for live production and music.</h1>
+      <p class="lede">
+        iamfatness builds focused, open tools that keep processing on the
+        operator's machine &mdash; no cloud middleman, no lock-in. Two products
+        ship today, each on its own subdomain.
+      </p>
+      <div class="hero-actions">
+        <a class="button primary" href="#products">Explore the products</a>
+        <a class="button" href="https://github.com/iamfatness">View on GitHub</a>
+      </div>
+    </section>
+
+    <section id="products" class="products" aria-label="Products">
+      <article class="product-card">
+        <span class="product-tag">Live video production</span>
+        <h2>CoreVideo</h2>
+        <p>
+          An OBS Studio plugin that routes raw Zoom participant video, audio,
+          screen share, and interpretation into broadcast, recording, and
+          ISO-style production workflows &mdash; plus CoreVideo Pro, a standalone
+          production app. Processing stays local to the operator machine.
+        </p>
+        <div class="product-actions">
+          <a class="button primary" href="https://corevideo.iamfatness.us/">corevideo.iamfatness.us</a>
+          <a class="button" href="https://github.com/iamfatness/CoreVideo">Source</a>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <span class="product-tag">Music &amp; DJ tooling</span>
+        <h2>Resonance</h2>
+        <p>
+          A DJ-style music player and EQ workbench for mixing embedded YouTube
+          decks with mood-driven guidance, hot cues, a crossfader, and
+          desktop-native audio processing experiments for real per-deck EQ.
+        </p>
+        <div class="product-actions">
+          <a class="button primary" href="https://resonance.iamfatness.us/">resonance.iamfatness.us</a>
+          <a class="button" href="https://github.com/iamfatness/resonance">Source</a>
+        </div>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <span>&copy; <span id="year">2026</span> iamfatness &mdash; independent open-source projects. Not affiliated with Zoom Video Communications, Inc. or YouTube / Google LLC.</span>
+  </footer>
+
+  <script>document.getElementById("year").textContent = new Date().getFullYear();</script>
+</body>
+</html>

--- a/iamfatness-website/push-to-website-repo.sh
+++ b/iamfatness-website/push-to-website-repo.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Copy this staged site into the standalone IamfatnessWebsite repo and push it.
+#
+# This staging folder lives on a branch of the CoreVideo repo only as a delivery
+# mechanism (the session that built it could not push to IamfatnessWebsite).
+# Run this from inside the `iamfatness-website/` directory.
+#
+# Usage:
+#   ./push-to-website-repo.sh [git-remote-url] [branch]
+#
+# Defaults:
+#   remote = git@github.com:iamfatness/IamfatnessWebsite.git
+#   branch = main
+#
+set -euo pipefail
+
+REMOTE="${1:-git@github.com:iamfatness/IamfatnessWebsite.git}"
+BRANCH="${2:-main}"
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Cloning $REMOTE ..."
+git clone "$REMOTE" "$WORK_DIR"
+
+echo "Copying staged site into the repo ..."
+# Copy everything except this script and any local build artifacts.
+rsync -a --delete \
+  --exclude '.git/' \
+  --exclude 'node_modules/' \
+  --exclude '.wrangler/' \
+  --exclude 'push-to-website-repo.sh' \
+  "$SRC_DIR"/ "$WORK_DIR"/
+
+cd "$WORK_DIR"
+git checkout -B "$BRANCH"
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to commit. The website repo is already up to date."
+  exit 0
+fi
+git commit -m "Add iamfatness.us umbrella landing site"
+git push -u origin "$BRANCH"
+
+echo
+echo "Done. Pushed the landing site to $REMOTE ($BRANCH)."
+echo "Next: set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID repo secrets,"
+echo "then run the 'Deploy Site' workflow (or 'npm install && npm run deploy')."

--- a/iamfatness-website/site-worker.js
+++ b/iamfatness-website/site-worker.js
@@ -1,0 +1,60 @@
+// Static-asset Cloudflare Worker for iamfatness.us.
+// Serves the contents of ./public with hardened security headers,
+// trailing-slash normalization, and a custom 404 page.
+
+const SECURITY_HEADERS = {
+  "content-security-policy":
+    "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; script-src 'self'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+  "referrer-policy": "strict-origin-when-cross-origin",
+  "x-content-type-options": "nosniff",
+  "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
+};
+
+function withHeaders(response) {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function fetchAsset(request, env, pathname) {
+  const url = new URL(request.url);
+  url.pathname = pathname;
+  return env.ASSETS.fetch(new Request(url, request));
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    let response = await env.ASSETS.fetch(request);
+    if (response.status !== 404) {
+      return withHeaders(response);
+    }
+
+    // Redirect extension-less paths to their trailing-slash form.
+    if (!url.pathname.endsWith("/") && !url.pathname.includes(".")) {
+      url.pathname += "/";
+      return Response.redirect(url.toString(), 301);
+    }
+
+    // Serve directory index documents.
+    if (url.pathname.endsWith("/")) {
+      response = await fetchAsset(request, env, `${url.pathname}index.html`);
+      if (response.status !== 404) {
+        return withHeaders(response);
+      }
+    }
+
+    response = await fetchAsset(request, env, "/404.html");
+    return withHeaders(new Response(response.body, {
+      status: 404,
+      headers: response.headers,
+    }));
+  },
+};

--- a/iamfatness-website/wrangler.jsonc
+++ b/iamfatness-website/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "iamfatness-website",
+  "main": "site-worker.js",
+  "compatibility_date": "2026-06-01",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    {
+      "pattern": "iamfatness.us/*",
+      "zone_name": "iamfatness.us"
+    },
+    {
+      "pattern": "www.iamfatness.us/*",
+      "zone_name": "iamfatness.us"
+    }
+  ],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "./public"
+  }
+}


### PR DESCRIPTION
## What

Adds a self-contained umbrella landing site for the **iamfatness.us** root domain under `iamfatness-website/`. It introduces the studio and links out to the products on their own subdomains:

- **CoreVideo** → corevideo.iamfatness.us (OBS plugin + CoreVideo Pro)
- **Resonance** → resonance.iamfatness.us (DJ-style player / EQ)

The site is dependency-free static HTML/CSS served by a Cloudflare Worker, mirroring the existing `corevideo-docs` / `resonance-app` deploy pattern (worker `iamfatness-website`, routes `iamfatness.us/*` + `www.iamfatness.us/*`).

```
iamfatness-website/
  public/{index.html,404.html,assets/site.css,CNAME}
  site-worker.js          static assets + security headers + trailing-slash + 404
  wrangler.jsonc          worker config + zone routes
  .github/workflows/deploy-site.yml
  push-to-website-repo.sh  helper to copy + push into IamfatnessWebsite
  README.md
```

## Why this is a draft / staging only

The goal is a **standalone `iamfatness/IamfatnessWebsite` repo**, but that repo wasn't in this session's scope, so it couldn't be pushed to directly. This branch is the delivery mechanism: the `iamfatness-website/` folder is meant to be copied into `IamfatnessWebsite` (via `push-to-website-repo.sh` or by hand — see the README), **not merged into CoreVideo**. Once the new repo is live and verified, the folder can be deleted from this branch.

## Scope note

Per the direction chosen, this only **creates a new umbrella landing page** (none existed before). It does **not** move the existing `corevideo.iamfatness.us` site out of this repo, and does **not** touch the Resonance or CoreVideo Pro repos — those subdomain sites are the products themselves.

## Follow-ups (manual)

1. Run `iamfatness-website/push-to-website-repo.sh` to publish into `IamfatnessWebsite`.
2. Set `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets on the new repo.
3. Run **Deploy Site** and point the `iamfatness.us` zone route at the `iamfatness-website` worker.

https://claude.ai/code/session_01AdKTLoghAXyxeNiRSNTpAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdKTLoghAXyxeNiRSNTpAQ)_