### PR TITLE
Add generated case-variant alias pages for corevideo.iamfatness.us

### DIFF
--- a/public/Privacy-Policy/index.html
+++ b/public/Privacy-Policy/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy | CoreVideo</title>
+  <meta name="description" content="Privacy Policy for the CoreVideo OBS Studio plugin.">
+  <link rel="stylesheet" href="/assets/site.css">
+</head>
+<body class="document-page">
+  <header class="site-header">
+    <a class="brand" href="/"><span class="brand-mark" aria-hidden="true"></span><span>CoreVideo</span></a>
+    <nav><a href="/">Home</a><a href="/pro/">CoreVideo Pro</a><a href="/documentation/">Documentation</a><a href="/core-plugin/">Core Plugin</a><a href="/oauth/">OAuth</a><a href="/terms/">Terms</a><a href="/privacy/">Privacy</a><a href="/support/">Support</a></nav>
+  </header>
+  <main class="content">
+    <h1>Privacy Policy</h1>
+<p><em>Last updated: May 2026</em></p>
+<h2>Overview</h2>
+<p>CoreVideo is an open-source OBS Studio plugin. This privacy policy explains what data the plugin processes, where it goes, and what is stored.</p>
+<hr>
+<h2>Data Processed</h2>
+<h3>Meeting Audio and Video</h3>
+<p>CoreVideo receives raw video (I420 YUV), screen share, interpretation audio, and audio (48 kHz PCM) streams from the Zoom Meeting SDK. These streams are:</p>
+<ul><li>Processed <strong>locally on the operator's machine only</strong></li><li>Delivered directly to OBS Studio as native source frames</li><li><strong>Never transmitted to any CoreVideo server, third-party service, or remote endpoint</strong></li></ul>
+<h3>Participant Roster</h3>
+<p>CoreVideo receives participant metadata from the Zoom SDK (display names, user IDs, mute/video/talking state, host/co-host status, spotlight position). This information is:</p>
+<ul><li>Held in memory only for the duration of the meeting session</li><li>Displayed within OBS for source assignment purposes</li><li>Not transmitted outside the local machine by CoreVideo</li></ul>
+<h3>Credentials and Tokens</h3>
+<p>Published CoreVideo builds use Zoom Public Client OAuth + PKCE through the CoreVideo broker. End users do not enter Zoom app client secrets.</p>
+<p>The following local settings may be saved by the plugin:</p>
+<table><thead><tr><th>Credential / setting</th><th>Storage location</th><th>Purpose</th></tr></thead><tbody><tr><td>Zoom OAuth access/refresh tokens</td><td>OBS plugin config directory</td><td>Zoom sign-in, token refresh, and ZAK requests</td></tr><tr><td>Control server token</td><td>OBS plugin config directory</td><td>Authenticating TCP/OSC API clients</td></tr><tr><td>Control server ports</td><td>OBS plugin config directory</td><td>TCP JSON and UDP OSC port configuration</td></tr><tr><td>Output profiles</td><td>OBS plugin config directory</td><td>Optional participant-to-source mappings</td></tr></tbody></table>
+<p>On Windows, OAuth tokens are DPAPI-protected before storage. Meeting SDK client secrets are not stored in the plugin or broker for the public-client production path.</p>
+<hr>
+<h2>Third-Party Services</h2>
+<h3>Zoom Meeting SDK</h3>
+<p>CoreVideo uses the <strong>Zoom Meeting SDK</strong> to join and capture meeting content. When joining a meeting, your machine connects to Zoom's infrastructure. Zoom's own privacy policy governs all data exchanged with Zoom's servers:</p>
+<ul><li><a href="https://explore.zoom.us/en/privacy/">Zoom Privacy Policy</a></li><li><a href="https://marketplace.zoom.us/docs/api-reference/developer-agreement">Zoom Marketplace Developer Agreement</a></li></ul>
+<h3>CoreVideo OAuth Broker</h3>
+<p>The broker at <code>corevideo.iamfatness.us</code> is used only for Zoom OAuth token exchange and refresh. It does not receive or process meeting audio, video, screen share, or participant media.</p>
+<h3>Cloudflare and GitHub (Documentation)</h3>
+<p>The documentation site at <code>corevideo.iamfatness.us</code> is served through Cloudflare and sourced from the public CoreVideo GitHub repository. Cloudflare's and GitHub's privacy policies apply to visits to that site:</p>
+<ul><li><a href="https://www.cloudflare.com/privacypolicy/">Cloudflare Privacy Policy</a></li><li><a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub Privacy Statement</a></li></ul>
+<hr>
+<h2>Data Retention</h2>
+<ul><li><strong>No meeting media is retained by CoreVideo</strong> beyond the local OBS session unless the operator records or streams through OBS.</li><li>OAuth tokens persist until the user signs out, revokes access, or removes the plugin configuration.</li><li>Credentials saved in the OBS config directory persist until deleted via the Settings dialog or plugin removal.</li><li>OBS itself may retain scenes, sources, and recordings per its own configuration - outside the scope of this policy.</li></ul>
+<hr>
+<h2>Children's Privacy</h2>
+<p>CoreVideo is a professional broadcast tool not directed at children. No data from minors is knowingly collected.</p>
+<hr>
+<h2>Changes to This Policy</h2>
+<p>Updates will be reflected in the <code>Last updated</code> date above. Significant changes will be noted in the <a href="https://github.com/iamfatness/CoreVideo/releases">release notes</a>.</p>
+<hr>
+<h2>Contact</h2>
+<p>For privacy questions, open an issue at <a href="https://github.com/iamfatness/CoreVideo/issues">github.com/iamfatness/CoreVideo/issues</a> with the label <code>privacy</code>.</p>
+  </main>
+  <footer class="site-footer">
+    <span>CoreVideo is an independent product and is not affiliated with Zoom Video Communications, Inc.</span>
+  </footer>
+</body>
+</html>

