### PR TITLE
Stabilize Zoom sign-in and join: one enforced auth decision path (#89)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,17 @@ if(BUILD_TESTING)
     add_test(NAME CoreVideoIpcHardening
              COMMAND CoreVideoIpcHardeningTest)
 
+    # Centralized Zoom auth/join decision path + error catalog (issue #89).
+    # Header-only logic; no Qt/OBS/SDK dependencies, no secrets.
+    add_executable(CoreVideoJoinDecisionTest
+        tests/join-decision-test.cpp
+    )
+    target_include_directories(CoreVideoJoinDecisionTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoJoinDecision
+             COMMAND CoreVideoJoinDecisionTest)
+
     # IPC line-I/O framing and write-failure semantics (POSIX socket-based test).
     if(NOT WIN32)
         add_executable(CoreVideoIpcLineIoTest

--- a/docs/ZOOM_MARKETPLACE_OAUTH.md
+++ b/docs/ZOOM_MARKETPLACE_OAUTH.md
@@ -98,6 +98,73 @@ local config cannot change the published app identity. Developers can still use
    waiting-room participants, manage self video/audio, and use normal meeting
    controls.
 
+## The enforced join decision path (issue #89)
+
+Sign-in has always worked; meeting *join* kept regressing because the code chose
+between OAuth / ZAK / public app key / SDK JWT / broker in several scattered
+places. Those choices are now centralized in one pure, unit-tested function,
+`zoom_join::plan_join()` in `src/zoom-join-decision.h`. Every caller (the dock's
+`on_join_clicked`, the engine client's error mapping, and the OAuth manager's
+token-error mapping) reads from that one place.
+
+The production path is fixed:
+
+1. **Sign-in** — Public Client OAuth + PKCE, issued through the HTTPS broker
+   (`/oauth/start`). `plan_join` reports `oauth_flow=broker`. Direct
+   `public_pkce` is a dev-only fallback when no broker URL is embedded.
+2. **ZAK** — if the operator did not supply a ZAK or on-behalf token, the
+   signed-in user's ZAK is fetched over OAuth (`zak=fetch_via_oauth`). If no
+   OAuth tokens are held yet, the plan sets `sign_in_required=1` and the dock
+   starts sign-in and retries the join afterward.
+3. **Meeting SDK auth** — the Marketplace Public Client ID is passed as
+   `AuthContext.publicAppKey` (`sdk_auth_mode=public_app_key`). Self-signed JWT
+   (from an SDK key/secret pair) and broker-minted SDK JWT are dev-only
+   fallbacks and are logged loudly as such, never silently.
+
+### The join-decision log block
+
+Every join attempt emits one coherent block (grep `[join-decision]`). It never
+contains a full secret — only masked tails (`****WXYZ`), kinds, and flags:
+
+```
+[obs-zoom-plugin] [join-decision] oauth_flow=broker oauth_client=****WXYZ \
+  broker=corevideo.iamfatness.us sdk_auth_mode=public_app_key \
+  public_app_key=****WXYZ zak=fetch_via_oauth token_type=auto_zak \
+  have_access_token=1 have_refresh_token=1 token_expired=0 \
+  sign_in_required=0 blocking_error=none
+```
+
+After the ZAK / broker-JWT step resolves, a second `[join-decision] resolved …`
+line records the final auth mode and ZAK presence. The Meeting SDK result code
+itself arrives asynchronously from the `ZoomObsEngine` child process and is
+logged by the engine client as `auth_ok` or `auth_fail` with the raw
+`AUTHRET_*` name and code.
+
+### Error-message catalog
+
+All operator-facing auth/join failures map to one enum, `zoom_join::ZoomJoinError`,
+with distinct guidance in `join_error_guidance()`. Distinct categories:
+
+| Category | Trigger (examples) | Operator guidance summary |
+| --- | --- | --- |
+| `wrong_environment` | OAuth `invalid_client`; `AUTHRET_JWTTOKENWRONG` in public-app-key mode; `AUTHRET_CLIENT_INCOMPATIBLE` | App identity is not valid for this Zoom environment / build. |
+| `expired_token` | OAuth `invalid_grant`; expired token, no refresh token | Sign in with Zoom again. |
+| `invalid_redirect` | OAuth `redirect_uri_mismatch` | Redirect URI not on the Marketplace allow list (publisher fix). |
+| `missing_approval` | OAuth `invalid_scope`; meeting fail 63/60/62/64 | App not published/approved or account not entitled. |
+| `sdk_auth_failure` | `AUTHRET_*` key/secret/jwt rejection (JWT mode) | Meeting SDK rejected the identity. |
+| `sdk_entitlement` | `AUTHRET_ACCOUNTNOTSUPPORT` / `ACCOUNTNOTENABLESDK` | Account not enabled for the Meeting SDK. |
+| `network_issue` | `AUTHRET_NETWORKISSUE` / `OVERTIME` / `SERVICE_BUSY` | Transient network problem; retry. |
+| `on_behalf_token_invalid` | meeting fail 500/502/503/505/506 | On-behalf token bad or mismatched. |
+| `needs_sign_in` | needs a ZAK but no tokens; meeting fail 504/82/23 | Sign in with Zoom first. |
+| `missing_credentials` | no SDK identity embedded and engine not authed | Install a build with the embedded identity. |
+
+These strings surface through the existing dock status/banner + error label and
+land in the support bundle, so the raw `AUTHRET_*` code stays available while the
+operator sees actionable text. The catalog and the planner are covered by
+`tests/join-decision-test.cpp` (ctest target `CoreVideoJoinDecision`), which
+also asserts that every category's message is non-empty and distinct and that
+the log block never leaks a full identifier.
+
 ## Security notes
 
 - No OAuth or Meeting SDK client secret is shipped in the binary. The settings

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -5,6 +5,7 @@
 #include "obs-utils.h"
 #include "speaker-director.h"
 #include "zoom-engine-client.h"
+#include "zoom-join-decision.h"
 #include "zoom-oauth.h"
 #include "zoom-output-manager.h"
 #include "zoom-output-dialog.h"
@@ -105,13 +106,6 @@ static QString sidecar_executable_path()
 #else
     return QStringLiteral("CoreVideoSidecar");
 #endif
-}
-
-static std::string redacted_tail(const std::string &value)
-{
-    if (value.empty()) return "empty";
-    if (value.size() <= 4) return "****";
-    return "****" + value.substr(value.size() - 4);
 }
 
 // Fast I420 -> RGB888 for dock thumbnails (shared with output dialog logic)
@@ -1602,42 +1596,51 @@ void ZoomDock::on_join_clicked()
     }
 
     ZoomPluginSettings s = ZoomPluginSettings::load();
