### PR TITLE
Fix platform claims and off-Windows OAuth token storage honesty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,7 +251,10 @@ jobs:
 
   # macOS
   build-macos:
-    name: macOS Universal
+    # Host-arch compile validation only - see "Configure" step below for why
+    # plugin/engine stay OFF, and "Package as ZIP" for why this is not a
+    # "universal" build and not a shippable macOS package.
+    name: macOS Compile Validation (host arch)
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -351,15 +354,26 @@ jobs:
         run: ctest --test-dir build --output-on-failure
 
       - name: Package as ZIP
+        # NOTE: this is a compile-validation artifact, not a product build.
+        # COREVIDEO_BUILD_PLUGIN and COREVIDEO_BUILD_ENGINE are OFF above, so
+        # `install` contains no obs-zoom-plugin, no ZoomObsEngine, and no
+        # OAuth callback helper - just whatever no-op install rules the
+        # top-level CMakeLists.txt runs with both targets disabled. It is
+        # NOT a "macOS universal" build (CMAKE_OSX_ARCHITECTURES is pinned to
+        # the single runner host-arch, not "arm64;x86_64"), and it is not
+        # uploaded to GitHub Releases (see the release job below). The name
+        # says "tools-unsupported" so nobody mistakes it for an installable
+        # macOS package.
         run: |
           cmake --install build --prefix install
-          cd install && zip -r ../CoreVideo-macOS-universal.zip .
+          ARCH="$(uname -m)"
+          cd install && zip -r "../CoreVideo-macOS-${ARCH}-tools-unsupported.zip" .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: CoreVideo-macOS
-          path: CoreVideo-macOS-universal.zip
+          name: CoreVideo-macOS-compile-validation
+          path: CoreVideo-macOS-*-tools-unsupported.zip
           if-no-files-found: warn
 
       - name: Upload build logs on failure
@@ -483,6 +497,12 @@ jobs:
           draft: false
           prerelease: ${{ steps.release_name.outputs.pre == 'true' }}
           generate_release_notes: true
+          # Windows x64 is the only shippable artifact today. The macOS job
+          # only compiles the cross-platform sources for portability
+          # validation (COREVIDEO_BUILD_PLUGIN/ENGINE=OFF); its ZIP contains
+          # no plugin, no engine, and no OAuth helper, so it is deliberately
+          # NOT attached to the GitHub Release - attaching it would look like
+          # an installable macOS package that doesn't exist. See the
+          # build-macos job's "Package as ZIP" step for details.
           files: |
             artifacts/CoreVideo-Windows/CoreVideo-Windows-x64.zip
