### PR TITLE
Harden plugin<->engine IPC/SHM boundary: generation guard, surfaced SHM failures, caps (#106)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,17 @@ if(BUILD_TESTING)
     add_test(NAME CoreVideoVersionCompare
              COMMAND CoreVideoVersionCompareTest)
 
+    # IPC/SHM hardening policy: heartbeat timeout, SHM generation guard, and
+    # source cap (plus Windows pipe line-I/O coverage on Windows).
+    add_executable(CoreVideoIpcHardeningTest
+        tests/ipc-hardening-test.cpp
+    )
+    target_include_directories(CoreVideoIpcHardeningTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoIpcHardening
+             COMMAND CoreVideoIpcHardeningTest)
+
     # IPC line-I/O framing and write-failure semantics (POSIX socket-based test).
     if(NOT WIN32)
         add_executable(CoreVideoIpcLineIoTest

--- a/engine/src/engine-audio.cpp
+++ b/engine/src/engine-audio.cpp
@@ -23,6 +23,19 @@ bool EngineAudio::init(IpcFd e2p_fd,
     {
         std::lock_guard<std::mutex> lock(m_targets_mtx);
         auto it = m_targets.find(source_uuid);
+        // Each audio target backs an SHM region — enforce the shared cap
+        // (kMaxShmSources in engine-ipc.h). Re-registering is always allowed.
+        if (shm_source_over_cap(m_targets.size(), it != m_targets.end())) {
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"audio_subscribe_rejected_capacity","source_uuid":")" +
+                source_uuid + R"(","limit":)" +
+                std::to_string(kMaxShmSources) + "}");
+            EngineIpc::write(
+                R"({"cmd":"error","msg":"subscribe_rejected","reason":"shm_capacity","source_uuid":")" +
+                source_uuid + R"(","limit":)" +
+                std::to_string(kMaxShmSources) + "}");
+            return false;
+        }
         if (it == m_targets.end()) {
             m_targets.emplace(source_uuid,
                 std::make_unique<AudioTarget>(e2p_fd, participant_id,
@@ -163,13 +176,26 @@ void EngineAudio::output_audio_frame(AudioTarget &target,
     if (byte_len == 0) return;
 
     if (!ensure_shm(target, source_uuid, byte_len) || !target.shm.ptr) {
-        if (target.frame_count == 0) {
+        // Surface once per failure episode (not per callback) as a real error
+        // so the plugin can show the operator that audio is being dropped.
+        if (!target.shm_fail_reported) {
+            target.shm_fail_reported = true;
             EngineIpc::write(
                 R"({"cmd":"debug","stage":"audio_shm_create_failed","source_uuid":")" +
                 source_uuid + R"(","byte_len":)" +
                 std::to_string(byte_len) + "}");
+            EngineIpc::write(
+                R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
+                source_uuid + R"(","byte_len":)" +
+                std::to_string(byte_len) + "}");
         }
         return;
+    }
+    if (target.shm_fail_reported) {
+        target.shm_fail_reported = false;
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"audio_shm_recovered","source_uuid":")" +
+            source_uuid + "\"}");
     }
 
     auto *hdr        = static_cast<ShmAudioHeader *>(target.shm.ptr);

--- a/engine/src/engine-audio.h
+++ b/engine/src/engine-audio.h
@@ -61,6 +61,9 @@ private:
         bool audience_audio = false;
         ShmRegion shm;
         uint64_t frame_count = 0;
+        // True after an ensure_shm() failure has been surfaced as an error —
+        // avoids re-emitting once per audio callback while the failure persists.
+        bool shm_fail_reported = false;
     };
 
     bool ensure_shm(AudioTarget &target,

--- a/engine/src/engine-share.cpp
+++ b/engine/src/engine-share.cpp
@@ -76,6 +76,20 @@ void EngineShare::subscribe(const std::string &source_uuid, IpcFd e2p_fd)
     if (source_uuid.empty())
         return;
     std::lock_guard<std::mutex> lock(m_mtx);
+    // Each share target backs an SHM region — enforce the shared cap
+    // (kMaxShmSources in engine-ipc.h). Re-registering is always allowed.
+    if (shm_source_over_cap(m_targets.size(),
+                            m_targets.find(source_uuid) != m_targets.end())) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"share_subscribe_rejected_capacity","source_uuid":")" +
+            source_uuid + R"(","limit":)" +
+            std::to_string(kMaxShmSources) + "}");
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"subscribe_rejected","reason":"shm_capacity","source_uuid":")" +
+            source_uuid + R"(","limit":)" +
+            std::to_string(kMaxShmSources) + "}");
+        return;
+    }
     const auto [it, inserted] = m_targets.emplace(source_uuid, nullptr);
     if (inserted)
         it->second = std::make_unique<ShareTarget>(e2p_fd);