-    const std::string resolved_public_app_key =
-        s.resolved_meeting_sdk_public_app_key();
+
+    // ── Single, auditable join decision path (issue #89) ────────────────────
+    // Every branch below is derived from one pure planner so the auth mode,
+    // ZAK plan, and sign-in requirement can be unit-tested and are logged as one
+    // coherent block. See src/zoom-join-decision.h.
+    zoom_join::JoinDecisionInputs decision_in;
+    decision_in.oauth_client_id         = s.oauth_client_id;
+    decision_in.oauth_authorization_url = s.oauth_authorization_url;
+    decision_in.meeting_sdk_auth_mode   = s.meeting_sdk_auth_mode;
+    decision_in.sdk_public_app_key      = s.sdk_public_app_key;
+    decision_in.has_sdk_key_secret_pair = !s.sdk_key.empty() && !s.sdk_secret.empty();
+    decision_in.has_embedded_jwt        = !s.jwt_token.empty();
+    decision_in.engine_already_authed   =
+        ZoomEngineClient::instance().is_authenticated();
+    decision_in.has_access_token        = !s.oauth_access_token.empty();
+    decision_in.has_refresh_token       = !s.oauth_refresh_token.empty();
+    decision_in.access_token_expired    =
+        s.oauth_expires_at <= QDateTime::currentSecsSinceEpoch();
+    decision_in.token_type              = token_type.toStdString();
+    // tokens.{user_zak,on_behalf_token} already reflect any typed/parsed value,
+    // so map them directly and leave has_typed_token false to avoid double count.
+    decision_in.has_parsed_zak          = !tokens.user_zak.empty();
+    decision_in.has_parsed_on_behalf    = !tokens.on_behalf_token.empty();
+
+    const zoom_join::JoinDecisionPlan plan = zoom_join::plan_join(decision_in);
+    blog(LOG_INFO, "[obs-zoom-plugin] %s",
+         zoom_join::format_join_decision_path(decision_in, plan).c_str());
+
+    const std::string resolved_public_app_key = plan.resolved_public_app_key;
     const bool use_public_app_key = !resolved_public_app_key.empty();
     std::string jwt = use_public_app_key ? std::string() : s.resolved_jwt_token();
-    if (!ZoomEngineClient::instance().is_authenticated() && jwt.empty() &&
-        !use_public_app_key) {
+
+    if (plan.blocking_error == zoom_join::ZoomJoinError::MissingCredentials) {
         QMessageBox::warning(this, "Zoom Authentication",
-            "This CoreVideo build does not have Zoom Meeting SDK credentials "
-            "configured. Rebuild with embedded SDK credentials or restore a "
-            "valid SDK JWT before joining.");
+            QString::fromUtf8(zoom_join::join_error_guidance(plan.blocking_error)));
         return;
     }
 
-    const bool needs_oauth_zak =
-        tokens.user_zak.empty() &&
-        tokens.on_behalf_token.empty();
-    blog(LOG_INFO,
-         "[obs-zoom-plugin] Zoom join token mode=%s zak_needed=%d typed_token=%d parsed_obf=%d parsed_zak=%d parsed_app=%d app_privilege_present=%d sdk_key=%s oauth_client_id=%s oauth_scopes=\"%s\"",
-         token_type.toUtf8().constData(),
-         needs_oauth_zak ? 1 : 0,
-         typed_token.empty() ? 0 : 1,
-         parsed.on_behalf_token.empty() ? 0 : 1,
-         parsed.user_zak.empty() ? 0 : 1,
-         parsed.app_privilege_token.empty() ? 0 : 1,
-         tokens.app_privilege_token.empty() ? 0 : 1,
-         use_public_app_key ? "(public_app_key)" : redacted_tail(s.sdk_key).c_str(),
-         redacted_tail(s.oauth_client_id).c_str(),
-         s.oauth_scopes.c_str());
-    if (needs_oauth_zak &&
-        s.oauth_access_token.empty() &&
-        s.oauth_refresh_token.empty()) {
+    if (plan.needs_oauth_sign_in) {
         QString error;
         if (!ZoomOAuthManager::instance().begin_authorization(this, &error)) {
             QMessageBox::warning(this, "Zoom Authentication",
                 error.isEmpty()
-                    ? QStringLiteral("Sign in with Zoom before joining meetings that require owner/host context.")
+                    ? QString::fromUtf8(zoom_join::join_error_guidance(
+                          zoom_join::ZoomJoinError::NeedsSignIn))
                     : error);
             return;
         }
@@ -1717,10 +1720,14 @@ void ZoomDock::on_join_clicked()
             }
         }
         blog(LOG_INFO,
-             "[obs-zoom-plugin] Meeting SDK auth mode=%s jwt_present=%d public_app_key_present=%d broker_jwt=%d",
-             settings.meeting_sdk_auth_mode.c_str(),
+             "[obs-zoom-plugin] [join-decision] resolved sdk_auth_mode=%s jwt_present=%d public_app_key=%s zak_present=%d broker_jwt=%d "
+             "(Meeting SDK result code follows from the engine as auth_ok/auth_fail)",
+             public_app_key.empty()
+                 ? (jwt.empty() ? "none" : "jwt")
+                 : "public_app_key",
              jwt.empty() ? 0 : 1,
-             public_app_key.empty() ? 0 : 1,
+             zoom_join::redacted_tail(public_app_key).c_str(),
+             tokens.user_zak.empty() ? 0 : 1,
              settings.use_broker_sdk_jwt() ? 1 : 0);
         const bool started = ZoomEngineClient::instance().start(jwt, public_app_key);
         const bool still_current =

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -1,5 +1,6 @@
 #include "zoom-engine-client.h"
 #include "speaker-director.h"
+#include "zoom-join-decision.h"
 #include "zoom-reconnect.h"
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -58,23 +59,26 @@ static std::string zoom_error_message(const QJsonObject &obj)
     const int code = obj.value("code").toInt(0);
 
     if (cmd == "auth_fail") {
-        std::string out = auth_mode == "public_app_key"
-            ? "Zoom SDK public app key authentication failed"
-            : "Zoom SDK authentication failed";
+        // Centralized error catalog (issue #89): map the Meeting SDK AuthResult
+        // name onto a distinct, actionable operator message. The public-app-key
+        // vs jwt mode changes how key/secret/jwt rejections are interpreted.
+        const bool public_app_key_mode = auth_mode == "public_app_key";
+        const zoom_join::ZoomJoinError category =
+            zoom_join::classify_sdk_auth_result(name.toStdString(),
+                                                public_app_key_mode);
+        std::string out = zoom_join::join_error_guidance(category);
+        // Keep the raw result code/name in the message for support bundles.
+        out += " [";
+        out += "sdk_auth_mode=" + (auth_mode.isEmpty()
+                                       ? std::string("jwt")
+                                       : auth_mode.toStdString());
+        if (code != 0)
+            out += " code=" + std::to_string(code);
+        if (!name.isEmpty())
+            out += " " + name.toStdString();
         if (!stage.isEmpty())
-            out += " at " + stage.toStdString();
-        if (code != 0 || (!name.isEmpty() && auth_mode != "public_app_key")) {
-            out += " (";
-            if (code != 0)
-                out += std::to_string(code);
-            if (!name.isEmpty() && auth_mode != "public_app_key") {
-                if (code != 0) out += " ";
-                out += name.toStdString();
-            }
-            out += ")";
-        }
-        if (auth_mode == "public_app_key")
-            out += ". Confirm the Marketplace Public Client ID is enabled for Meeting SDK Embed on this app/environment.";
+            out += " stage=" + stage.toStdString();
+        out += "]";
         return out;
     }
 