--- a/public/Support/index.html
+++ b/public/Support/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Support | CoreVideo</title>
+  <meta name="description" content="Support resources for the CoreVideo OBS Studio plugin.">
+  <link rel="stylesheet" href="/assets/site.css">
+</head>
+<body class="document-page">
+  <header class="site-header">
+    <a class="brand" href="/"><span class="brand-mark" aria-hidden="true"></span><span>CoreVideo</span></a>
+    <nav><a href="/">Home</a><a href="/pro/">CoreVideo Pro</a><a href="/documentation/">Documentation</a><a href="/core-plugin/">Core Plugin</a><a href="/oauth/">OAuth</a><a href="/terms/">Terms</a><a href="/privacy/">Privacy</a><a href="/support/">Support</a></nav>
+  </header>
+  <main class="content">
+    <h1>Support</h1>
+<h2>Documentation</h2>
+<p>Before opening an issue, check the full documentation site - most configuration questions and architecture details are covered there:</p>
+<p><strong><a href="/documentation/">/documentation/</a></strong></p>
+<table><thead><tr><th>Topic</th><th>Link</th></tr></thead><tbody><tr><td>Installation &amp; build</td><td><a href="/documentation/#installation">Installation</a></td></tr><tr><td>Configuration</td><td><a href="/documentation/#configuration">Configuration</a></td></tr><tr><td>Zoom Control Dock</td><td><a href="/documentation/#zoom-dock">Zoom Control Dock</a></td></tr><tr><td>Assignment modes (Spotlight, Active Speaker, Screen Share)</td><td><a href="/documentation/#assignment-modes">Assignment Modes</a></td></tr><tr><td>Active speaker debounce</td><td><a href="/documentation/#active-speaker">Active Speaker Mode</a></td></tr><tr><td>Auto-reconnect</td><td><a href="/documentation/#auto-reconnect">Auto-Reconnect</a></td></tr><tr><td>Hardware video acceleration</td><td><a href="/documentation/#hw-accel">Hardware Video Acceleration</a></td></tr><tr><td>TCP control API</td><td><a href="/documentation/#control-api">TCP Control API</a></td></tr><tr><td>OSC control API</td><td><a href="/documentation/#osc-api">OSC Control API</a></td></tr><tr><td>IPC protocol reference</td><td><a href="/documentation/#ipc-protocol">IPC Protocol</a></td></tr></tbody></table>
+<hr>
+<h2>Reporting Bugs</h2>
+<p>Open an issue at <strong><a href="https://github.com/iamfatness/CoreVideo/issues">github.com/iamfatness/CoreVideo/issues</a></strong>.</p>
+<p>Please include:</p>
+<ul><li><strong>CoreVideo version</strong> (shown in OBS log: <code>[obs-zoom-plugin] Loading plugin v...</code>)</li><li><strong>OBS Studio version</strong></li><li><strong>Operating system</strong> (Windows 10/11, macOS version, Linux distro)</li><li><strong>Zoom Meeting SDK version</strong> (5.17.x or 7.x)</li><li><strong>Steps to reproduce</strong> the issue</li><li><strong>OBS log file</strong> - in OBS go to Help -&gt; Log Files -&gt; Upload Current Log File and paste the link</li><li><strong>Expected vs. actual behavior</strong></li></ul>
+<hr>
+<h2>Common Issues</h2>
+<h3>Raw-data permission or stream-count error at runtime</h3>
+<p><strong>Cause:</strong> Raw data access is available through Zoom Meeting SDK apps, but the signed-in account and app entitlements still determine negotiated quality, bandwidth, and stream count. Standard accounts are typically limited to a 30 Mbps incoming video budget; Enhanced Media / HBM can raise that envelope to roughly 100 Mbps. Developers may also need an app-level entitlement flag to test more than a small number of concurrent raw streams.</p>
+<p><strong>Fix:</strong> Verify the Meeting SDK app is approved or beta-enabled for the account joining the meeting, then confirm the expected bandwidth and developer/app entitlements with Zoom. Treat Enhanced Media / HBM as a production quality and bandwidth tier, not as a hard prerequisite for raw data.</p>
+<hr>
+<h3>OAuth sign-in or join authentication fails</h3>
+<p><strong>Cause:</strong> The local plugin, published broker, or Zoom Marketplace app environment is out of sync.</p>
+<p><strong>Fix:</strong></p>
+<ol><li>Sign out and sign back in from <strong>Tools -&gt; Zoom Plugin Settings</strong>.</li><li>Confirm the published broker page is available at <code>https://corevideo.iamfatness.us/oauth/start</code>.</li><li>Confirm the Zoom Marketplace app has Public Client OAuth enabled, the redirect URL is <code>https://corevideo.iamfatness.us/oauth/callback</code>, and Meeting SDK / Embed is enabled for the same environment.</li><li>Check the OBS log for <code>[obs-zoom-plugin]</code> OAuth, ZAK, or Meeting SDK auth errors.</li></ol>
+<hr>
+<h3>Engine fails to start / IPC connection timeout</h3>
+<p><strong>Cause:</strong> <code>ZoomObsEngine</code> could not be launched or located.</p>
+<p><strong>Fix:</strong></p>
+<ol><li>Confirm <code>ZoomObsEngine</code> (<code>.exe</code> on Windows) is in the same directory as the plugin.</li><li>On macOS, remove quarantine: <code>xattr -d com.apple.quarantine ZoomObsEngine</code></li><li>On Linux, ensure execute permission: <code>chmod +x ZoomObsEngine</code></li><li>Check the OBS log for <code>[obs-zoom-plugin]</code> launch failure messages.</li></ol>
+<hr>
+<h3>Blank / black video from a participant</h3>
+<p><strong>Cause:</strong> Participant camera is off, or the subscription was dropped.</p>
+<p><strong>Fix:</strong></p>
+<ol><li>Confirm the participant has their camera enabled in Zoom.</li><li>Set <strong>On video loss</strong> -&gt; <strong>Hold last frame</strong> in source properties to avoid going black on brief drops.</li><li>Click <strong>Refresh</strong> in the participant list and re-subscribe.</li></ol>
+<hr>
+<h3>No audio from a participant</h3>
+<p><strong>Cause:</strong> Incorrect audio mode or participant is muted.</p>
+<p><strong>Fix:</strong></p>
+<ol><li>Set <strong>Audio Channels</strong> to <strong>Mono</strong> or <strong>Stereo</strong> (not None) in source properties.</li><li>Confirm the participant is unmuted in Zoom.</li><li>If using <strong>Isolate Audio</strong>, confirm the correct participant ID is selected.</li><li>Check the OBS audio mixer - the track may be muted or set to Monitor Only.</li></ol>
+<hr>
+<h3>Auto-reconnect triggers but never succeeds</h3>
+<p><strong>Cause:</strong> The underlying error (auth failure, app entitlement issue, network) is permanent.</p>
+<p><strong>Fix:</strong></p>
+<ol><li>Check the OBS log for the <code>RecoveryReason</code> and error codes.</li><li>If the reason is <code>LicenseError</code>, see the raw-data permission or stream-count issue above.</li><li>If the reason is <code>AuthFailure</code>, sign out and sign back in from <strong>Tools -&gt; Zoom Plugin Settings</strong>.</li><li>Click <strong>Cancel Recovery</strong> in the Zoom Control dock, resolve the root cause, then re-join manually.</li></ol>
+<hr>
+<h3>TCP or OSC control API not responding</h3>
+<p><strong>Fix:</strong></p>
+<ol><li>Confirm port numbers in <strong>Tools -&gt; Zoom Plugin Settings</strong> match your client (defaults: TCP 19870, OSC 19871).</li><li>Both servers bind to <code>127.0.0.1</code> (loopback) - external connections are not supported by default.</li><li>Check for <code>TCP control server unavailable</code> or <code>OSC server unavailable</code> in the OBS log - another process may own the port.</li></ol>
+<hr>
+<h2>Feature Requests</h2>
+<p>Feature requests are welcome as GitHub issues. Search existing issues first. Label your request <code>enhancement</code>.</p>
+<hr>
+<h2>Zoom Bandwidth and Enhanced Media / HBM</h2>
+<p>CoreVideo does not require Enhanced Media / HBM simply to access Meeting SDK raw data. Quality and concurrency are still bounded by Zoom account and app entitlements:</p>
+<ul><li>Standard accounts commonly operate within a 30 Mbps incoming video envelope.</li><li>Enhanced Media / HBM can raise the incoming video envelope to roughly 100 Mbps.</li><li>Standard 1080p feeds are typically about 4-6 Mbps each.</li><li>100 Mbps can support roughly 16 standard 1080p feeds, or about 8 high-bitrate / 60 fps feeds.</li><li>Developers may need a separate app entitlement flag for testing more than a small number of raw streams; end users should not need that developer flag.</li></ul>
+<hr>
+<h2>Security</h2>
+<p>For security vulnerabilities, <strong>do not open a public issue</strong>. See <a href="https://github.com/iamfatness/CoreVideo/blob/main/SECURITY.md">SECURITY.md</a> for the responsible disclosure process.</p>
+  </main>
+  <footer class="site-footer">
+    <span>CoreVideo is an independent product and is not affiliated with Zoom Video Communications, Inc.</span>
+  </footer>
+</body>
+</html>