@@ -241,7 +255,9 @@ bool EngineShare::ensure_shm(ShareTarget &target,
     if (target.shm.ptr && target.shm.size >= total) return true;
 
     const std::string region_name = IPC_SHM_PREFIX + source_uuid;
-    return shm_region_create(target.shm, region_name, total);
+    if (!shm_region_create(target.shm, region_name, total)) return false;
+    ++target.shm_gen; // new region — old plugin-side mappings are now stale
+    return true;
 }
 
 void EngineShare::set_active_share_user(uint32_t user_id)
@@ -282,13 +298,27 @@ void EngineShare::onRawDataFrameReceived(YUVRawDataI420 *data)
         const std::string &source_uuid = entry.first;
         ShareTarget &target = *entry.second;
         if (!ensure_shm(target, source_uuid, y_len) || !target.shm.ptr) {
-            if (target.frame_count == 0) {
+            // Surface once per failure episode (not per frame) as a real
+            // error so the plugin can show the operator that this source's
+            // frames are being dropped.
+            if (!target.shm_fail_reported) {
+                target.shm_fail_reported = true;
                 EngineIpc::write(
                     R"({"cmd":"debug","stage":"share_shm_create_failed","source_uuid":")" +
                     source_uuid + R"(","w":)" + std::to_string(w) +
                     R"(,"h":)" + std::to_string(h) + "}");
+                EngineIpc::write(
+                    R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
+                    source_uuid + R"(","w":)" + std::to_string(w) +
+                    R"(,"h":)" + std::to_string(h) + "}");
             }
             continue;
+        }
+        if (target.shm_fail_reported) {
+            target.shm_fail_reported = false;
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"share_shm_recovered","source_uuid":")" +
+                source_uuid + "\"}");
         }
 
         auto *hdr = static_cast<ShmFrameHeader *>(target.shm.ptr);
@@ -325,7 +355,8 @@ void EngineShare::onRawDataFrameReceived(YUVRawDataI420 *data)
             R"({"cmd":"frame","source_uuid":")" + source_uuid +
             R"(","participant_id":)" + std::to_string(share_user_id) +
             R"(,"w":)" + std::to_string(w) +
-            R"(,"h":)" + std::to_string(h) + "}");
+            R"(,"h":)" + std::to_string(h) +
+            R"(,"shm_gen":)" + std::to_string(target.shm_gen) + "}");
     }
 }
 

--- a/engine/src/engine-share.h
+++ b/engine/src/engine-share.h
@@ -72,6 +72,12 @@ private:
         IpcFd e2p_fd;
         ShmRegion shm;
         uint64_t frame_count = 0;
+        // Increments each time the SHM region is (re)created; sent with every
+        // frame event so the plugin can detect an orphaned mapping.
+        uint32_t shm_gen = 0;
+        // True after an ensure_shm() failure has been surfaced as an error —
+        // avoids re-emitting once per frame while the failure persists.
+        bool shm_fail_reported = false;
     };
 
     uint32_t active_share_source_id(uint32_t *user_id) const;

--- a/engine/src/engine-video.cpp
+++ b/engine/src/engine-video.cpp
@@ -169,7 +169,9 @@ bool ParticipantSubscription::ensure_shm(SourceTarget &target,
     if (target.shm.ptr && target.shm.size >= total) return true;
 
     const std::string region_name = IPC_SHM_PREFIX + source_uuid;
-    return shm_region_create(target.shm, region_name, total);
+    if (!shm_region_create(target.shm, region_name, total)) return false;
+    ++target.shm_gen; // new region — old plugin-side mappings are now stale
+    return true;
 }
 
 void ParticipantSubscription::onRawDataFrameReceived(YUVRawDataI420 *data)
@@ -192,14 +194,30 @@ void ParticipantSubscription::onRawDataFrameReceived(YUVRawDataI420 *data)
         SourceTarget &target = *entry.second;
 
         if (!ensure_shm(target, source_uuid, y_len) || !target.shm.ptr) {
-            if (target.frame_count == 0) {
+            // Surface once per failure episode (not per frame) as a real
+            // error so the plugin can show the operator that this source's
+            // frames are being dropped.
+            if (!target.shm_fail_reported) {
+                target.shm_fail_reported = true;
                 EngineIpc::write(
                     R"({"cmd":"debug","stage":"video_shm_create_failed","source_uuid":")" +
                     source_uuid + R"(","participant_id":)" +
                     std::to_string(m_participant_id) + R"(,"w":)" +
                     std::to_string(w) + R"(,"h":)" + std::to_string(h) + "}");
+                EngineIpc::write(
+                    R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
+                    source_uuid + R"(","participant_id":)" +
+                    std::to_string(m_participant_id) + R"(,"w":)" +
+                    std::to_string(w) + R"(,"h":)" + std::to_string(h) + "}");
             }
             continue;