--- a/src/zoom-join-decision.h
+++ b/src/zoom-join-decision.h
@@ -1,0 +1,429 @@
+#pragma once
+//
+// zoom-join-decision.h — the single, auditable "join decision path" for the
+// CoreVideo Zoom integration (GitHub issue #89).
+//
+// The production path is fixed and enforced:
+//   * Sign-in: Zoom Public Client OAuth + PKCE (or the HTTPS broker that wraps
+//     it). No desktop client secret, no user-entered credentials.
+//   * Join:    the signed-in user's ZAK, fetched over OAuth.
+//   * Meeting SDK auth: the Marketplace Public Client ID as AuthContext
+//     publicAppKey where supported.
+//
+// Historically the code picked between OAuth / ZAK / public app key / SDK JWT /
+// broker in several scattered places, which is exactly what kept regressing.
+// This header centralizes every branch point into one pure function,
+// plan_join(), plus one error-string catalog. Both are free of Qt / OBS / Zoom
+// SDK dependencies so they can be unit-tested without secrets or a live meeting
+// (see tests/join-decision-test.cpp).
+//
+// Rules:
+//   * NEVER put a full secret, token, client id, ZAK, or app key in a log line.
+//     Use redacted_tail() — last 4 chars only.
+//   * Keep every operator-facing message in join_error_guidance() so the
+//     messages stay distinct and testable.
+//
+#include <cstdint>
+#include <string>
+
+namespace zoom_join {
+
+// ── Redaction ────────────────────────────────────────────────────────────────
+// Last 4 characters only, masked. Used for every identifier that touches a log.
+inline std::string redacted_tail(const std::string &value)
+{
+    if (value.empty()) return "(empty)";
+    if (value.size() <= 4) return "****";
+    return "****" + value.substr(value.size() - 4);
+}
+
+// ── Decision enums ───────────────────────────────────────────────────────────
+
+// How the Meeting SDK (in the ZoomObsEngine child process) will authenticate.
+enum class SdkAuthMode {
+    None,          // no auth material available and engine not already authed
+    PublicAppKey,  // AuthContext.publicAppKey = Marketplace Public Client ID (production)
+    SelfSignedJwt, // dev-only: HS256 JWT signed from an SDK key/secret pair
+    BrokerJwt,     // dev/staging: SDK JWT minted by the CoreVideo broker
+};
+
+// How the sign-in / OAuth authorization request is issued.
+enum class OAuthClientKind {
+    None,        // no OAuth client id configured at all
+    PublicPkce,  // direct Public Client OAuth + PKCE against zoom.us
+    Broker,      // HTTPS broker /oauth/start wraps the PKCE flow (production)
+};
+
+// Where the join ZAK / owner-context token comes from.
+enum class ZakPlan {
+    NotNeeded,          // operator supplied a ZAK / on-behalf token already
+    ProvidedByOperator, // typed or parsed-from-URL token will be used
+    FetchViaOAuth,      // fetch the signed-in user's ZAK over OAuth before join
+};
+
+// ── Error catalog ────────────────────────────────────────────────────────────
+// One enum, one message function. Each value maps to DISTINCT operator guidance
+// so support can tell environments / tokens / redirects / approval / SDK-auth
+// failures apart without reading logs.
+enum class ZoomJoinError {
+    None,
+    MissingCredentials,   // build has no SDK auth material and engine not authed
+    NeedsSignIn,          // must complete Zoom OAuth sign-in first
+    WrongEnvironment,     // client id / app key not valid for this Zoom env
+    ExpiredToken,         // OAuth token expired and could not be refreshed
+    InvalidRedirect,      // redirect URI not on the Marketplace allow list
+    MissingApproval,      // app not published/approved or account not entitled
+    SdkAuthFailure,       // Meeting SDK rejected the JWT / key-secret
+    SdkEntitlement,       // account tier not enabled for the Meeting SDK
+    NetworkIssue,         // transient network / timeout / busy
+    OnBehalfTokenInvalid, // on-behalf token bad or mismatched for the meeting
+    Unknown,
+};
+
+// Short, stable identifier — used in logs and tests (never localized).
+inline const char *join_error_id(ZoomJoinError e)
+{
+    switch (e) {
+    case ZoomJoinError::None:                 return "none";
+    case ZoomJoinError::MissingCredentials:   return "missing_credentials";
+    case ZoomJoinError::NeedsSignIn:          return "needs_sign_in";
+    case ZoomJoinError::WrongEnvironment:     return "wrong_environment";
+    case ZoomJoinError::ExpiredToken:         return "expired_token";
+    case ZoomJoinError::InvalidRedirect:      return "invalid_redirect";
+    case ZoomJoinError::MissingApproval:      return "missing_approval";
+    case ZoomJoinError::SdkAuthFailure:       return "sdk_auth_failure";
+    case ZoomJoinError::SdkEntitlement:       return "sdk_entitlement";
+    case ZoomJoinError::NetworkIssue:         return "network_issue";
+    case ZoomJoinError::OnBehalfTokenInvalid: return "on_behalf_token_invalid";
+    case ZoomJoinError::Unknown:              return "unknown";
+    }
+    return "unknown";
+}
+
+// Operator-facing, actionable guidance. DISTINCT per category (issue #89 AC).
+inline const char *join_error_guidance(ZoomJoinError e)
+{
+    switch (e) {
+    case ZoomJoinError::None:
+        return "";
+    case ZoomJoinError::MissingCredentials:
+        return "This CoreVideo build has no Zoom Meeting SDK identity embedded. "
+               "Install a published build (or, for a dev build, set the embedded "
+               "Public Client ID) before joining.";
+    case ZoomJoinError::NeedsSignIn:
+        return "Sign in with Zoom before joining. CoreVideo needs your Zoom "
+               "account's ZAK to join with owner/host context.";
+    case ZoomJoinError::WrongEnvironment:
+        return "Zoom rejected the app identity for this environment. The OAuth "
+               "Client ID / Meeting SDK Public Client ID this build was compiled "
+               "with does not match an active Marketplace app, or it belongs to a "
+               "different Zoom environment (dev vs beta vs production). Confirm you "
+               "are running the build for this environment.";
+    case ZoomJoinError::ExpiredToken:
+        return "Your Zoom sign-in has expired and could not be refreshed. Click "
+               "Sign in with Zoom again to get a fresh token, then retry the join.";
+    case ZoomJoinError::InvalidRedirect:
+        return "Zoom rejected the OAuth redirect URI. The redirect URI this build "
+               "uses is not on the Marketplace app's allow list. Add it to the "
+               "app's OAuth allow list (publisher action) and try again.";
+    case ZoomJoinError::MissingApproval:
+        return "Zoom accepted your sign-in but this app is not approved to join "
+               "this meeting. The Marketplace app must be published (or beta/prod "
+               "access granted for this account), and Meeting SDK / Embed enabled, "
+               "for the host account you are joining.";
+    case ZoomJoinError::SdkAuthFailure:
+        return "The Zoom Meeting SDK rejected authentication. The embedded Public "
+               "Client ID (or dev SDK JWT) was not accepted. Confirm the app "
+               "identity is valid and enabled for Meeting SDK / Embed.";
+    case ZoomJoinError::SdkEntitlement:
+        return "This Zoom account is not enabled for the Meeting SDK. Ask the "
+               "account admin to enable Meeting SDK / Embed access, then retry.";
+    case ZoomJoinError::NetworkIssue:
+        return "A network problem interrupted Zoom authentication (timeout or "
+               "service busy). Check connectivity and try the join again.";
+    case ZoomJoinError::OnBehalfTokenInvalid:
+        return "Zoom rejected the on-behalf token: it is invalid or does not match "
+               "this meeting. Re-generate the token or use Zoom sign-in instead.";
+    case ZoomJoinError::Unknown:
+        return "Zoom authentication failed for an unrecognized reason. See the "
+               "OBS log and support bundle join-decision block for the raw code.";
+    }
+    return "";
+}
+
+// ── Classifiers ──────────────────────────────────────────────────────────────
+// Map raw Zoom result identifiers onto the catalog. Kept string/int based so the
+// engine (which speaks the SDK) can report a name/code over IPC and the plugin
+// maps it here — no SDK headers needed to test this.
+
+// Meeting SDK AuthResult, keyed by the AUTHRET_* name the engine reports.
+// public_app_key_mode changes the interpretation of key/secret/jwt rejections:
+// in public-app-key mode those almost always mean the Public Client ID is not
+// enabled for Embed on this environment (wrong env), not a bad secret.
+inline ZoomJoinError classify_sdk_auth_result(const std::string &authret_name,
+                                              bool public_app_key_mode)
+{
+    if (authret_name == "AUTHRET_SUCCESS")
+        return ZoomJoinError::None;
+    if (authret_name == "AUTHRET_ACCOUNTNOTSUPPORT" ||
+        authret_name == "AUTHRET_ACCOUNTNOTENABLESDK")
+        return ZoomJoinError::SdkEntitlement;
+    if (authret_name == "AUTHRET_NETWORKISSUE" ||
+        authret_name == "AUTHRET_OVERTIME" ||
+        authret_name == "AUTHRET_SERVICE_BUSY")
+        return ZoomJoinError::NetworkIssue;
+    if (authret_name == "AUTHRET_CLIENT_INCOMPATIBLE")
+        return ZoomJoinError::WrongEnvironment;
+    if (authret_name == "AUTHRET_KEYORSECRETEMPTY" ||
+        authret_name == "AUTHRET_KEYORSECRETWRONG" ||
+        authret_name == "AUTHRET_JWTTOKENWRONG")
+        return public_app_key_mode ? ZoomJoinError::WrongEnvironment
+                                   : ZoomJoinError::SdkAuthFailure;
+    if (authret_name == "AUTHRET_LIMIT_EXCEEDED_EXCEPTION")
+        return ZoomJoinError::SdkAuthFailure;
+    return ZoomJoinError::SdkAuthFailure;
+}
+
+// Meeting join failure (MEETING_STATUS_FAILED iResult code).
+inline ZoomJoinError classify_meeting_fail(int code)
+{
+    switch (code) {
+    case 63:  // MEETING_FAIL_UNABLE_TO_JOIN_EXTERNAL_MEETING
+    case 60:  // MEETING_FAIL_FORBID_TO_JOIN_INTERNAL_MEETING
+    case 62:  // MEETING_FAIL_HOST_DISALLOW_OUTSIDE_USER_JOIN
+    case 64:  // MEETING_FAIL_BLOCKED_BY_ACCOUNT_ADMIN
+        return ZoomJoinError::MissingApproval;
+    case 500: // MEETING_FAIL_APP_PRIVILEGE_TOKEN_ERROR
+    case 502: // MEETING_FAIL_ON_BEHALF_TOKEN_CONFLICT_LOGIN_ERROR
+    case 503: // MEETING_FAIL_USER_LEVEL_TOKEN_NOT_HAVE_HOST_ZAK_OBF
+    case 505: // MEETING_FAIL_ON_BEHALF_TOKEN_INVALID
+    case 506: // MEETING_FAIL_ON_BEHALF_TOKEN_NOT_MATCH_MEETING
+        return ZoomJoinError::OnBehalfTokenInvalid;
+    case 504: // MEETING_FAIL_APP_CAN_NOT_ANONYMOUS_JOIN_MEETING
+        return ZoomJoinError::NeedsSignIn;
+    case 82:  // MEETING_FAIL_NEED_SIGN_IN_FOR_PRIVATE_MEETING
+    case 23:  // MEETING_FAIL_ENFORCE_LOGIN
+        return ZoomJoinError::NeedsSignIn;
+    default:
+        return ZoomJoinError::Unknown;
+    }
+}
+
+// OAuth token endpoint error ("error" field of the token response body).
+inline ZoomJoinError classify_oauth_error(const std::string &oauth_error_code)
+{
+    if (oauth_error_code == "invalid_client")
+        return ZoomJoinError::WrongEnvironment;
+    if (oauth_error_code == "invalid_grant")
+        return ZoomJoinError::ExpiredToken;
+    if (oauth_error_code == "redirect_uri_mismatch" ||
+        oauth_error_code == "invalid_redirect_uri")
+        return ZoomJoinError::InvalidRedirect;
+    if (oauth_error_code == "invalid_scope")
+        return ZoomJoinError::MissingApproval;
+    return ZoomJoinError::Unknown;
+}
+
+// ── Decision planner ─────────────────────────────────────────────────────────
+
+struct JoinDecisionInputs {
+    // App identity (raw values — only tails are ever logged).
+    std::string oauth_client_id;          // Marketplace OAuth / Public Client ID
+    std::string oauth_authorization_url;  // broker /oauth/start URL, or empty
+    std::string meeting_sdk_auth_mode;    // "public_app_key" | "broker_jwt"
+    std::string sdk_public_app_key;       // configured public app key (dev)
+    bool        has_sdk_key_secret_pair = false; // dev self-sign material present
+    bool        has_embedded_jwt        = false; // dev static JWT present
+    bool        engine_already_authed   = false; // engine SDKAuth already succeeded
+
+    // OAuth token state.
+    bool        has_access_token   = false;
+    bool        has_refresh_token  = false;
+    bool        access_token_expired = false;
+
+    // Join-token selection from the dock.
+    std::string token_type;                 // "auto_zak"|"user_zak"|"app_privilege_token"
+    bool        has_typed_token         = false;
+    bool        has_parsed_on_behalf    = false; // on-behalf token parsed from URL
+    bool        has_parsed_zak          = false; // ZAK parsed from URL
+};
+
+struct JoinDecisionPlan {
+    OAuthClientKind oauth_client_kind = OAuthClientKind::None;
+    std::string     broker_host;              // host of broker URL, if broker
+    SdkAuthMode     sdk_auth_mode = SdkAuthMode::None;
+    std::string     resolved_public_app_key;  // raw; caller redacts for logs
+    bool            public_app_key_mode = false;
+    ZakPlan         zak_plan = ZakPlan::NotNeeded;
+    bool            needs_oauth_sign_in = false;
+    ZoomJoinError   blocking_error = ZoomJoinError::None;
+};
+
+// True if the configured authorization URL is a broker /oauth/start endpoint.
+inline bool is_broker_authorization_url(const std::string &url)
+{
+    if (url.rfind("http", 0) != 0) return false; // must be http(s)
+    // Find the path component after the authority.
+    const auto scheme_end = url.find("://");
+    if (scheme_end == std::string::npos) return false;
+    const auto path_start = url.find('/', scheme_end + 3);
+    if (path_start == std::string::npos) return false;
+    auto path = url.substr(path_start);
+    const auto q = path.find_first_of("?#");
+    if (q != std::string::npos) path = path.substr(0, q);
+    // Case-insensitive compare against "/oauth/start".
+    const std::string want = "/oauth/start";
+    if (path.size() != want.size()) return false;
+    for (size_t i = 0; i < want.size(); ++i) {
+        char c = path[i];
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+        if (c != want[i]) return false;
+    }
+    return true;
+}
+
+// Host portion of an http(s) URL (for logging the broker without the path).
+inline std::string url_host(const std::string &url)
+{
+    const auto scheme_end = url.find("://");
+    if (scheme_end == std::string::npos) return {};
+    const auto host_start = scheme_end + 3;
+    const auto host_end = url.find_first_of("/?#", host_start);
+    return url.substr(host_start,
+                      host_end == std::string::npos ? std::string::npos
+                                                    : host_end - host_start);
+}
+
+// Mirrors ZoomPluginSettings::resolved_meeting_sdk_public_app_key().
+inline std::string resolve_public_app_key(const JoinDecisionInputs &in)
+{
+    if (in.meeting_sdk_auth_mode == "public_app_key" && !in.oauth_client_id.empty())
+        return in.oauth_client_id;
+    return in.sdk_public_app_key;
+}
+
+// The one auditable decision. Pure: same inputs -> same plan, no side effects.
+inline JoinDecisionPlan plan_join(const JoinDecisionInputs &in)
+{
+    JoinDecisionPlan plan;
+
+    // 1. OAuth client kind.
+    if (is_broker_authorization_url(in.oauth_authorization_url)) {
+        plan.oauth_client_kind = OAuthClientKind::Broker;
+        plan.broker_host = url_host(in.oauth_authorization_url);
+    } else if (!in.oauth_client_id.empty()) {
+        plan.oauth_client_kind = OAuthClientKind::PublicPkce;
+    } else {
+        plan.oauth_client_kind = OAuthClientKind::None;
+    }
+
+    // 2. Meeting SDK auth mode (mirrors dock + settings resolution order).
+    plan.resolved_public_app_key = resolve_public_app_key(in);
+    const bool use_public_app_key = !plan.resolved_public_app_key.empty();
+    plan.public_app_key_mode = use_public_app_key;
+    const bool broker_jwt_mode = in.meeting_sdk_auth_mode == "broker_jwt";
+    if (use_public_app_key && broker_jwt_mode) {
+        // dev/staging: a broker mints an SDK JWT, public key is cleared at join.
+        plan.sdk_auth_mode = SdkAuthMode::BrokerJwt;
+        plan.public_app_key_mode = false;
+    } else if (use_public_app_key) {
+        plan.sdk_auth_mode = SdkAuthMode::PublicAppKey;   // production
+    } else if (in.has_embedded_jwt || in.has_sdk_key_secret_pair) {
+        plan.sdk_auth_mode = SdkAuthMode::SelfSignedJwt;  // dev fallback
+    } else {
+        plan.sdk_auth_mode = SdkAuthMode::None;
+    }
+
+    // 3. ZAK plan. Owner/host context needs a ZAK unless the operator already
+    //    supplied a ZAK or an on-behalf token (app-privilege token alone still
+    //    needs a ZAK, matching the existing dock behaviour).
+    const bool user_zak_present =
+        in.has_parsed_zak ||
+        (in.has_typed_token && in.token_type == "user_zak");
+    const bool on_behalf_present =
+        in.has_parsed_on_behalf ||
+        (in.has_typed_token && in.token_type != "user_zak" &&
+         in.token_type != "app_privilege_token");
+    const bool needs_zak = !user_zak_present && !on_behalf_present;
+    if (!needs_zak)
+        plan.zak_plan = ZakPlan::ProvidedByOperator;
+    else
+        plan.zak_plan = ZakPlan::FetchViaOAuth;
+
+    // 4. Sign-in requirement: need a ZAK but hold no OAuth tokens at all.
+    plan.needs_oauth_sign_in =
+        needs_zak && !in.has_access_token && !in.has_refresh_token;
+
+    // 5. Blocking errors (checked in priority order).
+    if (plan.sdk_auth_mode == SdkAuthMode::None && !in.engine_already_authed) {
+        plan.blocking_error = ZoomJoinError::MissingCredentials;
+    } else if (plan.needs_oauth_sign_in) {
+        plan.blocking_error = ZoomJoinError::NeedsSignIn;
+    } else if (needs_zak && in.access_token_expired && !in.has_refresh_token) {
+        plan.blocking_error = ZoomJoinError::ExpiredToken;
+    } else {
+        plan.blocking_error = ZoomJoinError::None;
+    }
+
+    return plan;
+}
+
+// ── Log rendering ────────────────────────────────────────────────────────────
+
+inline const char *sdk_auth_mode_id(SdkAuthMode m)
+{
+    switch (m) {
+    case SdkAuthMode::None:          return "none";
+    case SdkAuthMode::PublicAppKey:  return "public_app_key";
+    case SdkAuthMode::SelfSignedJwt: return "self_signed_jwt";
+    case SdkAuthMode::BrokerJwt:     return "broker_jwt";
+    }
+    return "none";
+}
+
+inline const char *oauth_client_kind_id(OAuthClientKind k)
+{
+    switch (k) {
+    case OAuthClientKind::None:       return "none";
+    case OAuthClientKind::PublicPkce: return "public_pkce";
+    case OAuthClientKind::Broker:     return "broker";
+    }
+    return "none";
+}
+
+inline const char *zak_plan_id(ZakPlan z)
+{
+    switch (z) {
+    case ZakPlan::NotNeeded:          return "not_needed";
+    case ZakPlan::ProvidedByOperator: return "provided_by_operator";
+    case ZakPlan::FetchViaOAuth:      return "fetch_via_oauth";
+    }
+    return "not_needed";
+}
+
+// The single coherent "join decision path" log block (issue #89). Never
+// contains a full secret — only redacted tails, kinds, and boolean flags.
+inline std::string format_join_decision_path(const JoinDecisionInputs &in,
+                                             const JoinDecisionPlan &plan)
+{
+    std::string out = "[join-decision]";
+    out += " oauth_flow=";      out += oauth_client_kind_id(plan.oauth_client_kind);
+    out += " oauth_client=";    out += redacted_tail(in.oauth_client_id);
+    if (plan.oauth_client_kind == OAuthClientKind::Broker) {
+        out += " broker=";
+        out += plan.broker_host.empty() ? "(unknown)" : plan.broker_host;
+    }
+    out += " sdk_auth_mode=";   out += sdk_auth_mode_id(plan.sdk_auth_mode);
+    out += " public_app_key=";  out += redacted_tail(plan.resolved_public_app_key);
+    out += " zak=";             out += zak_plan_id(plan.zak_plan);
+    out += " token_type=";      out += in.token_type.empty() ? "auto_zak"
+                                                              : in.token_type;
+    out += " have_access_token=";  out += in.has_access_token ? "1" : "0";
+    out += " have_refresh_token="; out += in.has_refresh_token ? "1" : "0";
+    out += " token_expired=";      out += in.access_token_expired ? "1" : "0";
+    out += " sign_in_required=";   out += plan.needs_oauth_sign_in ? "1" : "0";
+    out += " blocking_error=";     out += join_error_id(plan.blocking_error);
+    return out;
+}
+
+} // namespace zoom_join