--- a/public/Terms-of-Use/index.html
+++ b/public/Terms-of-Use/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Terms of Use | CoreVideo</title>
+  <meta name="description" content="Terms of Use for the CoreVideo OBS Studio plugin.">
+  <link rel="stylesheet" href="/assets/site.css">
+</head>
+<body class="document-page">
+  <header class="site-header">
+    <a class="brand" href="/"><span class="brand-mark" aria-hidden="true"></span><span>CoreVideo</span></a>
+    <nav><a href="/">Home</a><a href="/pro/">CoreVideo Pro</a><a href="/documentation/">Documentation</a><a href="/core-plugin/">Core Plugin</a><a href="/oauth/">OAuth</a><a href="/terms/">Terms</a><a href="/privacy/">Privacy</a><a href="/support/">Support</a></nav>
+  </header>
+  <main class="content">
+    <h1>Terms of Use</h1>
+<p><em>Last updated: May 2026</em></p>
+<h2>1. Acceptance</h2>
+<p>By installing, configuring, or using CoreVideo (&quot;the Plugin&quot;), you agree to these Terms of Use and to all applicable third-party terms referenced herein. If you do not agree, do not use the Plugin.</p>
+<hr>
+<h2>2. License</h2>
+<p>CoreVideo is released under the terms of its open-source license (see <a href="https://github.com/iamfatness/CoreVideo/blob/main/LICENSE">LICENSE</a> in the repository). You are free to use, modify, and redistribute the Plugin in accordance with that license.</p>
+<hr>
+<h2>3. Zoom Meeting SDK Raw Data and Account Limits</h2>
+<p>CoreVideo uses the Zoom Meeting SDK's <strong>raw data APIs</strong> to capture uncompressed video and audio. Raw data access is available through Meeting SDK apps, but negotiated quality, bandwidth, meeting duration, and concurrent stream count are governed by the signed-in Zoom account, the meeting configuration, and app/developer entitlements.</p>
+<p>Enhanced Media / HBM is not a hard prerequisite for raw data access. It can materially increase production headroom by raising the incoming video bandwidth envelope from roughly 30 Mbps to roughly 100 Mbps. At about 4-6 Mbps per standard 1080p stream, several 1080p feeds may work without EM; with EM/HBM, plan around up to 16 standard 1080p feeds or about 8 high-bitrate / 60 fps feeds before hitting the downlink budget.</p>
+<p>By using CoreVideo you confirm that:</p>
+<ul><li>You are responsible for confirming the Zoom account, meeting, and app entitlements needed for your intended production quality and stream count.</li><li>You will not use the Plugin to capture Zoom meeting content in violation of the <a href="https://marketplace.zoom.us/docs/api-reference/developer-agreement">Zoom Marketplace Developer Agreement</a> or applicable Zoom terms of service.</li><li>You understand that account bandwidth, app approval, developer flags, and Zoom plan limits can affect the number and quality of raw streams CoreVideo can receive.</li></ul>
+<hr>
+<h2>4. Zoom Terms of Service</h2>
+<p>Your use of the Zoom Meeting SDK through CoreVideo is additionally governed by:</p>
+<ul><li><a href="https://explore.zoom.us/en/terms/">Zoom Terms of Service</a></li><li><a href="https://marketplace.zoom.us/docs/api-reference/developer-agreement">Zoom Marketplace Developer Agreement</a></li><li><a href="https://explore.zoom.us/en/privacy/">Zoom Privacy Policy</a></li></ul>
+<p>CoreVideo is an independent project and is <strong>not affiliated with, endorsed by, or supported by Zoom Video Communications, Inc.</strong></p>
+<hr>
+<h2>5. Meeting Participant Consent</h2>
+<p>You are solely responsible for ensuring that all meeting participants have been informed of, and have consented to, any recording or live capture of their video, audio, or screen-share content. Requirements vary by jurisdiction. Consult legal counsel if unsure.</p>
+<hr>
+<h2>6. Permitted Use</h2>
+<p>The Plugin may be used for:</p>
+<ul><li>Professional broadcast, live production, and event streaming</li><li>Conference and event recording (with appropriate consent)</li><li>Internal corporate communications and hybrid events</li><li>Educational and research purposes</li></ul>
+<p>The Plugin may <strong>not</strong> be used for:</p>
+<ul><li>Unauthorized recording or surveillance of meeting participants</li><li>Capturing content in violation of applicable wiretapping, recording, or privacy laws</li><li>Any purpose that violates Zoom's terms of service or the Zoom Marketplace Developer Agreement</li></ul>
+<hr>
+<h2>7. No Warranty</h2>
+<p>The Plugin is provided <strong>&quot;as is&quot;</strong>, without warranty of any kind, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement. The authors make no guarantee that the Plugin will operate without interruption or error.</p>
+<hr>
+<h2>8. Limitation of Liability</h2>
+<p>To the maximum extent permitted by applicable law, the authors of CoreVideo shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of or inability to use the Plugin, even if advised of the possibility of such damages.</p>
+<hr>
+<h2>9. Changes</h2>
+<p>These terms may be updated at any time. Continued use of the Plugin after changes are posted constitutes acceptance of the revised terms. Material changes will be noted in the <a href="https://github.com/iamfatness/CoreVideo/releases">release notes</a>.</p>
+<hr>
+<h2>10. Contact</h2>
+<p>Questions about these terms may be directed to <a href="https://github.com/iamfatness/CoreVideo/issues">github.com/iamfatness/CoreVideo/issues</a>.</p>
+  </main>
+  <footer class="site-footer">
+    <span>CoreVideo is an independent product and is not affiliated with Zoom Video Communications, Inc.</span>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to #123. Commits the build-generated case-variant alias pages (`Support/`, `Terms-of-Use/`, `Privacy-Policy/`) emitted by `scripts/build-site.mjs`, so the checked-in `public/` snapshot matches the reworked pages (GitHub nav removed). These are regenerated at deploy regardless; this just keeps the tree clean.

https://claude.ai/code/session_014a9kwCDC3BQmxCcJxHUWWP

---
_Generated by [Claude Code](https://claude.ai/code/session_014a9kwCDC3BQmxCcJxHUWWP)_