### PR TITLE
Harden OBS dock/shutdown lifecycle (Closes #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,20 @@ obvious crash markers:
   -ExpectDockShow
 ```
 
+To exercise the **repeated open/close** acceptance criterion, close and reopen
+each dock several times in one OBS session, then assert each dock logged at
+least N shows with `-MinDockShows N`. With `-ExpectShutdown` the audit also
+enforces clean teardown ordering: it fails if any dock is (re)registered or
+shown *after* the shutdown marker, or if a dock was ever shown without an OBS
+host wrapper (the blank/detached-panel symptom), or if a crash marker appears:
+
+```powershell
+.\scripts\obs-scene-smoke-test.ps1 -LogOnly -ExpectShutdown `
+  -ObsLogPath "$env:APPDATA\obs-studio\logs\latest.log" `
+  -ExpectedDockId ZoomControlDock,ZoomOutputManagerDock,ZoomDiagnosticsDock,ZoomIsoRecorderDock `
+  -ExpectDockShow -MinDockShows 2
+```
+
 5. **Set up OAuth (for Marketplace / external-account joins)** - publishers configure the Cloudflare broker and bake `-DZOOM_EMBED_OAUTH_AUTHORIZATION_URL=https://corevideo.iamfatness.us/oauth/start` into the build. End users just open the Settings dialog and click **Sign in with Zoom**. See [`docs/ZOOM_MARKETPLACE_OAUTH.md`](docs/ZOOM_MARKETPLACE_OAUTH.md) for the full walkthrough.
 
 6. **Join once, then assign outputs** - use the CoreVideo dock or the TCP/OSC control APIs to join the meeting once per OBS session. Then add **Zoom Participant**, **Zoom Participant Audio**, **Zoom Share**, or **Zoom Interpretation Audio** sources and assign them to participants, active speaker, screen share, or Spotlight 1-8 dynamic roles.

--- a/scripts/obs-scene-smoke-test.ps1
+++ b/scripts/obs-scene-smoke-test.ps1
@@ -40,6 +40,10 @@ param(
     [switch]$ExpectDockShow,
 
     [Parameter()]
+    [ValidateRange(1, 100)]
+    [int]$MinDockShows = 1,
+
+    [Parameter()]
     [switch]$LogOnly
 )
 
@@ -366,12 +370,62 @@ function Assert-LogDoesNotContain {
     }
 }
 