--- a/src/zoom-oauth.cpp
+++ b/src/zoom-oauth.cpp
@@ -1,4 +1,5 @@
 #include "zoom-oauth.h"
+#include "zoom-join-decision.h"
 #include "zoom-settings.h"
 
 #include <QCryptographicHash>
@@ -227,11 +228,13 @@ static QString oauth_error_message(const QByteArray &body,
         const QJsonObject obj = doc.object();
         const QString oauth_error = obj.value("error").toString();
         const QString reason = obj.value("reason").toString();
-        if (oauth_error == "invalid_client") {
-            return "Zoom rejected the OAuth client. The OAuth Client ID this "
-                   "build of CoreVideo was compiled with does not match an "
-                   "active Marketplace app, or the Marketplace app is not "
-                   "configured for Public Client OAuth (PKCE).";
+        // Centralized error catalog (issue #89): distinct guidance for wrong
+        // environment (invalid_client), expired token (invalid_grant), invalid
+        // redirect, and missing approval (invalid_scope).
+        const zoom_join::ZoomJoinError category =
+            zoom_join::classify_oauth_error(oauth_error.toStdString());
+        if (category != zoom_join::ZoomJoinError::Unknown) {
+            return QString::fromUtf8(zoom_join::join_error_guidance(category));
         }
         if (!reason.isEmpty())
             return reason;

--- a/tests/join-decision-test.cpp
+++ b/tests/join-decision-test.cpp
@@ -1,0 +1,259 @@
+// Unit test for the centralized Zoom join decision path (issue #89).
+// Verifies the decision state machine and the error catalog without touching
+// Qt, OBS, the Zoom SDK, or any real secret.
+#include "zoom-join-decision.h"
+
+#include <iostream>
+#include <set>
+#include <string>
+
+using namespace zoom_join;
+
+static int g_failures = 0;
+
+static void check(bool cond, const std::string &name)
+{
+    if (!cond) {
+        std::cerr << "FAIL: " << name << "\n";
+        ++g_failures;
+    }
+}
+
+// A production-shaped input: embedded Public Client ID, broker OAuth, public
+// app key Meeting SDK auth, no operator-supplied token, holding OAuth tokens.
+static JoinDecisionInputs production_inputs()
+{
+    JoinDecisionInputs in;
+    in.oauth_client_id = "aaaabbbbccccWXYZ";
+    in.oauth_authorization_url = "https://corevideo.iamfatness.us/oauth/start";
+    in.meeting_sdk_auth_mode = "public_app_key";
+    in.token_type = "auto_zak";
+    in.has_access_token = true;
+    in.has_refresh_token = true;
+    return in;
+}
+
+int main()
+{
+    // ── Production path: broker OAuth + public app key + fetch ZAK ───────────
+    {
+        JoinDecisionInputs in = production_inputs();
+        JoinDecisionPlan p = plan_join(in);
+        check(p.oauth_client_kind == OAuthClientKind::Broker, "prod: broker oauth");
+        check(p.broker_host == "corevideo.iamfatness.us", "prod: broker host");
+        check(p.sdk_auth_mode == SdkAuthMode::PublicAppKey, "prod: public app key");
+        check(p.public_app_key_mode, "prod: public app key mode flag");
+        check(p.resolved_public_app_key == in.oauth_client_id,
+              "prod: public app key resolves to oauth client id");
+        check(p.zak_plan == ZakPlan::FetchViaOAuth, "prod: fetch zak");
+        check(!p.needs_oauth_sign_in, "prod: no sign-in needed (has tokens)");
+        check(p.blocking_error == ZoomJoinError::None, "prod: no blocking error");
+    }
+
+    // ── Fresh install: no tokens yet -> must sign in ─────────────────────────
+    {
+        JoinDecisionInputs in = production_inputs();
+        in.has_access_token = false;
+        in.has_refresh_token = false;
+        JoinDecisionPlan p = plan_join(in);
+        check(p.needs_oauth_sign_in, "fresh: sign-in required");
+        check(p.blocking_error == ZoomJoinError::NeedsSignIn, "fresh: needs_sign_in error");
+    }
+
+    // ── Operator supplied a ZAK -> no OAuth ZAK fetch, no sign-in ────────────
+    {
+        JoinDecisionInputs in = production_inputs();
+        in.has_access_token = false;
+        in.has_refresh_token = false;
+        in.token_type = "user_zak";
+        in.has_typed_token = true;
+        JoinDecisionPlan p = plan_join(in);
+        check(p.zak_plan == ZakPlan::ProvidedByOperator, "typed zak: provided by operator");
+        check(!p.needs_oauth_sign_in, "typed zak: no sign-in needed");
+        check(p.blocking_error == ZoomJoinError::None, "typed zak: no blocking error");
+    }
+
+    // ── ZAK parsed from a join URL is also operator-provided ─────────────────
+    {
+        JoinDecisionInputs in = production_inputs();
+        in.has_access_token = false;
+        in.has_refresh_token = false;
+        in.has_parsed_zak = true;
+        JoinDecisionPlan p = plan_join(in);
+        check(p.zak_plan == ZakPlan::ProvidedByOperator, "parsed zak: provided by operator");
+        check(!p.needs_oauth_sign_in, "parsed zak: no sign-in needed");
+    }
+
+    // ── App-privilege token alone still needs a ZAK (matches dock) ───────────
+    {
+        JoinDecisionInputs in = production_inputs();
+        in.has_access_token = false;
+        in.has_refresh_token = false;
+        in.token_type = "app_privilege_token";
+        in.has_typed_token = true;
+        JoinDecisionPlan p = plan_join(in);
+        check(p.zak_plan == ZakPlan::FetchViaOAuth, "app-priv: still needs zak");
+        check(p.needs_oauth_sign_in, "app-priv: sign-in needed");
+    }
+
+    // ── No SDK identity and engine not authed -> missing credentials ─────────
+    {
+        JoinDecisionInputs in;
+        in.token_type = "auto_zak";
+        JoinDecisionPlan p = plan_join(in);
+        check(p.sdk_auth_mode == SdkAuthMode::None, "empty: no sdk auth mode");
+        check(p.blocking_error == ZoomJoinError::MissingCredentials,
+              "empty: missing credentials");
+        check(p.oauth_client_kind == OAuthClientKind::None, "empty: no oauth client");
+    }
+
+    // ── Dev self-signed JWT fallback (SDK key/secret pair, no public key) ────
+    {
+        JoinDecisionInputs in;
+        in.token_type = "auto_zak";
+        in.has_sdk_key_secret_pair = true;
+        in.oauth_client_id = "devClient1234";
+        in.oauth_authorization_url = "https://zoom.us/oauth/authorize";
+        in.has_access_token = true;
+        in.has_refresh_token = true;
+        JoinDecisionPlan p = plan_join(in);
+        check(p.sdk_auth_mode == SdkAuthMode::SelfSignedJwt, "dev: self-signed jwt");
+        check(p.oauth_client_kind == OAuthClientKind::PublicPkce, "dev: public pkce oauth");
+        check(!p.public_app_key_mode, "dev: not public app key mode");
+    }
+
+    // ── Dev broker JWT mode: public key present but mode=broker_jwt ──────────
+    {
+        JoinDecisionInputs in = production_inputs();
+        in.meeting_sdk_auth_mode = "broker_jwt";
+        in.sdk_public_app_key = "somePublicKeyABCD"; // resolves via sdk_public_app_key
+        JoinDecisionPlan p = plan_join(in);
+        check(p.sdk_auth_mode == SdkAuthMode::BrokerJwt, "broker-jwt: mode");
+        check(!p.public_app_key_mode, "broker-jwt: public key cleared for jwt");
+    }
+
+    // ── Engine already authenticated covers a missing SDK identity ───────────
+    {
+        JoinDecisionInputs in;
+        in.token_type = "auto_zak";
+        in.engine_already_authed = true;
+        in.has_access_token = true;
+        in.has_refresh_token = true;
+        JoinDecisionPlan p = plan_join(in);
+        check(p.blocking_error == ZoomJoinError::None,
+              "authed: no missing-credentials error when already authed");
+    }
+
+    // ── Expired token with no refresh token, needing a ZAK -> expired error ──
+    {
+        JoinDecisionInputs in = production_inputs();
+        in.has_access_token = true;
+        in.has_refresh_token = false;
+        in.access_token_expired = true;
+        JoinDecisionPlan p = plan_join(in);
+        check(p.blocking_error == ZoomJoinError::ExpiredToken, "expired: expired_token error");
+    }
+
+    // ── Broker URL detection ─────────────────────────────────────────────────
+    check(is_broker_authorization_url("https://corevideo.iamfatness.us/oauth/start"),
+          "broker url: https start");
+    check(is_broker_authorization_url("https://host/oauth/start?x=1"),
+          "broker url: start with query");
+    check(!is_broker_authorization_url("https://zoom.us/oauth/authorize"),
+          "broker url: authorize is not broker");
+    check(!is_broker_authorization_url("corevideo://oauth/callback"),
+          "broker url: custom scheme is not broker");
+    check(!is_broker_authorization_url(""), "broker url: empty");
+    check(url_host("https://corevideo.iamfatness.us/oauth/start") ==
+              "corevideo.iamfatness.us",
+          "url host extraction");
+
+    // ── Classifier: SDK auth result, public-app-key vs jwt interpretation ────
+    check(classify_sdk_auth_result("AUTHRET_JWTTOKENWRONG", true) ==
+              ZoomJoinError::WrongEnvironment,
+          "classify: jwt wrong in public mode -> wrong env");
+    check(classify_sdk_auth_result("AUTHRET_JWTTOKENWRONG", false) ==
+              ZoomJoinError::SdkAuthFailure,
+          "classify: jwt wrong in jwt mode -> sdk auth failure");
+    check(classify_sdk_auth_result("AUTHRET_ACCOUNTNOTENABLESDK", true) ==
+              ZoomJoinError::SdkEntitlement,
+          "classify: account not enabled -> entitlement");
+    check(classify_sdk_auth_result("AUTHRET_NETWORKISSUE", true) ==
+              ZoomJoinError::NetworkIssue,
+          "classify: network issue");
+    check(classify_sdk_auth_result("AUTHRET_SUCCESS", true) == ZoomJoinError::None,
+          "classify: success -> none");
+
+    // ── Classifier: meeting failure codes ────────────────────────────────────
+    check(classify_meeting_fail(63) == ZoomJoinError::MissingApproval,
+          "classify: 63 external meeting -> missing approval");
+    check(classify_meeting_fail(505) == ZoomJoinError::OnBehalfTokenInvalid,
+          "classify: 505 -> on-behalf invalid");
+    check(classify_meeting_fail(504) == ZoomJoinError::NeedsSignIn,
+          "classify: 504 anonymous -> needs sign in");
+    check(classify_meeting_fail(999) == ZoomJoinError::Unknown,
+          "classify: unknown meeting code");
+
+    // ── Classifier: OAuth token endpoint errors ──────────────────────────────
+    check(classify_oauth_error("invalid_client") == ZoomJoinError::WrongEnvironment,
+          "classify: invalid_client -> wrong env");
+    check(classify_oauth_error("invalid_grant") == ZoomJoinError::ExpiredToken,
+          "classify: invalid_grant -> expired");
+    check(classify_oauth_error("redirect_uri_mismatch") == ZoomJoinError::InvalidRedirect,
+          "classify: redirect mismatch -> invalid redirect");
+    check(classify_oauth_error("invalid_scope") == ZoomJoinError::MissingApproval,
+          "classify: invalid_scope -> missing approval");
+
+    // ── Every error category has DISTINCT, non-empty operator guidance ───────
+    {
+        const ZoomJoinError all[] = {
+            ZoomJoinError::MissingCredentials, ZoomJoinError::NeedsSignIn,
+            ZoomJoinError::WrongEnvironment,   ZoomJoinError::ExpiredToken,
+            ZoomJoinError::InvalidRedirect,    ZoomJoinError::MissingApproval,
+            ZoomJoinError::SdkAuthFailure,     ZoomJoinError::SdkEntitlement,
+            ZoomJoinError::NetworkIssue,       ZoomJoinError::OnBehalfTokenInvalid,
+            ZoomJoinError::Unknown,
+        };
+        std::set<std::string> messages;
+        std::set<std::string> ids;
+        for (ZoomJoinError e : all) {
+            const std::string msg = join_error_guidance(e);
+            const std::string id = join_error_id(e);
+            check(!msg.empty(), std::string("guidance non-empty: ") + id);
+            check(messages.insert(msg).second,
+                  std::string("guidance distinct: ") + id);
+            check(ids.insert(id).second, std::string("id distinct: ") + id);
+        }
+    }
+
+    // ── Log block: contains only redacted tails, never the full identity ─────
+    {
+        JoinDecisionInputs in = production_inputs();
+        JoinDecisionPlan p = plan_join(in);
+        const std::string block = format_join_decision_path(in, p);
+        check(block.rfind("[join-decision]", 0) == 0, "log: has tag prefix");
+        check(block.find("****WXYZ") != std::string::npos, "log: redacted tail present");
+        check(block.find(in.oauth_client_id) == std::string::npos,
+              "log: full client id NOT present");
+        check(block.find("sdk_auth_mode=public_app_key") != std::string::npos,
+              "log: sdk auth mode present");
+        check(block.find("oauth_flow=broker") != std::string::npos, "log: oauth flow present");
+        check(block.find("broker=corevideo.iamfatness.us") != std::string::npos,
+              "log: broker host present");
+        check(block.find("zak=fetch_via_oauth") != std::string::npos, "log: zak plan present");
+        check(block.find("blocking_error=none") != std::string::npos,
+              "log: blocking error present");
+    }
+
+    // ── Redaction helper edge cases ──────────────────────────────────────────
+    check(redacted_tail("") == "(empty)", "redact: empty");
+    check(redacted_tail("ab") == "****", "redact: short");
+    check(redacted_tail("abcdef") == "****cdef", "redact: normal");
+
+    if (g_failures == 0) {
+        std::cout << "join-decision-test: all checks passed\n";
+        return 0;
+    }
+    std::cerr << "join-decision-test: " << g_failures << " check(s) failed\n";
+    return 1;
+}


### PR DESCRIPTION
Closes #89

## Problem
Operators could sign in, but meeting **join** kept regressing between OAuth, ZAK, public app key, SDK auth, and broker paths because the auth-mode decision was scattered across `zoom-dock.cpp`, `zoom-oauth.cpp`, `zoom-settings.cpp`, and `zoom-engine-client.cpp`. This centralizes the decision into one auditable, unit-tested place and gives every failure a distinct operator message.

## The one enforced production path
- **Sign-in:** Public Client OAuth + PKCE via the HTTPS broker (`/oauth/start`). Direct public PKCE is a dev-only fallback.
- **Join:** the signed-in user's **ZAK**, fetched over OAuth (unless the operator supplied a ZAK / on-behalf token).
- **Meeting SDK auth:** the Marketplace Public Client ID as `AuthContext.publicAppKey`.
- No desktop client secret or user-credential fields in published builds. Self-signed JWT / broker-minted SDK JWT remain **loudly-logged** dev/staging fallbacks (owner values robustness + loud failures over deleting fallbacks).

## Design: `src/zoom-join-decision.h`
A pure header (no Qt/OBS/Zoom-SDK deps, no secrets) that is the single source of truth:
- `plan_join(JoinDecisionInputs) -> JoinDecisionPlan` — decides `SdkAuthMode` (PublicAppKey / SelfSignedJwt / BrokerJwt / None), `OAuthClientKind` (Broker / PublicPkce / None), `ZakPlan` (fetch-via-OAuth / provided-by-operator / not-needed), `needs_oauth_sign_in`, and a `blocking_error`. Mirrors the exact resolution order that `ZoomPluginSettings` + the dock used, so behavior is preserved.
- One **error-string catalog** (`ZoomJoinError` + `join_error_guidance()`) plus classifiers: `classify_sdk_auth_result(AUTHRET_* name, public_app_key_mode)`, `classify_meeting_fail(code)`, `classify_oauth_error(code)`.
- `format_join_decision_path()` — renders the single coherent log block with **redacted tails only**.

Callers now read from it:
- **zoom-dock** `on_join_clicked` builds the inputs, logs one `[join-decision]` block, and drives every branch from the plan.
- **zoom-engine-client** maps `auth_fail` through the catalog (keeps raw code/name for support bundles).
- **zoom-oauth** maps token-endpoint errors through the catalog.

## Log format (one coherent block, no secrets)
```
[obs-zoom-plugin] [join-decision] oauth_flow=broker oauth_client=****WXYZ \
  broker=corevideo.iamfatness.us sdk_auth_mode=public_app_key public_app_key=****WXYZ \
  zak=fetch_via_oauth token_type=auto_zak have_access_token=1 have_refresh_token=1 \
  token_expired=0 sign_in_required=0 blocking_error=none
```
A follow-up `[join-decision] resolved …` line logs the final auth mode + ZAK presence; the Meeting SDK result code arrives from the `ZoomObsEngine` child as `auth_ok`/`auth_fail` with the raw `AUTHRET_*` name.

## Error-message catalog (distinct operator guidance)
`wrong_environment`, `expired_token`, `invalid_redirect`, `missing_approval`, `sdk_auth_failure`, `sdk_entitlement`, `network_issue`, `on_behalf_token_invalid`, `needs_sign_in`, `missing_credentials` — each maps to distinct actionable text that surfaces through the existing dock status/error label and the support bundle. Full mapping table in `docs/ZOOM_MARKETPLACE_OAUTH.md`.

## Tests
`tests/join-decision-test.cpp` (ctest target `CoreVideoJoinDecision`) covers the decision matrix (fresh install, typed/parsed ZAK, app-privilege, dev fallbacks, expired token, engine-already-authed), all three classifiers, that every catalog message is non-empty and **distinct**, and that the log block never leaks a full identifier.

## Verification
- Full Release build on Windows / VS 2022 BuildTools (`-G "Visual Studio 17 2022" -A x64`): `obs-zoom-plugin.dll` and `ZoomObsEngine.exe` built clean.
- `ctest -C Release`: **10/10 pass**, including the new `CoreVideoJoinDecision`.
- **Not verifiable in this environment:** an actual live Zoom meeting join. I could not exercise real OAuth sign-in, ZAK fetch against Zoom, or a real Meeting SDK `SDKAuth` round-trip. Coverage is build + unit tests + code-path tracing only; the runtime auth-mode/ZAK/publicAppKey wiring is unchanged in behavior and simply sourced from the centralized planner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)