### PR TITLE
Link the CoreVideo Pro page to the live web demo

### DIFF
--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -10,7 +10,7 @@
 <body class="home-page">
   <header class="site-header">
     <a class="brand" href="/"><span class="brand-mark" aria-hidden="true"></span><span>CoreVideo</span></a>
-    <nav><a href="/">Home</a><a href="/pro/">CoreVideo Pro</a><a href="/pro/documentation/">Pro Docs</a><a href="/documentation/">Plugin Docs</a><a href="/core-plugin/">Core Plugin</a><a href="/oauth/">OAuth</a><a href="/terms/">Terms</a><a href="/privacy/">Privacy</a><a href="/support/">Support</a></nav>
+    <nav><a href="/">Home</a><a href="/pro/">CoreVideo Pro</a><a href="/pro/demo/">Demo</a><a href="/pro/documentation/">Pro Docs</a><a href="/documentation/">Plugin Docs</a><a href="/core-plugin/">Core Plugin</a><a href="/oauth/">OAuth</a><a href="/terms/">Terms</a><a href="/privacy/">Privacy</a><a href="/support/">Support</a></nav>
   </header>
   <main class="content">
     <section class="hero">
@@ -22,9 +22,11 @@
     <h1>Produce polished live conversations from your Zoom calls.</h1>
     <p class="lede">CoreVideo Pro is the premium, all-in-one studio for live Zoom production: everything the CoreVideo plugin captures, plus multi-scene production, participant management, recording and multi-destination streaming, and an AI auto-director &mdash; in one standalone app for producers who want a dedicated, ready-to-go console.</p>
     <div class="hero-actions">
-      <a class="button primary" href="/pro/documentation/">Read the architecture docs</a>
+      <a class="button primary" href="/pro/demo/">Try the live demo</a>
+      <a class="button" href="/pro/documentation/">Read the architecture docs</a>
       <a class="button" href="/core-plugin/">Compare with the OBS plugin</a>
     </div>
+    <p class="hero-note">The demo runs entirely in your browser on a simulated Zoom session &mdash; explore the production console with no install and no real meeting.</p>
   </div>
 </section>
 <section class="link-grid" aria-label="CoreVideo Pro features">


### PR DESCRIPTION
## What

Adds a **"Try the live demo"** call-to-action to the CoreVideo Pro marketing page (`/pro/`), pointing at the new interactive web demo at **`/pro/demo/`** — the CoreVideo Pro operator console running in-browser on a simulated Zoom session.

## Changes (`public/pro/index.html`)

- Primary hero button **"Try the live demo"** → `/pro/demo/` (docs/compare buttons kept as secondary).
- **"Demo"** nav link.
- A short note clarifying the demo is browser-only on simulated data (no install, no real meeting).

## Sequencing ⚠️

`/pro/demo/` is served by the **`corevideo-pro-demo`** Worker built in the **CoreVideoPro** repo (PR iamfatness/corevideopro#97), via a more-specific Cloudflare route on `corevideo.iamfatness.us`. **Merge and deploy that PR first** so this link resolves; otherwise `/pro/demo/` 404s until the demo worker is live.

No other CoreVideo content changes; the rest of `corevideo.iamfatness.us` is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUMdGjcGroKzKe7J8qsdb3)_