+function Assert-LogCountAtLeast {
+    param(
+        [string]$Path,
+        [string]$Marker,
+        [int]$Minimum
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "OBS log file not found: $Path"
+    }
+
+    $lines = @(Get-Content -LiteralPath $Path)
+    $escaped = [regex]::Escape($Marker)
+    $count = @($lines | Where-Object { $_ -match $escaped }).Count
+    if ($count -lt $Minimum) {
+        throw "OBS log expected marker '$Marker' at least $Minimum time(s) but found $count. Repeated dock open/close may be failing."
+    }
+}
+
+function Assert-NoMarkerAfterMarker {
+    param(
+        [string]$Path,
+        [string]$FirstMarker,
+        [string[]]$Forbidden
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "OBS log file not found: $Path"
+    }
+
+    $lines = @(Get-Content -LiteralPath $Path)
+    $escapedFirst = [regex]::Escape($FirstMarker)
+    $firstIndex = -1
+    for ($i = 0; $i -lt $lines.Count; ++$i) {
+        if ($lines[$i] -match $escapedFirst) { $firstIndex = $i; break }
+    }
+    if ($firstIndex -lt 0) {
+        return  # nothing to check; presence of $FirstMarker is asserted separately
+    }
+
+    for ($i = $firstIndex + 1; $i -lt $lines.Count; ++$i) {
+        foreach ($marker in $Forbidden) {
+            if ($lines[$i] -match [regex]::Escape($marker)) {
+                throw "OBS log shows '$marker' AFTER '$FirstMarker' (line $($i + 1)). Dock/engine activity after shutdown began indicates a teardown-order or use-after-free hazard."
+            }
+        }
+    }
+}
+
 function Test-CoreVideoObsLog {
     param(
         [string]$Path,
         [string[]]$ExpectedDockId,
         [bool]$ExpectShutdown,
-        [bool]$ExpectDockShow
+        [bool]$ExpectDockShow,
+        [int]$MinDockShows = 1
     )
 
     if (-not $Path) {
@@ -393,9 +447,40 @@ function Test-CoreVideoObsLog {
     Assert-LogContains -Path $Path -Expected $markers
     Assert-LogDoesNotContain -Path $Path -Forbidden @(
         "[obs-zoom-plugin] obs_frontend_get_main_window() returned null",
+        # A dock shown with no OBS host wrapper is the blank/detached-panel
+        # symptom this issue is about; it must never happen on reopen.
+        "[obs-zoom-plugin] Showing dock without host:",
         "Unhandled exception",
         "Access violation"
     )
+
+    # Repeated open/close coverage: with -ExpectDockShow -MinDockShows N, assert
+    # each dock was shown at least N times (i.e. reopened after being closed),
+    # not merely registered once at load.
+    if ($ExpectDockShow -and $MinDockShows -gt 1) {
+        foreach ($id in $ExpectedDockId) {
+            Assert-LogCountAtLeast -Path $Path `
+                -Marker "[obs-zoom-plugin] Showing dock: $id" `
+                -Minimum $MinDockShows
+        }
+        Write-Host "CoreVideo docks were each shown at least $MinDockShows time(s) (repeated open/close)."
+    }
+
+    # Clean-shutdown ordering: once teardown has begun, nothing may re-register
+    # or re-show a dock, and no crash marker may appear. Catches use-after-free
+    # / dock-resurrection during exit.
+    if ($ExpectShutdown) {
+        Assert-NoMarkerAfterMarker -Path $Path `
+            -FirstMarker "[obs-zoom-plugin] Shutting down CoreVideo runtime" `
+            -Forbidden @(
+                "[obs-zoom-plugin] Registered dock:",
+                "[obs-zoom-plugin] Showing dock:",
+                "Unhandled exception",
+                "Access violation"
+            )
+        Write-Host "CoreVideo shutdown ordering is clean (no dock activity or crash after teardown began)."
+    }
+
     Write-Host "CoreVideo OBS log lifecycle markers are present."
 }
 
@@ -404,7 +489,8 @@ if ($LogOnly) {
         -Path $ObsLogPath `
         -ExpectedDockId $ExpectedDockId `
         -ExpectShutdown:$ExpectShutdown `
-        -ExpectDockShow:$ExpectDockShow
+        -ExpectDockShow:$ExpectDockShow `
+        -MinDockShows $MinDockShows
     return
 }
 
@@ -456,7 +542,8 @@ try {
             -Path $ObsLogPath `
             -ExpectedDockId $ExpectedDockId `
             -ExpectShutdown:$ExpectShutdown `
-            -ExpectDockShow:$ExpectDockShow
+            -ExpectDockShow:$ExpectDockShow `
+            -MinDockShows $MinDockShows
     }
 
     $sourceScene = "CoreVideo Sources"

--- a/src/zoom-osc-server.cpp
+++ b/src/zoom-osc-server.cpp
@@ -177,8 +177,14 @@ bool ZoomOscServer::start(quint16 port)
         }, Qt::QueuedConnection);
     });
 
-    m_poll_timer = new QTimer(this);
-    connect(m_poll_timer, &QTimer::timeout, this, [this]() { poll_and_push(); });
+    // Create the poll timer once. start() can be called again after stop()
+    // (e.g. when the port is changed in settings); re-using the existing timer
+    // avoids leaking a QTimer child and stacking duplicate timeout handlers on
+    // the singleton for the life of the OBS session.
+    if (!m_poll_timer) {
+        m_poll_timer = new QTimer(this);
+        connect(m_poll_timer, &QTimer::timeout, this, [this]() { poll_and_push(); });
+    }
     m_poll_timer->start(kPollIntervalMs);
 
     return true;


### PR DESCRIPTION
Closes #91

## Summary
A focused lifecycle audit of the OBS UI surface for the P0 close/exit-crash and dock-reopen issue, plus fixes for the residual hazard found and stronger scripted lifecycle coverage.