+        }
+        if (target.shm_fail_reported) {
+            target.shm_fail_reported = false;
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"video_shm_recovered","source_uuid":")" +
+                source_uuid + R"(","participant_id":)" +
+                std::to_string(m_participant_id) + "}");
         }
 
         auto *hdr    = static_cast<ShmFrameHeader *>(target.shm.ptr);
@@ -231,7 +249,8 @@ void ParticipantSubscription::onRawDataFrameReceived(YUVRawDataI420 *data)
         EngineIpc::write(
             R"({"cmd":"frame","source_uuid":")" + source_uuid +
             R"(","participant_id":)" + std::to_string(m_participant_id) +
-            R"(,"w":)" + std::to_string(w) + R"(,"h":)" + std::to_string(h) + "}");
+            R"(,"w":)" + std::to_string(w) + R"(,"h":)" + std::to_string(h) +
+            R"(,"shm_gen":)" + std::to_string(target.shm_gen) + "}");
     }
 }
 
@@ -268,18 +287,21 @@ void EngineVideo::subscribe(uint32_t participant_id,
 
     // Bound the number of distinct video source UUIDs. Each source backs a
     // shared-memory region, so without a cap a misbehaving or runaway plugin
-    // could create unbounded SHM regions and exhaust memory. The product
-    // targets up to 8 feeds plus active-speaker/spotlight/screenshare slots;
-    // 32 leaves generous headroom while staying bounded. Re-subscribing an
+    // could create unbounded SHM regions and exhaust memory (policy and
+    // rationale live with kMaxShmSources in engine-ipc.h). Re-subscribing an
     // existing source is always allowed.
-    constexpr size_t kMaxVideoSources = 32;
-    if (m_source_participants.find(source_uuid) == m_source_participants.end() &&
-        m_source_participants.size() >= kMaxVideoSources) {
+    if (shm_source_over_cap(m_source_participants.size(),
+                            m_source_participants.find(source_uuid) !=
+                                m_source_participants.end())) {
         EngineIpc::write(
             R"({"cmd":"debug","stage":"video_subscribe_rejected_capacity","source_uuid":")" +
             source_uuid + R"(","participant_id":)" +
             std::to_string(participant_id) + R"(,"limit":)" +
-            std::to_string(kMaxVideoSources) + "}");
+            std::to_string(kMaxShmSources) + "}");
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"subscribe_rejected","reason":"shm_capacity","source_uuid":")" +
+            source_uuid + R"(","limit":)" +
+            std::to_string(kMaxShmSources) + "}");
         return;
     }
 

--- a/engine/src/engine-video.h
+++ b/engine/src/engine-video.h
@@ -44,6 +44,12 @@ private:
         IpcFd e2p_fd;
         ShmRegion shm;
         uint64_t frame_count = 0;