-            artifacts/CoreVideo-macOS/CoreVideo-macOS-universal.zip

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Operator Quickstart: **[Install, sign in, assign outputs, record ISO ->](docs/OP
 - **Output profiles** - save and load named participant-to-source mappings as JSON files
 - **Output manager dock** - dockable OBS panel and API for viewing and reconfiguring all sources at runtime, including active speaker, screen-share, and Spotlight 1-8 assignments with roster markers
 - **Public Client Meeting SDK authentication** - published builds pass the Marketplace Public Client ID as `AuthContext.publicAppKey`; no Meeting SDK secret is shipped in the desktop app
-- **Zoom OAuth PKCE** - user-level OAuth 2.0 with PKCE (public client, no desktop secret) for attributed joins and Marketplace compliance; the broker start URL is baked in at build time; `corevideo://` custom URL scheme with platform callback helpers (`CoreVideoOAuthCallback.exe` / `.app`); DPAPI token protection on Windows
+- **Zoom OAuth PKCE** - user-level OAuth 2.0 with PKCE (public client, no desktop secret) for attributed joins and Marketplace compliance; the broker start URL is baked in at build time; `corevideo://` custom URL scheme with platform callback helpers (`CoreVideoOAuthCallback.exe` / `.app`); DPAPI token protection on Windows (plaintext with a logged warning elsewhere - see [Security](#security))
 - **Visible Zoom Meeting SDK window** - the helper process uses Zoom's default Meeting SDK UI so operators can admit waiting-room participants, start self video/audio, and use normal in-meeting controls while OBS receives raw feeds
 - **SDK 5.17.x and 7.x** - auto-detects flat and subfolder header layouts
 - **Hardened security** - constant-time token comparison, validated IPC input, sanitised participant IDs, SIGPIPE handling
 - **Modern UI** - CoreVideo stylesheet with dark theme, animated `CvStatusDot`, `CvBanner` first-run notices, and button role variants (primary / danger)
-- **Multi-platform** - Windows (x64/arm64), macOS (universal arm64 + x86_64), Linux
+- **Platform support** - Windows 10/11 x64 is the only supported, packaged, and CI-released target. The same CMake project also configures on Windows arm64, macOS, and Linux, so source builds are possible there, but they are unsupported/experimental: no official installers or ZIPs are published for them today. See [Platform Support](#platform-support) below.
 
 ## Requirements
 
@@ -71,6 +71,17 @@ Operator Quickstart: **[Install, sign in, assign outputs, record ISO ->](docs/OP
 | Zoom Meeting SDK | **5.17.x / 7.x** | Source builds only: place in `third_party/zoom-sdk/`. Official Windows release downloads bundle the runtime files needed by end users. |
 | C++ compiler | C++17 | MSVC 2022 / Clang 14+ / GCC 11+ |
 | Zoom Developer Account | - | Marketplace app with Public Client OAuth + PKCE and Meeting SDK / Embed enabled for the same environment. |
+
+## Platform Support
+
+| Platform | Status |
+|---|---|
+| **Windows 10/11 x64** | **Supported.** The only platform with a maintained release pipeline (`.github/workflows/release-windows.yml`): checksummed ZIP and NSIS installer, published to GitHub Releases. This is the only configuration the maintainers build, test, and run in production. |
+| Windows arm64 | Source build only, untested. `CMakeLists.txt` auto-detects an arm64 Zoom SDK layout under `third_party/zoom-sdk/arm64` if present, but there is no arm64 CI job, no arm64 release artifact, and no maintainer testing on arm64 hardware. Treat it as "may compile," not "known to work." |
+| macOS (arm64 / x86_64) | Source build only, unsupported - **no official packages**. CI (`build.yml`, macOS job) only compiles the cross-platform engine/plugin sources with `-DCOREVIDEO_BUILD_PLUGIN=OFF -DCOREVIDEO_BUILD_ENGINE=OFF` to catch portability regressions; it does not build, link, or package the actual OBS plugin, and the CI artifact it produces is a compile-validation ZIP, not an installable macOS build (see below). There is no macOS Keychain-backed token storage yet (see Security), no notarization/signing, and no macOS QA. |
+| Linux | Source build only, unsupported - **no official packages**. CI (`build.yml`, Linux job) compiles and unit-tests only the cross-platform C++ (`BUILD_TESTING`) with the plugin/engine/sidecar all `OFF`; it never links against Qt6, OBS, or the Zoom SDK on Linux. There is no Linux packaging, no distro integration, and no libsecret-backed token storage yet (see Security). |
+
+The CMake project genuinely supports configuring on all of the above (see `buildspec/macos.cmake`, the Unix-socket IPC path in `engine-ipc.h`, and `oauth-callback-helper-macos.mm`), so a source build is *possible* on macOS/Linux/Windows-arm64 - it is just not something the project packages, tests, or supports today. If you get one working, bug reports and PRs are welcome, but expect to do your own SDK/Qt/OBS wiring.
 
 ## Quick Start
 
@@ -260,7 +271,7 @@ These values are compiled into the plugin and used for every install of that bui
 2. The browser opens at `https://corevideo.iamfatness.us/oauth/start`; the broker generates the PKCE verifier/challenge and redirects to Zoom.
 3. Zoom redirects to `https://corevideo.iamfatness.us/oauth/callback`; the broker returns a short-lived broker token to `corevideo://oauth/callback`.
 4. `CoreVideoOAuthCallback.exe` (Windows) or `CoreVideoOAuthCallback.app` (macOS) forwards the URL to the plugin via the TCP control server (`oauth_callback` command).
-5. The plugin verifies state, redeems the broker token over HTTPS, and persists access + refresh tokens. On Windows, tokens are DPAPI-protected before storage.
+5. The plugin verifies state, redeems the broker token over HTTPS, and persists access + refresh tokens. On Windows, tokens are DPAPI-protected before storage; on macOS/Linux they are currently stored in plaintext with a logged warning (see [Security](#security)).
 6. Before each meeting join, CoreVideo refreshes the token if needed and fetches the signed-in user's ZAK. The Zoom helper process initializes the SDK with `AuthContext.publicAppKey` set to the embedded Public Client ID and `AuthContext.jwt_token` set to null, then joins with the ZAK.
 
 See [`docs/ZOOM_MARKETPLACE_OAUTH.md`](docs/ZOOM_MARKETPLACE_OAUTH.md) for the full setup guide and security notes.
@@ -549,6 +560,23 @@ CoreVideo/
 ## Security
 
 See [SECURITY.md](SECURITY.md) for the vulnerability disclosure policy.
+
+### OAuth token storage
+
+Zoom OAuth access and refresh tokens are persisted in OBS's global config
+(`global.ini`, `[ZoomPlugin]` section).
+
+- **Windows** - tokens are encrypted with DPAPI (`CryptProtectData`, scoped to
+  the current Windows user) before being written to disk.
+- **macOS / Linux** - there is currently no OS-level secret store wired up
+  (no Keychain, no libsecret), so tokens are written to `global.ini` in
+  **plaintext**. The plugin logs a prominent one-time warning
+  (`SECURITY: OAuth tokens are stored WITHOUT OS-level encryption...`) to the
+  OBS log on these platforms so this isn't silent. Anyone with read access to
+  the OBS config directory can read the stored tokens. Follow-up work to add
+  Keychain (`Security.framework`) support on macOS and `libsecret` support on
+  Linux is tracked as a to-do; see the PR that introduced this note for
+  details.
 
 ## License
 

--- a/docs/ZOOM_MARKETPLACE_OAUTH.md
+++ b/docs/ZOOM_MARKETPLACE_OAUTH.md
@@ -107,6 +107,10 @@ local config cannot change the published app identity. Developers can still use
   tokens are AES-GCM encrypted, contain only the authorization code, and expire
   after 5 minutes.
 - Windows token storage uses DPAPI before writing tokens into OBS global config.
+  macOS and Linux have no OS-level secret store wired up yet, so tokens are
+  written to OBS global config in plaintext there; the plugin logs a one-time
+  `SECURITY:` warning on those platforms. See README.md's Security section.
+  Keychain (macOS) / libsecret (Linux) support is tracked as follow-up work.
 - Refresh tokens are rotated; always persist the latest refresh token Zoom
   returns.
 - Windows builds must ship Qt's TLS backend plugins, especially the Schannel

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -6,6 +6,7 @@
 #include <QJsonObject>
 #include <QMessageAuthenticationCode>
 #include <obs-frontend-api.h>
+#include <util/base.h>
 #include <util/config-file.h>
 #if defined(_WIN32)
 #include <windows.h>
@@ -37,6 +38,26 @@ static bool has_embedded_value(const char *value)
     return value && *value;
 }
 
+#if !defined(_WIN32)
+// No OS-level secret store is wired up on this platform yet (macOS Keychain /
+// Linux libsecret are tracked as follow-up work - see README.md "Security").
+// Until then, OAuth tokens are written to OBS's global.ini in plaintext, so
+// warn loudly instead of failing silently. Logged once per process.
+static void warn_plaintext_token_storage_once()
+{
+    static bool warned = false;
+    if (warned) return;
+    warned = true;
+    blog(LOG_WARNING,
+         "[obs-zoom-plugin] SECURITY: OAuth tokens are stored WITHOUT "
+         "OS-level encryption on this platform (DPAPI token protection is "
+         "Windows-only). Access/refresh tokens are written in plaintext to "
+         "OBS's global.ini under the [ZoomPlugin] section. Anyone with "
+         "filesystem or config-file access can read them. See the Security "
+         "section of README.md.");
+}
+#endif
+
 static std::string protect_secret(const std::string &secret)
 {
     if (secret.empty()) return {};
@@ -54,6 +75,7 @@ static std::string protect_secret(const std::string &secret)
     LocalFree(out.pbData);
     return bytes.toBase64().toStdString();
 #else
+    warn_plaintext_token_storage_once();
     return secret;
 #endif
 }
@@ -75,6 +97,7 @@ static std::string unprotect_secret(const char *stored)
     LocalFree(out.pbData);
     return secret;
 #else
+    warn_plaintext_token_storage_once();
     return stored;
 #endif
 }


### PR DESCRIPTION
## Summary

Fixes two honesty gaps found in review: overstated platform support claims, and silent plaintext OAuth token storage on non-Windows platforms.

### 1. Truthful platform story
- `README.md` "Multi-platform" claim ("Windows (x64/arm64), macOS (universal arm64 + x86_64), Linux") replaced with a **Platform Support** table:
  - **Windows 10/11 x64** — supported, the only platform with a maintained release pipeline (`release-windows.yml`).
  - **Windows arm64** — source build only, untested (CMake auto-detects an arm64 SDK layout, but there's no arm64 CI job or release artifact).
  - **macOS / Linux** — source build only, unsupported, no official packages, explicitly called out as *possible* (the CMake paths genuinely exist — `buildspec/macos.cmake`, Unix-socket IPC, `oauth-callback-helper-macos.mm`) rather than impossible.
- Cross-referenced from the features list and the OAuth PKCE flow section.
- No changes to `docs/index.html` — it already used honest, qualified language ("Windows is the primary release channel...").

### 2. Fixed the misleading macOS CI artifact
In `.github/workflows/build.yml`, **macOS job and release job only** (Windows job untouched — did not touch its steps per the parallel-work constraint):
- Renamed the job from "macOS Universal" to "macOS Compile Validation (host arch)" with a comment explaining why plugin/engine are OFF.
- Renamed the produced ZIP from `CoreVideo-macOS-universal.zip` to `CoreVideo-macOS-<arch>-tools-unsupported.zip` (also fixed the false "universal" claim — the job only builds for the single runner host arch, not `arm64;x86_64`).
- Renamed the uploaded artifact to `CoreVideo-macOS-compile-validation`.
- **Decision:** dropped the macOS zip from the GitHub Release's `files:` list entirely rather than just relabeling it, since it contains no plugin, no engine, and no OAuth helper — attaching it to a release would still look like a real macOS package. `needs: [build-windows, build-macos]` is left in place as a CI gate (release still requires the macOS compile-validation job to pass).
- Validated with `python -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly. I can't run macOS CI locally, so this is eyeball + parser validation only, not a live run.

### 3. Token storage hardening off-Windows
`src/zoom-settings.cpp`: `protect_secret`/`unprotect_secret`'s non-Windows branches (`#else`) previously returned the token unchanged with zero indication anything was different from the Windows DPAPI path. They now call a new `warn_plaintext_token_storage_once()` that logs a prominent `blog(LOG_WARNING, "[obs-zoom-plugin] SECURITY: OAuth tokens are stored WITHOUT OS-level encryption...")` exactly once per process. Windows DPAPI path (`CryptProtectData`/`CryptUnprotectData`) is byte-for-byte unchanged.

Documented in `README.md`'s Security section (new "OAuth token storage" subsection) and `docs/ZOOM_MARKETPLACE_OAUTH.md`'s security notes.

**Follow-up (not implemented here):** macOS Keychain (`Security.framework`) and Linux `libsecret` support for real OS-level encryption. Skipped for this PR because I can only build/test Windows locally and didn't want to ship unverified crypto/Keychain code — the loud-warning + docs approach was the explicitly allowed fallback. Worth a dedicated PR from someone who can build/test on macOS and Linux.

## Test plan
- [x] Configured Windows x64 build in an isolated worktree build dir (`-G "Visual Studio 17 2022" -A x64`, OBS `CMAKE_PREFIX_PATH`/`CMAKE_MODULE_PATH` per the standard local dev setup, `ZOOM_SDK_DIR` for SDK 7.0.2.34512, `FFMPEG_ROOT=C:/ffmpeg -DENABLE_FFMPEG_HW_ACCEL=ON`) — configure succeeded.
- [x] `cmake --build build-verify --config Release --parallel` — full rebuild, exit code 0, zero "error" matches in the log. `obs-zoom-plugin.dll`, `ZoomObsEngine.exe`, `CoreVideoOAuthCallback.exe`, and all test binaries built successfully with the modified `zoom-settings.cpp`.
- [x] `build.yml` YAML parses cleanly via `pyyaml`.
- [ ] macOS/Linux builds not run (no local toolchain access) — reviewed by eye only.
- Did not touch `src/engine-ipc.h`, `zoom-engine-client.cpp`, `zoom-oauth.cpp`, `zoom-auth.cpp`, dock/panel files, or the Windows job steps in `build.yml`, per the parallel-work constraints for this repo tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)