Most of #91's outcomes were already implemented by the prior progress commits on `main` (idempotent `shutdown_corevideo`, reverse-order teardown, `m_alive`/`QPointer`/`QueuedConnection` callback guards, dock host weak-pointers + destroyed-signal clearing + re-registration recovery, unified cancel path, and log-marker smoke coverage). This PR verifies that hardening, fixes the one concrete residual hazard, and closes the remaining acceptance-criteria gap (a scripted test that actually exercises *repeated* open/close and *shutdown ordering*).

## Hazards found -> fix applied
- **OSC control server leaks/duplicates its poll `QTimer` on restart** (`src/zoom-osc-server.cpp`). `ZoomOscServer::start()` can be called again after `stop()` when the OSC port is changed in Settings; it unconditionally `new`ed a `QTimer` each time, leaking the previous one (parented to the singleton, so it lives for the whole session) and stacking duplicate `poll_and_push` handlers. `ZoomControlServer` already guards this with `if (!m_poll_timer)`. **Fix:** create the timer once and reuse it, matching the control-server pattern.
- **Smoke test could not prove repeated dock open/close or clean shutdown ordering** (`scripts/obs-scene-smoke-test.ps1`). The existing `-ExpectDockShow` only checked that each "Showing dock" marker appeared at least once. **Fix:** added `-MinDockShows N` (assert each dock was shown >= N times), rejected the `Showing dock without host` blank/detached-panel symptom, and with `-ExpectShutdown` added a teardown-order assertion that fails if any dock is re-registered/shown or a crash marker (`Unhandled exception`/`Access violation`) appears *after* the shutdown marker. Documented in `README.md`.

## Audit notes (no change needed — verified sound)
- **plugin-main.cpp**: `shutdown_corevideo()` is idempotent and tears down in reverse order (panels -> control server -> OSC server -> ISO recorder -> engine); dock widgets are QWidgets registered via `obs_frontend_add_dock_by_id` and owned by OBS; QPointers + `destroyed` signals null stale globals so later Tools-menu opens can't target deleted hosts/widgets.
- **Callback safety**: `ZoomDock`/`ZoomOutputDialog` roster/error/preview callbacks all capture a shared `std::atomic<bool> m_alive` (plus `QPointer` for preview labels) and marshal to the UI thread via `Qt::QueuedConnection`, so a reader-thread callback firing into a torn-down widget is a no-op. Engine callback maps are keyed by `void*` under a mutex (re-add overwrites; no duplicates/iterator invalidation).
- **Cancel-retry (the #91 "stops all pending reconnect attempts" requirement)**: verified in `src/zoom-reconnect.cpp` — cancellation is generation-counter based, and the dock (`on_cancel_recovery_clicked`), TCP (`recovery_cancel`) and OSC (`/zoom/recovery/cancel`) paths all route through the unified `ZoomEngineClient::stop()`, which calls `ReconnectManager::cancel()` **and** `clear_session()` before tearing down the engine, so a queued `execute_retry` on the UI thread becomes a no-op and no retry loop can restart.
- **Thread joins**: engine reader/monitor threads are joined in `stop()`; the reconnect timer thread is joined in its destructor; the dock join thread is joined in `~ZoomDock`. The TCP/OSC servers are Qt-event-loop based (no worker thread to join), so joining engine threads from the UI thread at exit does not deadlock (reader-thread callbacks are non-blocking `QueuedConnection`). The owner's sibling-product deadlock (blocking UI-thread teardown) does not reproduce here.

## Verification
- `cmake --build build-vs-release --config Release --target obs-zoom-plugin --parallel` — clean (toolchain: VS 2022 BuildTools, `-A x64`, `-DENABLE_FFMPEG_HW_ACCEL=ON`).
- `ctest --test-dir build-vs-release -C Release --output-on-failure` — 9/9 passed.
- Smoke-script logic self-tested against synthetic OBS logs: pass on a clean repeated-cycle+shutdown log; correctly fails on (a) a dock shown after shutdown, (b) a `Showing dock without host` line, and (c) fewer shows than `-MinDockShows`.
- `git diff --check` — clean.

### Needs live OBS verification (owner)
Runtime dock cycling and true exit-crash behavior require a live OBS session. Recommended: in one session, open/close each of the four docks 2-3 times, join/leave a meeting (and force an engine-crash recovery + Cancel Recovery), then exit and run the log-only audit with `-ExpectDockShow -ExpectShutdown -MinDockShows 2` against `latest.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