+        // Increments each time the SHM region is (re)created; sent with every
+        // frame event so the plugin can detect an orphaned mapping.
+        uint32_t shm_gen = 0;
+        // True after an ensure_shm() failure has been surfaced as an error —
+        // avoids re-emitting once per frame while the failure persists.
+        bool shm_fail_reported = false;
     };
 
     bool ensure_shm(SourceTarget &target,

--- a/src/engine-ipc.h
+++ b/src/engine-ipc.h
@@ -26,6 +26,55 @@
 // Shared-memory name prefix (no leading slash — added per-platform below)
 #define IPC_SHM_PREFIX "ZoomObsPlugin_"
 
+// ── IPC / SHM hardening policy (pure logic, unit-tested) ─────────────────────
+
+// Upper bound on distinct SHM-backed sources per media path. The video, share,
+// and audio paths each keep one region per source UUID; without a cap a
+// misbehaving or runaway peer could create unbounded SHM regions and exhaust
+// memory. The product targets up to 8 feeds plus active-speaker/spotlight/
+// screenshare slots; 32 leaves generous headroom while staying bounded.
+static constexpr size_t kMaxShmSources = 32;
+
+// True when registering a new source_uuid would push a media path past the SHM
+// cap. Re-registering an already-present source never counts against the cap.
+static inline bool shm_source_over_cap(size_t existing_count,
+                                       bool already_present,
+                                       size_t max_sources = kMaxShmSources)
+{
+    return !already_present && existing_count >= max_sources;
+}
+
+// True when a read-side SHM mapping must be (re)opened before consuming a
+// frame event: never mapped, mapped too small, or the event carries a newer
+// SHM generation than the mapping was opened against. The generation changes
+// whenever the engine (re)creates the region — e.g. after an engine restart —
+// at which point the old mapping points at an orphaned region that will never
+// be written again; without this check the plugin would show a frozen frame
+// forever. event_gen == 0 means the peer did not send a generation (older
+// engine binary) — the generation check is skipped for backward compatibility.
+static inline bool shm_mapping_stale(const void *mapped_ptr,
+                                     size_t mapped_size,
+                                     size_t needed_size,
+                                     uint32_t event_gen,
+                                     uint32_t mapped_gen)
+{
+    if (!mapped_ptr || mapped_size < needed_size) return true;
+    if (event_gen != 0 && event_gen != mapped_gen) return true;
+    return false;
+}
+
+// Heartbeat expiry: true when the peer has been silent for longer than
+// timeout_ms. last_rx_ms == 0 means "nothing received yet" — never expired
+// (callers seed the clock when the link comes up). A last_rx_ms in the future
+// (clock skew / re-seed race) is treated as fresh, not expired.
+static inline bool ipc_heartbeat_expired(uint64_t now_ms,
+                                         uint64_t last_rx_ms,
+                                         uint64_t timeout_ms)
+{
+    return last_rx_ms != 0 && now_ms > last_rx_ms &&
+           (now_ms - last_rx_ms) > timeout_ms;
+}
+
 struct ShmFrameHeader {
     uint32_t sequence;
     uint32_t width;

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -338,7 +338,7 @@ void ZoomEngineClient::monitor_loop()
             (st == MeetingState::InMeeting || st == MeetingState::Joining)) {
             const uint64_t now = os_gettime_ns() / 1000000ULL;
             const uint64_t last = m_last_rx_ms.load(std::memory_order_acquire);
-            if (last != 0 && now > last && (now - last) > kHeartbeatTimeoutMs) {
+            if (ipc_heartbeat_expired(now, last, kHeartbeatTimeoutMs)) {
                 heartbeat_timeout = true;
                 break;
             }
@@ -704,6 +704,38 @@ void ZoomEngineClient::handle_event(const std::string &line)
     }
     if (cmd == "error" || cmd == "auth_fail") {
         blog(LOG_ERROR, "[obs-zoom-plugin] Zoom engine event: %s", line.c_str());
+        const QString emsg = obj.value("msg").toString();
+        // Media-path errors: the meeting itself is still healthy, so surface
+        // them loudly to the operator but do NOT tear the session down or
+        // trigger the reconnect flow.
+        if (emsg == "shm_create_failed" || emsg == "subscribe_rejected") {
+            const std::string uuid =
+                obj.value("source_uuid").toString().toStdString();
+            std::string error_message;
+            if (emsg == "shm_create_failed") {
+                error_message =
+                    "Zoom engine could not allocate shared memory for source " +
+                    (uuid.empty() ? std::string("(unknown)") : uuid) +
+                    " — its frames are being dropped";
+            } else {
+                const int limit = obj.value("limit").toInt(0);
+                error_message =
+                    "Zoom engine rejected subscription for source " +
+                    (uuid.empty() ? std::string("(unknown)") : uuid) +
+                    ": too many active sources" +
+                    (limit > 0 ? " (limit " + std::to_string(limit) + ")"
+                               : std::string());
+            }
+            std::vector<ErrorCallback> error_callbacks;
+            {
+                std::lock_guard<std::mutex> lk(m_mtx);
+                m_last_error = error_message;
+                for (const auto &entry : m_error_callbacks)
+                    if (entry.second) error_callbacks.push_back(entry.second);
+            }
+            for (const auto &cb : error_callbacks) cb(error_message);
+            return;
+        }
         const QString reason = obj.value("reason").toString();
         const int code = obj.value("code").toInt(0);
         std::vector<ErrorCallback> error_callbacks;
@@ -814,10 +846,13 @@ void ZoomEngineClient::handle_event(const std::string &line)
                  uuid.c_str(), static_cast<unsigned long long>(frame_count),
                  obj.value("w").toInt(), obj.value("h").toInt());
         }
+        // shm_gen guards against reading a stale/orphaned SHM region after the
+        // engine recreated it (e.g. engine restart). 0 = not sent (old engine).
         callbacks.on_frame(static_cast<uint32_t>(obj.value("w").toInt()),
                            static_cast<uint32_t>(obj.value("h").toInt()),
                            static_cast<uint32_t>(
-                               obj.value("participant_id").toInt()));
+                               obj.value("participant_id").toInt()),
+                           static_cast<uint32_t>(obj.value("shm_gen").toInt()));
     }
     if (cmd == "audio" && callbacks.on_audio) {
         callbacks.on_audio(static_cast<uint32_t>(obj.value("byte_len").toInt()),

--- a/src/zoom-engine-client.h
+++ b/src/zoom-engine-client.h
@@ -22,8 +22,12 @@ public:
     };
 
     struct SourceCallbacks {
+        // shm_generation: engine-side generation of the SHM region backing the
+        // frame (increments each time the region is (re)created). 0 when the
+        // engine did not report one (older engine binary).
         std::function<void(uint32_t width, uint32_t height,
-                           uint32_t participant_id)> on_frame;
+                           uint32_t participant_id,
+                           uint32_t shm_generation)> on_frame;
         std::function<void(uint32_t byte_len,
                            uint32_t participant_id)> on_audio;
     };

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -1063,51 +1063,72 @@ void ZoomSource::maybe_update_director_subscription()
 }
 
 void ZoomSource::on_engine_frame(uint32_t event_width, uint32_t event_height,
-                                 uint32_t resolved_participant_id)
+                                 uint32_t resolved_participant_id,
+                                 uint32_t shm_generation)
 {
     std::lock_guard<std::mutex> lk(m_mtx);
-    output_video_from_shared_memory(source_uuid, m_video_shm, m_video_buf,
-                                    m_scaled_video_buf, event_width,
-                                    event_height, resolved_participant_id,
+    output_video_from_shared_memory(source_uuid, m_video_shm, m_video_shm_gen,
+                                    m_video_buf, m_scaled_video_buf,
+                                    event_width, event_height,
+                                    resolved_participant_id, shm_generation,
                                     false);
 }
 
 void ZoomSource::on_director_preview_frame(uint32_t event_width,
                                            uint32_t event_height,
-                                           uint32_t resolved_participant_id)
+                                           uint32_t resolved_participant_id,
+                                           uint32_t shm_generation)
 {
     std::lock_guard<std::mutex> lk(m_mtx);
     output_video_from_shared_memory(m_director_preview_uuid,
                                     m_director_preview_shm,
+                                    m_director_preview_shm_gen,
                                     m_director_preview_buf,
                                     m_director_preview_scaled_buf,
                                     event_width, event_height,
-                                    resolved_participant_id, true);
+                                    resolved_participant_id, shm_generation,
+                                    true);
 }
 
 bool ZoomSource::output_video_from_shared_memory(
     const std::string &uuid,
     ShmRegion &video_shm,
+    uint32_t &video_shm_gen,
     std::vector<uint8_t> &video_buf,
     std::vector<uint8_t> &scaled_video_buf,
     uint32_t event_width,
     uint32_t event_height,
     uint32_t resolved_participant_id,
+    uint32_t event_shm_gen,
     bool commit_director_cut)
 {
     const std::string shm_name = IPC_SHM_PREFIX + uuid;
     if (event_width == 0 || event_height == 0) return false;
     const size_t frame_bytes = sizeof(ShmFrameHeader) +
         static_cast<size_t>(event_width) * event_height * 3 / 2;
-    if ((!video_shm.ptr || video_shm.size < frame_bytes) &&
-        !shm_region_open_read(video_shm, shm_name, frame_bytes)) {
-        if (m_frame_count == 0) {
-            blog(LOG_WARNING,
-                 "[obs-zoom-plugin] Failed to open video shared memory: source=%s uuid=%s w=%u h=%u bytes=%zu",
-                 output_name().c_str(), uuid.c_str(), event_width,
-                 event_height, frame_bytes);
+    if (shm_mapping_stale(video_shm.ptr, video_shm.size, frame_bytes,
+                          event_shm_gen, video_shm_gen)) {
+        // A generation change means the engine recreated the region (e.g.
+        // after a restart) — our old mapping points at an orphaned region
+        // that will never update again, so drop it and re-open by name.
+        if (video_shm.ptr && event_shm_gen != 0 &&
+            event_shm_gen != video_shm_gen) {
+            blog(LOG_INFO,
+                 "[obs-zoom-plugin] Re-opening video shared memory after engine generation change: source=%s uuid=%s gen %u -> %u",
+                 output_name().c_str(), uuid.c_str(), video_shm_gen,
+                 event_shm_gen);
+            shm_region_destroy(video_shm);
         }
-        return false;
+        if (!shm_region_open_read(video_shm, shm_name, frame_bytes)) {
+            if (m_frame_count == 0) {
+                blog(LOG_WARNING,
+                     "[obs-zoom-plugin] Failed to open video shared memory: source=%s uuid=%s w=%u h=%u bytes=%zu",
+                     output_name().c_str(), uuid.c_str(), event_width,
+                     event_height, frame_bytes);
+            }
+            return false;
+        }
+        video_shm_gen = event_shm_gen;
     }
 
     auto *hdr = static_cast<const ShmFrameHeader *>(video_shm.ptr);
@@ -1484,6 +1505,8 @@ void ZoomSource::release_shared_memory()
     shm_region_destroy(m_video_shm);
     shm_region_destroy(m_director_preview_shm);
     shm_region_destroy(m_audio_shm);
+    m_video_shm_gen = 0;
+    m_director_preview_shm_gen = 0;
 }
 
 static const char *zoom_source_get_name(void *)
@@ -1519,10 +1542,11 @@ static void *zoom_source_create_common(obs_data_t *settings, obs_source_t *sourc
 
     ZoomEngineClient::instance().register_source(ctx->source_uuid, {
         [ctx, gate = ctx->m_callback_gate](uint32_t w, uint32_t h,
-                                           uint32_t participant_id) {
+                                           uint32_t participant_id,
+                                           uint32_t shm_gen) {
             std::lock_guard<std::mutex> callback_lock(gate->mtx);
             if (!gate->alive) return;
-            ctx->on_engine_frame(w, h, participant_id);
+            ctx->on_engine_frame(w, h, participant_id, shm_gen);
         },
         [ctx, gate = ctx->m_callback_gate](uint32_t byte_len,
                                            uint32_t participant_id) {
@@ -1534,10 +1558,11 @@ static void *zoom_source_create_common(obs_data_t *settings, obs_source_t *sourc
     if (dedicated_active_speaker) {
         ZoomEngineClient::instance().register_source(ctx->m_director_preview_uuid, {
             [ctx, gate = ctx->m_callback_gate](uint32_t w, uint32_t h,
-                                               uint32_t participant_id) {
+                                               uint32_t participant_id,
+                                               uint32_t shm_gen) {
                 std::lock_guard<std::mutex> callback_lock(gate->mtx);
                 if (!gate->alive) return;
-                ctx->on_director_preview_frame(w, h, participant_id);
+                ctx->on_director_preview_frame(w, h, participant_id, shm_gen);
             },
             [gate = ctx->m_callback_gate](uint32_t, uint32_t) {
                 std::lock_guard<std::mutex> callback_lock(gate->mtx);

--- a/src/zoom-source.h
+++ b/src/zoom-source.h
@@ -79,9 +79,11 @@ struct ZoomSource {
     void deactivate();
     void on_roster_changed();
     void on_engine_frame(uint32_t width, uint32_t height,
-                         uint32_t resolved_participant_id);
+                         uint32_t resolved_participant_id,
+                         uint32_t shm_generation);
     void on_director_preview_frame(uint32_t width, uint32_t height,
-                                   uint32_t resolved_participant_id);
+                                   uint32_t resolved_participant_id,
+                                   uint32_t shm_generation);
     void on_engine_audio(uint32_t byte_len,
                          uint32_t resolved_participant_id);
 
@@ -104,17 +106,24 @@ private:
     void maybe_update_director_subscription();
     bool output_video_from_shared_memory(const std::string &uuid,
                                          ShmRegion &video_shm,
+                                         uint32_t &video_shm_gen,
                                          std::vector<uint8_t> &video_buf,
                                          std::vector<uint8_t> &scaled_video_buf,
                                          uint32_t event_width,
                                          uint32_t event_height,
                                          uint32_t resolved_participant_id,
+                                         uint32_t event_shm_gen,
                                          bool commit_director_cut);
 
     mutable std::mutex m_mtx;
     ShmRegion m_video_shm;
     ShmRegion m_director_preview_shm;
     ShmRegion m_audio_shm;
+    // Engine-reported SHM generation each mapping was opened against. Used to
+    // detect a recreated (orphaned) region so we re-open instead of reading a
+    // frozen frame forever. 0 = opened without a generation (older engine).
+    uint32_t m_video_shm_gen = 0;
+    uint32_t m_director_preview_shm_gen = 0;
     std::vector<uint8_t> m_placeholder_buf;
     std::vector<uint8_t> m_video_buf;
     std::vector<uint8_t> m_scaled_video_buf;

--- a/tests/ipc-hardening-test.cpp
+++ b/tests/ipc-hardening-test.cpp
@@ -1,0 +1,168 @@
+// Unit tests for the IPC/SHM hardening policy helpers in engine-ipc.h
+// (issue #106): the heartbeat-timeout decision, the SHM generation/staleness
+// guard, and the SHM source cap. On Windows this file also exercises the
+// line-I/O framing and write-failure semantics over a real pipe (the POSIX
+// socket equivalent lives in ipc-line-io-test.cpp).
+
+#include "engine-ipc.h"
+
+#include <iostream>
+#include <string>
+
+static int g_failures = 0;
+
+static void check(bool ok, const char *what)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << what << "\n";
+        ++g_failures;
+    }
+}
+
+// ── Heartbeat timeout decision (used by ZoomEngineClient::monitor_loop) ──────
+static void test_heartbeat_expiry()
+{
+    // Nothing received yet — never expired (caller seeds the clock on connect).
+    check(!ipc_heartbeat_expired(50000, 0, 10000), "last_rx=0 is never expired");
+
+    // Fresh traffic within the timeout window.
+    check(!ipc_heartbeat_expired(15000, 10000, 10000),
+          "silence shorter than timeout is not expired");
+
+    // Exactly at the timeout boundary — not yet expired (strictly greater).
+    check(!ipc_heartbeat_expired(20000, 10000, 10000),
+          "silence equal to timeout is not expired");
+
+    // Past the timeout — expired.
+    check(ipc_heartbeat_expired(20001, 10000, 10000),
+          "silence longer than timeout is expired");
+
+    // last_rx in the future (clock re-seed race) — treated as fresh.
+    check(!ipc_heartbeat_expired(10000, 20000, 10000),
+          "future last_rx is not expired");
+}
+
+// ── SHM mapping staleness / generation guard (plugin read side) ──────────────
+static void test_shm_mapping_stale()
+{
+    int dummy = 0;
+    const void *mapped = &dummy;
+
+    // Never mapped — must open.
+    check(shm_mapping_stale(nullptr, 0, 100, 1, 0), "unmapped region is stale");
+
+    // Mapped but too small for this frame — must re-open.
+    check(shm_mapping_stale(mapped, 64, 100, 1, 1),
+          "undersized mapping is stale");
+
+    // Same generation and big enough — reusable.
+    check(!shm_mapping_stale(mapped, 100, 100, 3, 3),
+          "matching generation is not stale");
+
+    // Engine recreated the region (generation moved on) — old mapping is
+    // orphaned even though it is big enough.
+    check(shm_mapping_stale(mapped, 4096, 100, 4, 3),
+          "generation change makes mapping stale");
+
+    // Old engine that never sends a generation (event_gen == 0) — the
+    // generation check must be skipped for backward compatibility.
+    check(!shm_mapping_stale(mapped, 4096, 100, 0, 3),
+          "missing event generation skips the generation check");
+
+    // First open recorded gen 0 (old engine), new engine now reports gen 1 —
+    // must re-open.
+    check(shm_mapping_stale(mapped, 4096, 100, 1, 0),
+          "upgrade from gen-less mapping to generation 1 is stale");
+}
+
+// ── SHM source cap (engine video/share/audio subscribe paths) ────────────────
+static void test_shm_source_cap()
+{
+    // Below the cap: new sources are accepted.
+    check(!shm_source_over_cap(0, false), "first source accepted");
+    check(!shm_source_over_cap(kMaxShmSources - 1, false),
+          "source at cap-1 accepted");
+
+    // At the cap: a NEW source is rejected...
+    check(shm_source_over_cap(kMaxShmSources, false),
+          "new source over cap rejected");
+
+    // ...but re-registering an existing source is always allowed.
+    check(!shm_source_over_cap(kMaxShmSources, true),
+          "existing source re-subscribe allowed at cap");
+    check(!shm_source_over_cap(kMaxShmSources + 5, true),
+          "existing source re-subscribe allowed over cap");
+
+    // Explicit cap override behaves the same way.
+    check(shm_source_over_cap(2, false, 2), "custom cap enforced");
+    check(!shm_source_over_cap(1, false, 2), "custom cap not yet reached");
+}
+
+#if defined(WIN32)
+// ── Line I/O over a real Windows pipe ────────────────────────────────────────
+// Mirrors the POSIX socket coverage in ipc-line-io-test.cpp: framing round
+// trips, the oversized-line guard, and — most importantly — that
+// ipc_write_line() reports failure instead of silently dropping bytes once the
+// peer is gone.
+static void test_win_line_io()
+{
+    HANDLE rd = nullptr, wr = nullptr;
+    check(CreatePipe(&rd, &wr, nullptr, 0) != 0, "anonymous pipe created");
+
+    check(ipc_write_line(wr, "{\"cmd\":\"ping\"}"), "write returns true");
+    check(ipc_write_line(wr, "second"), "second write returns true");
+
+    std::string line;
+    check(ipc_read_line(rd, line) && line == "{\"cmd\":\"ping\"}",
+          "round-trip payload matches (newline stripped)");
+    check(ipc_read_line(rd, line) && line == "second", "second line framed");
+
+    // Oversized line must be rejected rather than read unbounded.
+    check(ipc_write_line(wr, std::string(64, 'x')), "oversized payload written");
+    check(!ipc_read_line(rd, line, 16), "oversized line rejected");
+
+    CloseHandle(rd);
+    CloseHandle(wr);
+}
+
+static void test_win_broken_pipe()
+{
+    HANDLE rd = nullptr, wr = nullptr;
+    check(CreatePipe(&rd, &wr, nullptr, 0) != 0, "anonymous pipe created");
+
+    CloseHandle(rd); // drop the reader
+
+    // Writing to a pipe whose read end is closed must report failure, not
+    // silently drop the message — the hardened reconnect path depends on it.
+    bool saw_failure = false;
+    for (int i = 0; i < 10000 && !saw_failure; ++i) {
+        if (!ipc_write_line(wr, "{\"cmd\":\"frame\"}"))
+            saw_failure = true;
+    }
+    check(saw_failure, "write to closed peer eventually returns false");
+
+    CloseHandle(wr);
+}
+
+static void test_win_invalid_fd()
+{
+    check(!ipc_write_line(kIpcInvalidFd, "anything"),
+          "write to invalid handle returns false");
+}
+#endif // WIN32
+
+int main()
+{
+    test_heartbeat_expiry();
+    test_shm_mapping_stale();
+    test_shm_source_cap();
+#if defined(WIN32)
+    test_win_line_io();
+    test_win_broken_pipe();
+    test_win_invalid_fd();
+#endif
+
+    if (g_failures == 0)
+        std::cout << "All IPC hardening tests passed\n";
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Closes #106

Finishes the P0 IPC-hardening issue. The first two outcomes were already merged earlier (checked/looping `ipc_write_line` with reconnect propagation in PR #111; engine ping heartbeat + plugin rx-timeout monitor in PR #112). This PR closes the remaining gaps and adds unit tests for the pure decision logic.

## What changed

### 1. SHM generation guard on frame events (new)
- The engine now sends `"shm_gen"` with every `frame` event — a per-target counter that increments each time the source's SHM region is (re)created (`engine/src/engine-video.cpp`, `engine/src/engine-share.cpp`).
- The plugin remembers the generation each mapping was opened against and re-opens the region by name when the event generation moves on (`src/zoom-source.cpp`). Previously, an engine restart that recreated a region left the plugin's old (still-size-valid) mapping pointing at an orphaned region — a frozen frame forever, silently. Now it recovers on the next frame and logs the re-open.
- The staleness decision is a pure helper, `shm_mapping_stale()` in `src/engine-ipc.h`, shared by both and unit-tested.

### 2. `ensure_shm()` failure surfaced (was silent/debug-only)
- Video, share, AND audio paths now emit `{"cmd":"error","msg":"shm_create_failed",...}` once per failure episode (with a `*_shm_recovered` debug event when it clears). The old code emitted a `debug` event under a `frame_count == 0` condition that actually re-fired on every frame during a persistent failure and was never operator-visible.
- The plugin maps these to a clear operator message ("could not allocate shared memory … frames are being dropped"), sets `last_error`, and fires error callbacks — **without** tearing down the meeting or triggering reconnect, since the session itself is healthy.

### 3. SHM region cap, operator-visible (video had a silent cap; share/audio had none)
- One shared policy: `kMaxShmSources = 32` + `shm_source_over_cap()` in `src/engine-ipc.h`, now enforced in the video, share, and audio subscribe paths. Re-subscribing an existing source is always allowed.
- Over-cap subscriptions now emit `{"cmd":"error","msg":"subscribe_rejected","reason":"shm_capacity","limit":32}` in addition to the diagnostics debug event, so the operator sees the rejection (plugin error surface + LOG_ERROR) instead of a source that just never shows video.

### 4. Heartbeat expiry extracted + tested
- The monitor thread's timeout decision is now the pure helper `ipc_heartbeat_expired()` (same semantics as before: seeded clock, strict timeout, future-timestamp tolerated) so the state machine is unit-testable.

## Wire-protocol compatibility
- `shm_gen` is an additive JSON field. An **old engine + new plugin** simply omits it; the plugin treats "no generation" as "skip the generation check" and behaves exactly as before (size-based re-open only). A **new engine + old plugin** ignores the extra field. Same for the new `error` msg kinds — an old plugin logs them via the generic error path.
- SHM header layout is untouched (generation travels in the event, not the header), so mixed-version SHM reads stay layout-compatible.
- Heartbeat/write semantics unchanged from PRs #111/#112.

## Tests
New `tests/ipc-hardening-test.cpp`, registered as `CoreVideoIpcHardening` via `add_test` (runs on all platforms):
- heartbeat expiry: seeded clock, within/at/past timeout, future last-rx
- generation guard: unmapped, undersized, generation change, gen-less (old-engine) event, gen-0→gen-1 upgrade
- SHM cap: below/at/over cap, existing-source re-subscribe exemption, custom cap
- Windows-only: line-I/O framing round-trip, oversized-line guard, broken-pipe write failure, invalid-handle write over real Win32 pipes (POSIX equivalents already covered by `CoreVideoIpcLineIo`)

## Verification
- Full Windows build (VS 2022, x64 Release): `obs-zoom-plugin.dll`, `ZoomObsEngine.exe`, and all test executables build clean, no new warnings.
- `ctest -C Release`: **10/10 passed**, including the new `CoreVideoIpcHardening`.

## Deliberately left out
- Audio (`"audio"`) events do not carry `shm_gen` — audio regions only grow (recreate on larger `byte_len`), and the plugin's size check already forces a re-open in that case; an engine restart forces full resubscription which recreates the audio flow. Can be added later with the same helper if we ever see a stale-audio report.
- No plugin→engine ping (engine already exits on plugin-side pipe close; the plugin-side heartbeat from PR #112 covers the other direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)