### PR TITLE
Add unit tests for control/OSC parsing and reconnect state machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,63 @@ if(BUILD_TESTING)
         add_test(NAME CoreVideoIpcLineIo
                  COMMAND CoreVideoIpcLineIoTest)
     endif()
+
+    # Reconnect back-off schedule and generation-guard state machine. Pure
+    # C++, no Qt/OBS/Zoom SDK dependency, so this builds and runs on every
+    # platform/job (including the Linux GCC portability job).
+    add_executable(CoreVideoReconnectBackoffTest
+        tests/zoom-reconnect-backoff-test.cpp
+    )
+    target_include_directories(CoreVideoReconnectBackoffTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoReconnectBackoff
+             COMMAND CoreVideoReconnectBackoffTest)
+
+    add_executable(CoreVideoReconnectScheduleTest
+        tests/zoom-reconnect-schedule-test.cpp
+    )
+    target_include_directories(CoreVideoReconnectScheduleTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoReconnectSchedule
+             COMMAND CoreVideoReconnectScheduleTest)
+
+    # OSC wire-format and TCP control-request parsing. These use QByteArray /
+    # QJsonObject / QString, so they only build where Qt6::Core is available
+    # (i.e. when COREVIDEO_BUILD_PLUGIN found it above). Guarded rather than
+    # required so the Linux portability job and any Qt-less configuration
+    # keep working unchanged.
+    if(TARGET Qt6::Core)
+        add_executable(CoreVideoOscWireTest
+            tests/zoom-osc-wire-test.cpp
+        )
+        target_include_directories(CoreVideoOscWireTest PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/src"
+        )
+        target_link_libraries(CoreVideoOscWireTest PRIVATE Qt6::Core)
+        add_test(NAME CoreVideoOscWire
+                 COMMAND CoreVideoOscWireTest)
+
+        add_executable(CoreVideoControlParseTest
+            tests/zoom-control-parse-test.cpp
+        )
+        target_include_directories(CoreVideoControlParseTest PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/src"
+        )
+        target_link_libraries(CoreVideoControlParseTest PRIVATE Qt6::Core)
+        add_test(NAME CoreVideoControlParse
+                 COMMAND CoreVideoControlParseTest)
+
+        if(WIN32 AND _qt_bin_dir)
+            set_tests_properties(CoreVideoOscWire PROPERTIES
+                ENVIRONMENT_MODIFICATION
+                    "PATH=path_list_prepend:${_qt_bin_dir}")
+            set_tests_properties(CoreVideoControlParse PROPERTIES
+                ENVIRONMENT_MODIFICATION
+                    "PATH=path_list_prepend:${_qt_bin_dir}")
+        endif()
+    endif()
 endif()
 
 set(CPACK_GENERATOR                 "ZIP")

--- a/src/zoom-control-parse.h
+++ b/src/zoom-control-parse.h
@@ -1,0 +1,155 @@
+#pragma once
+
+// Pure TCP control-server request parsing, factored out of
+// zoom-control-server.cpp so it can be unit tested on the host without OBS,
+// Qt networking, or the Zoom SDK. No behavior change from the original code
+// in ZoomControlServer::handle_line() -- this header is a verbatim move of
+// the JSON-parse / token-auth front end plus a handful of small pure
+// helpers, marked `inline` so it can be included from multiple translation
+// units (the plugin .cpp and the standalone test executable).
+
+#include "zoom-types.h"
+#include <QByteArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QString>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+// Timing-safe string equality — prevents token leakage via timing side-channel.
+// noinline prevents the compiler from inlining this and then optimising away
+// the constant-time loop when the result is observable from context.
+#if defined(_MSC_VER)
+__declspec(noinline)
+#else
+__attribute__((noinline))
+#endif
+inline bool ct_equal(const std::string &a, const std::string &b)
+{
+    volatile size_t diff = a.size() ^ b.size();
+    const size_t max_len = std::max(a.size(), b.size());
+    for (size_t i = 0; i < max_len; ++i) {
+        const uint8_t ca = i < a.size() ? static_cast<uint8_t>(a[i]) : 0;
+        const uint8_t cb = i < b.size() ? static_cast<uint8_t>(b[i]) : 0;
+        diff |= static_cast<size_t>(ca ^ cb);
+    }
+    return diff == 0;
+}
+
+// Extracts obj[key] as a uint32_t. Rejects non-numeric values, negative
+// values, non-finite values (NaN/Infinity), values above UINT32_MAX, and
+// non-integral values (e.g. 1.5).
+inline bool json_to_uint32(const QJsonObject &obj, const char *key, uint32_t &out)
+{
+    const QJsonValue value = obj.value(key);
+    if (!value.isDouble()) return false;
+
+    const double raw = value.toDouble(-1);
+    if (!std::isfinite(raw) || raw < 0 ||
+        raw > static_cast<double>(std::numeric_limits<uint32_t>::max()) ||
+        std::floor(raw) != raw) {
+        return false;
+    }
+
+    out = static_cast<uint32_t>(raw);
+    return true;
+}
+
+// Maps the "video_resolution" field of a JSON request to VideoResolution.
+// Unrecognized or missing values default to 720p.
+inline VideoResolution video_resolution_from_json(const QJsonObject &req)
+{
+    const QString value = req.value("video_resolution").toString("720p");
+    if (value == "360p" || value == "360") return VideoResolution::P360;
+    if (value == "1080p" || value == "1080") return VideoResolution::P1080;
+    return VideoResolution::P720;
+}
+
+inline QString meeting_state_to_string(MeetingState state)
+{
+    switch (state) {
+    case MeetingState::Idle:       return "idle";
+    case MeetingState::Joining:    return "joining";
+    case MeetingState::InMeeting:  return "in_meeting";
+    case MeetingState::Leaving:    return "leaving";
+    case MeetingState::Recovering: return "recovering";
+    case MeetingState::Failed:     return "failed";
+    }
+    return "unknown";
+}
+
+// The full set of commands dispatched by ZoomControlServer::handle_line().
+// Kept in sync manually with the "help" response and the if-chain in
+// handle_line(); used here only to give the "unknown command" acceptance
+// criterion something pure to test against.
+inline const std::array<const char *, 19> &known_control_commands()
+{
+    static const std::array<const char *, 19> kCommands = {
+        "help", "status", "list_participants", "list_outputs",
+        "assign_output", "assign_output_ex",
+        "recover_stale_outputs", "upgrade_low_quality_outputs",
+        "speaker_director_status", "speaker_director_configure",
+        "speaker_director_take", "speaker_director_release",
+        "join", "leave", "start_engine", "stop_engine",
+        "oauth_callback", "subscribe_events", "recovery_cancel",
+    };
+    return kCommands;
+}
+
+inline bool is_known_control_command(const QString &cmd)
+{
+    for (const char *known : known_control_commands()) {
+        if (cmd == QString::fromUtf8(known)) return true;
+    }
+    return false;
+}
+
+enum class ControlRequestError {
+    None,
+    InvalidJson,
+    Unauthorized,
+};
+
+struct ParsedControlRequest {
+    ControlRequestError error = ControlRequestError::None;
+    QJsonObject request; // valid only when error == None
+    QString cmd;         // "" when request has no "cmd" field
+};
+
+// Parses one control-server line into JSON and validates the auth token,
+// mirroring the front of ZoomControlServer::handle_line() before command
+// dispatch. `token` is the server's configured auth token; an empty token
+// means auth is disabled. "oauth_callback" is always exempt from the token
+// check (it is itself part of establishing auth).
+inline ParsedControlRequest parse_control_request(const QByteArray &line,
+                                                   const std::string &token)
+{
+    ParsedControlRequest result;
+
+    QJsonParseError parse_error;
+    const QJsonDocument doc = QJsonDocument::fromJson(line, &parse_error);
+    if (parse_error.error != QJsonParseError::NoError || !doc.isObject()) {
+        result.error = ControlRequestError::InvalidJson;
+        return result;
+    }
+
+    result.request = doc.object();
+    result.cmd = result.request.value("cmd").toString();
+
+    if (!token.empty() && result.cmd != "oauth_callback") {
+        const std::string provided =
+            result.request.value("token").toString().toStdString();
+        if (!ct_equal(provided, token)) {
+            result.error = ControlRequestError::Unauthorized;
+            return result;
+        }
+    }
+
+    return result;
+}

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -1,6 +1,7 @@
 #include "zoom-control-server.h"
 #include "obs-utils.h"
 #include "speaker-director.h"
+#include "zoom-control-parse.h"
 #include "zoom-engine-client.h"
 #include "zoom-iso-recorder.h"
 #include "zoom-oauth.h"
@@ -22,45 +23,11 @@
 #include <limits>
 #include <vector>
 
-// Timing-safe string equality — prevents token leakage via timing side-channel.
-// noinline prevents the compiler from inlining this and then optimising away
-// the constant-time loop when the result is observable from context.
-#if defined(_MSC_VER)
-__declspec(noinline)
-#else
-__attribute__((noinline))
-#endif
-static bool ct_equal(const std::string &a, const std::string &b)
-{
-    volatile size_t diff = a.size() ^ b.size();
-    const size_t max_len = std::max(a.size(), b.size());
-    for (size_t i = 0; i < max_len; ++i) {
-        const uint8_t ca = i < a.size() ? static_cast<uint8_t>(a[i]) : 0;
-        const uint8_t cb = i < b.size() ? static_cast<uint8_t>(b[i]) : 0;
-        diff |= static_cast<size_t>(ca ^ cb);
-    }
-    return diff == 0;
-}
-
-static bool json_to_uint32(const QJsonObject &obj, const char *key, uint32_t &out)
-{
-    const QJsonValue value = obj.value(key);
-    if (!value.isDouble()) return false;
-
-    const double raw = value.toDouble(-1);
-    if (!std::isfinite(raw) || raw < 0 ||
-        raw > static_cast<double>(std::numeric_limits<uint32_t>::max()) ||
-        std::floor(raw) != raw) {
-        return false;
-    }
-
-    out = static_cast<uint32_t>(raw);
-    return true;
-}
+// ct_equal, json_to_uint32, video_resolution_from_json and
+// meeting_state_to_string now live in zoom-control-parse.h so they can be
+// unit tested on the host without OBS/Qt-network/Zoom-SDK dependencies.
 
 static QJsonObject speaker_director_to_json();
-
-static QString meeting_state_to_string(MeetingState state);
 
 ZoomControlServer &ZoomControlServer::instance()
 {
@@ -406,64 +373,27 @@ static QJsonObject speaker_director_to_json()
     return obj;
 }
 
-static VideoResolution video_resolution_from_json(const QJsonObject &req)
-{
-    const QString value = req.value("video_resolution").toString("720p");
-    if (value == "360p" || value == "360") return VideoResolution::P360;
-    if (value == "1080p" || value == "1080") return VideoResolution::P1080;
-    return VideoResolution::P720;
-}
-
-static QString meeting_state_to_string(MeetingState state)
-{
-    switch (state) {
-    case MeetingState::Idle:       return "idle";
-    case MeetingState::Joining:    return "joining";
-    case MeetingState::InMeeting:  return "in_meeting";
-    case MeetingState::Leaving:    return "leaving";
-    case MeetingState::Recovering: return "recovering";
-    case MeetingState::Failed:     return "failed";
-    }
-    return "unknown";
-}
-
 void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
 {
-    QJsonParseError parse_error;
-    const QJsonDocument doc = QJsonDocument::fromJson(line, &parse_error);
-    if (parse_error.error != QJsonParseError::NoError || !doc.isObject()) {
+    const ParsedControlRequest parsed = parse_control_request(line, m_token);
+    if (parsed.error == ControlRequestError::InvalidJson) {
         write_response(socket, {
             {"ok", false},
             {"error", "invalid_json"}
         });
         return;
     }
-
-    const QJsonObject req = doc.object();
-
-    const QString cmd = req.value("cmd").toString();
-
-    if (!m_token.empty() && cmd != "oauth_callback") {
-        const std::string provided = req.value("token").toString().toStdString();
-        if (!ct_equal(provided, m_token)) {
-            write_response(socket, {{"ok", false}, {"error", "unauthorized"}});
-            return;
-        }
+    if (parsed.error == ControlRequestError::Unauthorized) {
+        write_response(socket, {{"ok", false}, {"error", "unauthorized"}});
+        return;
     }
+
+    const QJsonObject &req = parsed.request;
+    const QString &cmd = parsed.cmd;
 
     if (cmd == "help") {
         QJsonArray commands;
-        for (const char *c : {"help", "status", "list_participants", "list_outputs",
-                              "assign_output", "assign_output_ex",
-                              "recover_stale_outputs",
-                              "upgrade_low_quality_outputs",
-                              "speaker_director_status",
-                              "speaker_director_configure",
-                              "speaker_director_take",
-                              "speaker_director_release",
-                              "join", "leave", "start_engine", "stop_engine",
-                              "oauth_callback",
-                              "subscribe_events", "recovery_cancel"})
+        for (const char *c : known_control_commands())
             commands.append(c);
         write_response(socket, {{"ok", true}, {"commands", commands}});
         return;

--- a/src/zoom-osc-server.cpp
+++ b/src/zoom-osc-server.cpp
@@ -16,112 +16,23 @@
 #include <cstring>
 
 // ── OSC wire-format helpers ──────────────────────────────────────────────────
-
-// Round up to the next multiple of 4.
-static int pad4(int n) { return (n + 3) & ~3; }
-
-// Read a null-terminated, 4-byte-padded OSC string from buf[offset].
-// Returns "" and leaves offset unchanged on error.
-static std::string read_osc_string(const QByteArray &buf, int &offset)
-{
-    const int start = offset;
-    const int len   = buf.size();
-    while (offset < len && buf[offset] != '\0') ++offset;
-    if (offset >= len) { offset = start; return {}; }
-    const std::string s(buf.constData() + start, offset - start);
-    ++offset; // consume NUL
-    offset = pad4(offset);
-    return s;
-}
-
-// Read a big-endian int32 from buf[offset].
-static int32_t read_int32(const QByteArray &buf, int &offset)
-{
-    if (offset + 4 > buf.size()) return 0;
-    const auto *p = reinterpret_cast<const uint8_t *>(buf.constData() + offset);
-    offset += 4;
-    return static_cast<int32_t>((uint32_t(p[0]) << 24) | (uint32_t(p[1]) << 16) |
-                                 (uint32_t(p[2]) << 8)  |  uint32_t(p[3]));
-}
-
-// Read a big-endian float32 from buf[offset].
-static float read_float32(const QByteArray &buf, int &offset)
-{
-    const int32_t raw = read_int32(buf, offset);
-    float f; std::memcpy(&f, &raw, 4);
-    return f;
-}
-
-// Encode a big-endian int32.
-static void write_int32(QByteArray &out, int32_t v)
-{
-    out.append(static_cast<char>((v >> 24) & 0xFF));
-    out.append(static_cast<char>((v >> 16) & 0xFF));
-    out.append(static_cast<char>((v >>  8) & 0xFF));
-    out.append(static_cast<char>( v        & 0xFF));
-}
-
-// Encode an OSC string (null-terminated, padded to 4 bytes).
-static void write_osc_string(QByteArray &out, const std::string &s)
-{
-    out.append(s.c_str(), static_cast<int>(s.size()) + 1);
-    while (out.size() % 4 != 0) out.append('\0');
-}
-
-// Parse a raw OSC message datagram into address + args.
-// Returns false if the packet is malformed.
-static bool parse_osc(const QByteArray &data,
-                      QString &address,
+//
+// The actual encode/decode primitives (osc_read_string, osc_read_int32,
+// osc_parse_message, osc_build_message, etc.) live in zoom-osc-wire.h so they
+// can be exercised by a standalone host-side unit test without OBS, the Zoom
+// SDK, or a live UDP socket. Local aliases below keep the rest of this file
+// unchanged.
+static bool parse_osc(const QByteArray &data, QString &address,
                       std::vector<OscArg> &args)
 {
-    int offset = 0;
-    const std::string addr_str = read_osc_string(data, offset);
-    if (addr_str.empty() || addr_str[0] != '/') return false;
-    address = QString::fromStdString(addr_str);
-
-    if (offset >= data.size() || data[offset] != ',') return true; // no type tag — valid
-    const std::string type_tags = read_osc_string(data, offset);
-
-    for (size_t i = 1; i < type_tags.size(); ++i) {
-        OscArg arg;
-        switch (type_tags[i]) {
-        case 'i':
-            arg.type = OscArg::Int32;
-            arg.i    = read_int32(data, offset);
-            break;
-        case 'f':
-            arg.type = OscArg::Float32;
-            arg.f    = read_float32(data, offset);
-            break;
-        case 's':
-            arg.type = OscArg::String;
-            arg.s    = read_osc_string(data, offset);
-            break;
-        case 'T': arg.type = OscArg::Int32; arg.i = 1; break;
-        case 'F': arg.type = OscArg::Int32; arg.i = 0; break;
-        default:  return false; // unsupported type
-        }
-        args.push_back(std::move(arg));
-    }
-    return true;
+    return osc_parse_message(data, address, args);
 }
 
-// Build a complete single-message OSC packet (address + type tags + args).
 static QByteArray build_osc(const std::string &address,
                              const std::string &type_tags,
                              const std::vector<OscArg> &args)
 {
-    QByteArray pkt;
-    write_osc_string(pkt, address);
-    write_osc_string(pkt, "," + type_tags);
-    for (size_t i = 0; i < args.size(); ++i) {
-        switch (type_tags[i]) {
-        case 'i': write_int32(pkt, args[i].i); break;
-        case 's': write_osc_string(pkt, args[i].s); break;
-        default: break;
-        }
-    }
-    return pkt;
+    return osc_build_message(address, type_tags, args);
 }
 
 static bool find_output_by_source(const std::string &source, ZoomOutputInfo &out);

--- a/src/zoom-osc-server.h
+++ b/src/zoom-osc-server.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "zoom-osc-wire.h"
 #include "zoom-types.h"
 #include <QDateTime>
 #include <QHostAddress>
@@ -12,13 +13,8 @@
 
 class QUdpSocket;
 
-// Lightweight OSC argument — supports int32, float32, and string types.
-struct OscArg {
-    enum Type { Int32, Float32, String } type;
-    int32_t     i = 0;
-    float       f = 0.f;
-    std::string s;
-};
+// OscArg is defined in zoom-osc-wire.h (shared with the standalone OSC
+// wire-format unit tests).
 
 class ZoomOscServer : public QObject {
 public:

--- a/src/zoom-osc-wire.h
+++ b/src/zoom-osc-wire.h
@@ -1,0 +1,143 @@
+#pragma once
+
+// Pure OSC (Open Sound Control) wire-format encode/decode helpers, factored
+// out of zoom-osc-server.cpp so they can be unit tested on the host without
+// OBS, the Zoom SDK, or a live UDP socket. No behavior change from the
+// original static functions in zoom-osc-server.cpp — this header is a
+// verbatim move, marked `inline` so it can be included from multiple
+// translation units (the plugin .cpp and the standalone test executable).
+
+#include <QByteArray>
+#include <QString>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// Lightweight OSC argument — supports int32, float32, and string types.
+struct OscArg {
+    enum Type { Int32, Float32, String } type;
+    int32_t     i = 0;
+    float       f = 0.f;
+    std::string s;
+};
+
+// Round up to the next multiple of 4.
+inline int osc_pad4(int n)
+{
+    return (n + 3) & ~3;
+}
+
+// Read a null-terminated, 4-byte-padded OSC string from buf[offset].
+// Returns "" and leaves offset unchanged on error (no NUL found before the
+// end of the buffer).
+inline std::string osc_read_string(const QByteArray &buf, int &offset)
+{
+    const int start = offset;
+    const int len   = buf.size();
+    while (offset < len && buf[offset] != '\0') ++offset;
+    if (offset >= len) { offset = start; return {}; }
+    const std::string s(buf.constData() + start, offset - start);
+    ++offset; // consume NUL
+    offset = osc_pad4(offset);
+    return s;
+}
+
+// Read a big-endian int32 from buf[offset]. Returns 0 and leaves offset
+// unchanged if fewer than 4 bytes remain (truncated buffer).
+inline int32_t osc_read_int32(const QByteArray &buf, int &offset)
+{
+    if (offset + 4 > buf.size()) return 0;
+    const auto *p = reinterpret_cast<const uint8_t *>(buf.constData() + offset);
+    offset += 4;
+    return static_cast<int32_t>((uint32_t(p[0]) << 24) | (uint32_t(p[1]) << 16) |
+                                 (uint32_t(p[2]) << 8)  |  uint32_t(p[3]));
+}
+
+// Read a big-endian float32 from buf[offset]. Same truncation behavior as
+// osc_read_int32 (returns 0.0f, offset unchanged) since it is implemented
+// in terms of it.
+inline float osc_read_float32(const QByteArray &buf, int &offset)
+{
+    const int32_t raw = osc_read_int32(buf, offset);
+    float f;
+    std::memcpy(&f, &raw, 4);
+    return f;
+}
+
+// Encode a big-endian int32.
+inline void osc_write_int32(QByteArray &out, int32_t v)
+{
+    out.append(static_cast<char>((v >> 24) & 0xFF));
+    out.append(static_cast<char>((v >> 16) & 0xFF));
+    out.append(static_cast<char>((v >>  8) & 0xFF));
+    out.append(static_cast<char>( v        & 0xFF));
+}
+
+// Encode an OSC string (null-terminated, padded to 4 bytes).
+inline void osc_write_string(QByteArray &out, const std::string &s)
+{
+    out.append(s.c_str(), static_cast<int>(s.size()) + 1);
+    while (out.size() % 4 != 0) out.append('\0');
+}
+
+// Parse a raw OSC message datagram into address + args.
+// Returns false if the packet is malformed: no address, address does not
+// start with '/', or an unsupported type tag is encountered. Note that a
+// truncated numeric/string argument does NOT make this return false --
+// the reader helpers above silently yield 0 / "" for a truncated value.
+// This mirrors the original zoom-osc-server.cpp behavior exactly (a
+// deliberate choice preserved here, not a bug being introduced).
+inline bool osc_parse_message(const QByteArray &data,
+                               QString &address,
+                               std::vector<OscArg> &args)
+{
+    int offset = 0;
+    const std::string addr_str = osc_read_string(data, offset);
+    if (addr_str.empty() || addr_str[0] != '/') return false;
+    address = QString::fromStdString(addr_str);
+
+    if (offset >= data.size() || data[offset] != ',') return true; // no type tag — valid
+    const std::string type_tags = osc_read_string(data, offset);
+
+    for (size_t i = 1; i < type_tags.size(); ++i) {
+        OscArg arg;
+        switch (type_tags[i]) {
+        case 'i':
+            arg.type = OscArg::Int32;
+            arg.i    = osc_read_int32(data, offset);
+            break;
+        case 'f':
+            arg.type = OscArg::Float32;
+            arg.f    = osc_read_float32(data, offset);
+            break;
+        case 's':
+            arg.type = OscArg::String;
+            arg.s    = osc_read_string(data, offset);
+            break;
+        case 'T': arg.type = OscArg::Int32; arg.i = 1; break;
+        case 'F': arg.type = OscArg::Int32; arg.i = 0; break;
+        default:  return false; // unsupported type
+        }
+        args.push_back(std::move(arg));
+    }
+    return true;
+}
+
+// Build a complete single-message OSC packet (address + type tags + args).
+inline QByteArray osc_build_message(const std::string &address,
+                                     const std::string &type_tags,
+                                     const std::vector<OscArg> &args)
+{
+    QByteArray pkt;
+    osc_write_string(pkt, address);
+    osc_write_string(pkt, "," + type_tags);
+    for (size_t i = 0; i < args.size(); ++i) {
+        switch (type_tags[i]) {
+        case 'i': osc_write_int32(pkt, args[i].i); break;
+        case 's': osc_write_string(pkt, args[i].s); break;
+        default: break;
+        }
+    }
+    return pkt;
+}

--- a/src/zoom-reconnect-backoff.h
+++ b/src/zoom-reconnect-backoff.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// Pure exponential-backoff-with-jitter math, factored out of
+// ZoomReconnectManager::compute_delay_locked() so it can be unit tested on
+// the host without OBS/Qt/Zoom-SDK dependencies or real randomness. No
+// behavior change: this is the same formula, same clamp-then-jitter-then-
+// clamp order, that compute_delay_locked() used inline before this
+// refactor.
+
+#include <algorithm>
+#include <cmath>
+
+// jitter_factor is expected to already be drawn from the caller's RNG (the
+// production code uses std::uniform_real_distribution<double>(0.8, 1.2));
+// this function only applies it and clamps. Passing jitter_factor == 1.0
+// gives the unjittered schedule, which is what most tests want to assert.
+inline double compute_backoff_delay_ms(int attempt,
+                                        double base_delay_ms,
+                                        double backoff_multiplier,
+                                        double max_delay_ms,
+                                        double jitter_factor)
+{
+    double delay = base_delay_ms * std::pow(backoff_multiplier, attempt);
+    delay = std::min(delay, max_delay_ms);
+    // Apply randomized jitter in [0.8, 1.2] so simultaneous recoveries do not
+    // thunder against the broker/SDK at the same instant. The cap is applied
+    // before jitter; clamp again afterwards so the result never exceeds it.
+    delay *= jitter_factor;
+    delay = std::min(delay, max_delay_ms);
+    return delay;
+}

--- a/src/zoom-reconnect-schedule.h
+++ b/src/zoom-reconnect-schedule.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+
+// Pure generation/pending bookkeeping for ZoomReconnectManager's retry
+// scheduler, factored out for host-side unit testing without OBS/Qt/
+// Zoom-SDK dependencies. NOT thread-safe by itself: ZoomReconnectManager
+// only ever touches an instance of this class while holding its own m_mtx,
+// exactly as it did the raw m_pending/m_generation fields before this
+// refactor -- this class only centralizes the *rules*, not the locking.
+//
+// Contract (mirrors the original in-class fields byte-for-byte):
+//  - schedule() marks a retry pending and bumps the generation, so any
+//    earlier wake-up (or a previously queued execute_retry hand-off)
+//    recognizes itself as stale via is_current().
+//  - consume_pending() clears the pending flag WITHOUT bumping the
+//    generation -- this is what the timer thread does right before handing
+//    the fire-generation off to execute_retry() on the OBS UI thread, so
+//    is_current() still recognizes that hand-off as valid.
+//  - reset() clears pending and bumps the generation -- used on
+//    cancel/give-up/success so any in-flight wake-up or already-queued
+//    execute_retry() call becomes stale and no-ops.
+class ZoomReconnectSchedule {
+public:
+    uint64_t schedule()
+    {
+        ++m_generation;
+        m_pending = true;
+        return m_generation;
+    }
+
+    void consume_pending() { m_pending = false; }
+
+    uint64_t reset()
+    {
+        m_pending = false;
+        ++m_generation;
+        return m_generation;
+    }
+
+    bool pending() const { return m_pending; }
+    uint64_t generation() const { return m_generation; }
+    bool is_current(uint64_t generation) const { return m_generation == generation; }
+
+private:
+    bool     m_pending    = false;
+    uint64_t m_generation = 0;
+};

--- a/src/zoom-reconnect.cpp
+++ b/src/zoom-reconnect.cpp
@@ -2,6 +2,7 @@
 #include "zoom-engine-client.h"
 #include "zoom-oauth.h"
 #include "zoom-output-manager.h"
+#include "zoom-reconnect-backoff.h"
 #include "zoom-settings.h"
 #include <obs-module.h>
 #include <algorithm>
@@ -26,8 +27,7 @@ ZoomReconnectManager::~ZoomReconnectManager()
     {
         std::lock_guard<std::mutex> lk(m_mtx);
         m_stop_thread = true;
-        m_pending     = false;
-        ++m_generation;
+        m_schedule.reset();
     }
     m_cv.notify_all();
     if (m_timer.joinable()) m_timer.join();
@@ -86,15 +86,15 @@ void ZoomReconnectManager::clear_session()
 
 int ZoomReconnectManager::compute_delay_locked(int attempt) const
 {
-    double delay = m_policy.base_delay_ms *
-                   std::pow(static_cast<double>(m_policy.backoff_multiplier), attempt);
-    delay = std::min(delay, static_cast<double>(m_policy.max_delay_ms));
-    // Apply randomized jitter in [0.8, 1.2] so simultaneous recoveries do not
-    // thunder against the broker/SDK at the same instant. The cap is applied
-    // before jitter; clamp again afterwards so the result never exceeds it.
+    // Randomized jitter in [0.8, 1.2] so simultaneous recoveries do not
+    // thunder against the broker/SDK at the same instant. See
+    // zoom-reconnect-backoff.h for the (unit-tested) clamp-then-jitter-then-
+    // clamp formula.
     std::uniform_real_distribution<double> jitter(0.8, 1.2);
-    delay *= jitter(m_rng);
-    delay = std::min(delay, static_cast<double>(m_policy.max_delay_ms));
+    const double delay = compute_backoff_delay_ms(
+        attempt, m_policy.base_delay_ms,
+        static_cast<double>(m_policy.backoff_multiplier),
+        m_policy.max_delay_ms, jitter(m_rng));
     return static_cast<int>(delay);
 }
 
@@ -103,15 +103,14 @@ int ZoomReconnectManager::next_retry_ms() const
     if (!m_recovering.load(std::memory_order_acquire)) return 0;
     using namespace std::chrono;
     std::lock_guard<std::mutex> lk(m_mtx);
-    if (!m_pending) return 0;
+    if (!m_schedule.pending()) return 0;
     auto remaining = duration_cast<milliseconds>(m_retry_at - steady_clock::now());
     return std::max(0, static_cast<int>(remaining.count()));
 }
 
 void ZoomReconnectManager::reset_state_locked()
 {
-    m_pending = false;
-    ++m_generation;
+    m_schedule.reset();
     m_recovering.store(false, std::memory_order_release);
     m_attempt.store(0, std::memory_order_release);
 }
@@ -195,7 +194,7 @@ void ZoomReconnectManager::cancel()
 {
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        if (!m_recovering.load(std::memory_order_acquire) && !m_pending) return;
+        if (!m_recovering.load(std::memory_order_acquire) && !m_schedule.pending()) return;
         reset_state_locked();
     }
     m_cv.notify_all();
@@ -229,7 +228,7 @@ void ZoomReconnectManager::on_join_failed(bool permanent)
     }
 
     std::unique_lock<std::mutex> lk(m_mtx);
-    if (!m_recovering.load(std::memory_order_acquire) && !m_pending) {
+    if (!m_recovering.load(std::memory_order_acquire) && !m_schedule.pending()) {
         blog(LOG_INFO,
              "[obs-zoom-plugin] Join failed outside recovery - not retrying");
         reset_state_locked();
@@ -265,8 +264,7 @@ void ZoomReconnectManager::schedule_retry_locked(int delay_ms)
     // Must be called with m_mtx held. Bumps generation so any previously
     // scheduled wake-up that races to fire will see the new generation and
     // ignore itself.
-    ++m_generation;
-    m_pending  = true;
+    m_schedule.schedule();
     m_retry_at = std::chrono::steady_clock::now() +
                  std::chrono::milliseconds(delay_ms);
     m_cv.notify_all();
@@ -276,16 +274,16 @@ void ZoomReconnectManager::timer_loop()
 {
     std::unique_lock<std::mutex> lk(m_mtx);
     while (!m_stop_thread) {
-        if (!m_pending) {
-            m_cv.wait(lk, [this]() { return m_stop_thread || m_pending; });
+        if (!m_schedule.pending()) {
+            m_cv.wait(lk, [this]() { return m_stop_thread || m_schedule.pending(); });
             continue;
         }
 
-        const uint64_t gen      = m_generation;
+        const uint64_t gen      = m_schedule.generation();
         const auto      deadline = m_retry_at;
         // Sleep until deadline, but wake early if state changes.
         const bool interrupted = m_cv.wait_until(lk, deadline, [this, gen]() {
-            return m_stop_thread || !m_pending || m_generation != gen;
+            return m_stop_thread || !m_schedule.pending() || m_schedule.generation() != gen;
         });
 
         if (interrupted) {
@@ -295,8 +293,8 @@ void ZoomReconnectManager::timer_loop()
         if (std::chrono::steady_clock::now() < m_retry_at) continue; // spurious wake
 
         // Consume the pending request before scheduling on UI thread.
-        m_pending = false;
-        const uint64_t fire_gen = m_generation;
+        m_schedule.consume_pending();
+        const uint64_t fire_gen = m_schedule.generation();
         lk.unlock();
 
         // We pass the generation through to execute_retry so it can verify
@@ -322,7 +320,7 @@ void ZoomReconnectManager::execute_retry(uint64_t generation)
     ZoomJoinAuthTokens tokens;
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        if (m_generation != generation) return;     // cancelled or superseded
+        if (!m_schedule.is_current(generation)) return; // cancelled or superseded
         if (!m_recovering.load(std::memory_order_acquire)) return;
         jwt          = m_jwt;
         meeting_id   = m_meeting_id;

--- a/src/zoom-reconnect.h
+++ b/src/zoom-reconnect.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "zoom-reconnect-schedule.h"
 #include "zoom-types.h"
 #include <atomic>
 #include <chrono>
@@ -92,9 +93,10 @@ private:
     // Timer thread state (guarded by m_mtx unless otherwise noted)
     std::thread                 m_timer;
     std::condition_variable     m_cv;
-    bool                        m_pending     = false;  // a retry is scheduled
     bool                        m_stop_thread = false;  // shut the timer thread down
-    // Generation: every call to schedule_retry_locked or cancel bumps this.
+    // Pending-retry / generation-guard bookkeeping. Every call to
+    // schedule_retry_locked or reset_state_locked bumps the generation;
     // execute_retry compares against the latest value and bails on mismatch.
-    uint64_t                    m_generation  = 0;
+    // See zoom-reconnect-schedule.h for the (unit-tested) rules.
+    ZoomReconnectSchedule       m_schedule;
 };

--- a/tests/zoom-control-parse-test.cpp
+++ b/tests/zoom-control-parse-test.cpp
@@ -1,0 +1,256 @@
+#include "zoom-control-parse.h"
+
+#include <iostream>
+#include <limits>
+
+static int g_failures = 0;
+
+static void expect(const char *name, bool cond)
+{
+    if (!cond) {
+        std::cerr << name << ": failed\n";
+        ++g_failures;
+    }
+}
+
+// ── ct_equal ─────────────────────────────────────────────────────────────
+
+static void test_ct_equal()
+{
+    expect("ct_equal: identical strings", ct_equal("secret-token", "secret-token"));
+    expect("ct_equal: both empty", ct_equal("", ""));
+    expect("ct_equal: different content same length", !ct_equal("aaaaaaaa", "aaaaaaab"));
+    expect("ct_equal: different lengths", !ct_equal("short", "much-longer-token"));
+    expect("ct_equal: empty vs non-empty", !ct_equal("", "token"));
+    expect("ct_equal: case sensitive", !ct_equal("Token", "token"));
+    expect("ct_equal: one-char difference at the end",
+           !ct_equal("abcdefgh", "abcdefgi"));
+}
+
+// ── json_to_uint32 ───────────────────────────────────────────────────────
+
+static void test_json_to_uint32()
+{
+    uint32_t out = 0;
+
+    {
+        QJsonObject obj{{"n", 42}};
+        expect("json_to_uint32: valid integer", json_to_uint32(obj, "n", out));
+        expect("json_to_uint32: valid integer value", out == 42);
+    }
+    {
+        QJsonObject obj{{"n", 0}};
+        expect("json_to_uint32: zero is valid", json_to_uint32(obj, "n", out));
+        expect("json_to_uint32: zero value", out == 0);
+    }
+    {
+        QJsonObject obj{{"n", -1}};
+        expect("json_to_uint32: negative is rejected", !json_to_uint32(obj, "n", out));
+    }
+    {
+        QJsonObject obj{{"n", 1.5}};
+        expect("json_to_uint32: fractional is rejected", !json_to_uint32(obj, "n", out));
+    }
+    {
+        QJsonObject obj{{"n", "42"}};
+        expect("json_to_uint32: string value is rejected", !json_to_uint32(obj, "n", out));
+    }
+    {
+        QJsonObject obj;
+        expect("json_to_uint32: missing key is rejected", !json_to_uint32(obj, "n", out));
+    }
+    {
+        const double too_big =
+            static_cast<double>(std::numeric_limits<uint32_t>::max()) + 1024.0;
+        QJsonObject obj{{"n", too_big}};
+        expect("json_to_uint32: above uint32 max is rejected",
+               !json_to_uint32(obj, "n", out));
+    }
+    {
+        QJsonObject obj{{"n", static_cast<double>(std::numeric_limits<uint32_t>::max())}};
+        expect("json_to_uint32: exactly uint32 max is accepted",
+               json_to_uint32(obj, "n", out));
+        expect("json_to_uint32: uint32 max value",
+               out == std::numeric_limits<uint32_t>::max());
+    }
+    {
+        QJsonObject obj{{"n", QJsonValue(QJsonValue::Null)}};
+        expect("json_to_uint32: null value is rejected", !json_to_uint32(obj, "n", out));
+    }
+}
+
+// ── video_resolution_from_json ──────────────────────────────────────────
+
+static void test_video_resolution_from_json()
+{
+    expect("video_resolution: missing defaults to 720p",
+           video_resolution_from_json(QJsonObject{}) == VideoResolution::P720);
+    expect("video_resolution: '360p'",
+           video_resolution_from_json(QJsonObject{{"video_resolution", "360p"}}) ==
+               VideoResolution::P360);
+    expect("video_resolution: '360'",
+           video_resolution_from_json(QJsonObject{{"video_resolution", "360"}}) ==
+               VideoResolution::P360);
+    expect("video_resolution: '1080p'",
+           video_resolution_from_json(QJsonObject{{"video_resolution", "1080p"}}) ==
+               VideoResolution::P1080);
+    expect("video_resolution: '1080'",
+           video_resolution_from_json(QJsonObject{{"video_resolution", "1080"}}) ==
+               VideoResolution::P1080);
+    expect("video_resolution: '720p' explicit",
+           video_resolution_from_json(QJsonObject{{"video_resolution", "720p"}}) ==
+               VideoResolution::P720);
+    expect("video_resolution: unrecognized value defaults to 720p",
+           video_resolution_from_json(QJsonObject{{"video_resolution", "bogus"}}) ==
+               VideoResolution::P720);
+}
+
+// ── meeting_state_to_string ──────────────────────────────────────────────
+
+static void test_meeting_state_to_string()
+{
+    expect("meeting_state: idle", meeting_state_to_string(MeetingState::Idle) == "idle");
+    expect("meeting_state: joining",
+           meeting_state_to_string(MeetingState::Joining) == "joining");
+    expect("meeting_state: in_meeting",
+           meeting_state_to_string(MeetingState::InMeeting) == "in_meeting");
+    expect("meeting_state: leaving",
+           meeting_state_to_string(MeetingState::Leaving) == "leaving");
+    expect("meeting_state: recovering",
+           meeting_state_to_string(MeetingState::Recovering) == "recovering");
+    expect("meeting_state: failed", meeting_state_to_string(MeetingState::Failed) == "failed");
+    expect("meeting_state: out-of-range value falls back to unknown",
+           meeting_state_to_string(static_cast<MeetingState>(99)) == "unknown");
+}
+
+// ── known_control_commands / is_known_control_command ────────────────────
+
+static void test_known_commands()
+{
+    expect("known commands: help", is_known_control_command("help"));
+    expect("known commands: status", is_known_control_command("status"));
+    expect("known commands: join", is_known_control_command("join"));
+    expect("known commands: oauth_callback", is_known_control_command("oauth_callback"));
+    expect("known commands: recovery_cancel", is_known_control_command("recovery_cancel"));
+    expect("unknown command is rejected", !is_known_control_command("totally_bogus_cmd"));
+    expect("empty command is rejected", !is_known_control_command(""));
+    expect("known commands are case sensitive", !is_known_control_command("HELP"));
+    expect("known command list has no duplicates and no gaps",
+           known_control_commands().size() == 19);
+}
+
+// ── parse_control_request: JSON validity + auth ──────────────────────────
+
+static void test_parse_control_request()
+{
+    // Valid JSON, no token configured: always authorized.
+    {
+        const auto r = parse_control_request(R"({"cmd":"status"})", "");
+        expect("valid json, no token: no error", r.error == ControlRequestError::None);
+        expect("valid json, no token: cmd extracted", r.cmd == "status");
+    }
+
+    // Invalid JSON syntax.
+    {
+        const auto r = parse_control_request(R"({"cmd":)", "");
+        expect("malformed json is rejected", r.error == ControlRequestError::InvalidJson);
+    }
+
+    // Empty line.
+    {
+        const auto r = parse_control_request(QByteArray(""), "");
+        expect("empty line is rejected", r.error == ControlRequestError::InvalidJson);
+    }
+
+    // Valid JSON but not an object (array).
+    {
+        const auto r = parse_control_request(R"(["status"])", "");
+        expect("json array (not object) is rejected",
+               r.error == ControlRequestError::InvalidJson);
+    }
+
+    // Valid JSON but not an object (bare number).
+    {
+        const auto r = parse_control_request(R"(42)", "");
+        expect("bare json number is rejected", r.error == ControlRequestError::InvalidJson);
+    }
+
+    // Object with trailing garbage is still malformed per strict JSON.
+    {
+        const auto r = parse_control_request(R"({"cmd":"status"} trailing)", "");
+        expect("trailing garbage after object is rejected",
+               r.error == ControlRequestError::InvalidJson);
+    }
+
+    // Token configured, correct token supplied.
+    {
+        const auto r = parse_control_request(
+            R"({"cmd":"status","token":"s3cret"})", "s3cret");
+        expect("correct token is authorized", r.error == ControlRequestError::None);
+    }
+
+    // Token configured, wrong token supplied.
+    {
+        const auto r = parse_control_request(
+            R"({"cmd":"status","token":"wrong"})", "s3cret");
+        expect("wrong token is unauthorized", r.error == ControlRequestError::Unauthorized);
+    }
+
+    // Token configured, token field missing entirely.
+    {
+        const auto r = parse_control_request(R"({"cmd":"status"})", "s3cret");
+        expect("missing token field is unauthorized",
+               r.error == ControlRequestError::Unauthorized);
+    }
+
+    // Token configured, but request is oauth_callback: bypasses auth even
+    // with a wrong/missing token, mirroring handle_line()'s special case.
+    {
+        const auto r = parse_control_request(
+            R"({"cmd":"oauth_callback","url":"https://example.test"})", "s3cret");
+        expect("oauth_callback bypasses token check", r.error == ControlRequestError::None);
+        expect("oauth_callback cmd is preserved", r.cmd == "oauth_callback");
+    }
+    {
+        const auto r = parse_control_request(
+            R"({"cmd":"oauth_callback","token":"wrong"})", "s3cret");
+        expect("oauth_callback bypasses token check even with a wrong token",
+               r.error == ControlRequestError::None);
+    }
+
+    // No token configured: even a garbage "token" field is ignored.
+    {
+        const auto r = parse_control_request(
+            R"({"cmd":"status","token":"anything"})", "");
+        expect("no server token configured: request always authorized",
+               r.error == ControlRequestError::None);
+    }
+
+    // Missing "cmd" field: parses fine, cmd is empty (dispatch would treat
+    // this as an unknown command).
+    {
+        const auto r = parse_control_request(R"({"foo":"bar"})", "");
+        expect("missing cmd field still parses", r.error == ControlRequestError::None);
+        expect("missing cmd field yields empty cmd", r.cmd.isEmpty());
+    }
+
+    // Boundary: token equal length, differs only in the last byte.
+    {
+        const auto r = parse_control_request(
+            R"({"cmd":"status","token":"s3cretX"})", "s3crety");
+        expect("same-length differing token is unauthorized",
+               r.error == ControlRequestError::Unauthorized);
+    }
+}
+
+int main()
+{
+    test_ct_equal();
+    test_json_to_uint32();
+    test_video_resolution_from_json();
+    test_meeting_state_to_string();
+    test_known_commands();
+    test_parse_control_request();
+
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/zoom-osc-wire-test.cpp
+++ b/tests/zoom-osc-wire-test.cpp
@@ -1,0 +1,205 @@
+#include "zoom-osc-wire.h"
+
+#include <cstring>
+#include <iostream>
+
+static int g_failures = 0;
+
+static void expect(const char *name, bool cond)
+{
+    if (!cond) {
+        std::cerr << name << ": failed\n";
+        ++g_failures;
+    }
+}
+
+// Build a raw OSC message buffer by hand (independent of osc_build_message)
+// so the parser tests aren't just round-tripping against themselves.
+static QByteArray raw_osc_string(const std::string &s)
+{
+    QByteArray out;
+    out.append(s.c_str(), static_cast<int>(s.size()) + 1);
+    while (out.size() % 4 != 0) out.append('\0');
+    return out;
+}
+
+int main()
+{
+    // pad4 boundary values.
+    expect("pad4(0) == 0", osc_pad4(0) == 0);
+    expect("pad4(1) == 4", osc_pad4(1) == 4);
+    expect("pad4(3) == 4", osc_pad4(3) == 4);
+    expect("pad4(4) == 4", osc_pad4(4) == 4);
+    expect("pad4(5) == 8", osc_pad4(5) == 8);
+
+    // ── Address matching / no-type-tag messages ─────────────────────────
+    {
+        QByteArray buf = raw_osc_string("/zoom/ping");
+        QString address;
+        std::vector<OscArg> args;
+        expect("address-only message parses", osc_parse_message(buf, address, args));
+        expect("address matches", address == "/zoom/ping");
+        expect("no args for address-only message", args.empty());
+    }
+
+    // Explicit empty type-tag string (",") is valid and yields no args.
+    {
+        QByteArray buf = raw_osc_string("/zoom/ping") + raw_osc_string(",");
+        QString address;
+        std::vector<OscArg> args;
+        expect("empty type-tag message parses", osc_parse_message(buf, address, args));
+        expect("empty type-tag message has no args", args.empty());
+    }
+
+    // ── Type tags i / f / s / T / F ──────────────────────────────────────
+    // Hand-built rather than via osc_build_message(): that helper's write
+    // switch only serializes 'i' and 's' payloads (which matches every
+    // build_osc() call site actually used in zoom-osc-server.cpp today --
+    // no production message sends a float or boolean tag), so it is not a
+    // valid oracle for 'f'/'T'/'F' wire bytes. This test constructs the
+    // datagram directly with the same primitives, matching exactly what a
+    // real OSC client would put on the wire.
+    {
+        QByteArray pkt;
+        osc_write_string(pkt, "/zoom/test");
+        osc_write_string(pkt, ",ifsTF");
+        osc_write_int32(pkt, 42); // i
+        float fval = 3.5f;
+        int32_t fraw;
+        std::memcpy(&fraw, &fval, 4);
+        osc_write_int32(pkt, fraw); // f (big-endian bit pattern)
+        osc_write_string(pkt, "hello"); // s
+        // T and F carry no payload bytes on the wire.
+
+        QString address;
+        std::vector<OscArg> out;
+        expect("full type-tag message parses", osc_parse_message(pkt, address, out));
+        expect("address round-trips", address == "/zoom/test");
+        if (out.size() == 5) {
+            expect("int32 round-trips", out[0].type == OscArg::Int32 && out[0].i == 42);
+            expect("float32 round-trips", out[1].type == OscArg::Float32 && out[1].f == 3.5f);
+            expect("string round-trips", out[2].type == OscArg::String && out[2].s == "hello");
+            expect("T tag decodes to int 1", out[3].type == OscArg::Int32 && out[3].i == 1);
+            expect("F tag decodes to int 0", out[4].type == OscArg::Int32 && out[4].i == 0);
+        } else {
+            expect("expected 5 args", false);
+        }
+    }
+
+    // Negative int32 round-trips through the two's-complement encoding.
+    {
+        std::vector<OscArg> in(1);
+        in[0].type = OscArg::Int32;
+        in[0].i = -12345;
+        const QByteArray pkt = osc_build_message("/zoom/negative", "i", in);
+        QString address;
+        std::vector<OscArg> out;
+        expect("negative int32 message parses", osc_parse_message(pkt, address, out));
+        expect("negative int32 round-trips", out.size() == 1 && out[0].i == -12345);
+    }
+
+    // ── Malformed packets ────────────────────────────────────────────────
+
+    // Empty buffer: no address at all.
+    {
+        QByteArray buf;
+        QString address;
+        std::vector<OscArg> args;
+        expect("empty buffer is rejected", !osc_parse_message(buf, address, args));
+    }
+
+    // Address missing the leading '/'.
+    {
+        QByteArray buf = raw_osc_string("zoom/ping");
+        QString address;
+        std::vector<OscArg> args;
+        expect("address without leading slash is rejected",
+               !osc_parse_message(buf, address, args));
+    }
+
+    // Address with no NUL terminator before the end of the buffer
+    // (truncated mid-address).
+    {
+        QByteArray buf = "/zoom/pi"; // no NUL, no padding
+        QString address;
+        std::vector<OscArg> args;
+        expect("truncated address (no NUL) is rejected",
+               !osc_parse_message(buf, address, args));
+    }
+
+    // ── Unsupported type tags ────────────────────────────────────────────
+    {
+        // 'd' (double) is not a supported tag in this implementation.
+        std::vector<OscArg> in(1);
+        in[0].type = OscArg::Int32;
+        in[0].i = 7;
+        // Hand-build so the unsupported tag doesn't trip up osc_build_message
+        // (which only knows how to encode 'i' and 's').
+        QByteArray pkt = raw_osc_string("/zoom/bad") + raw_osc_string(",id");
+        osc_write_int32(pkt, 7); // value for the 'i' tag; nothing follows for 'd'
+
+        QString address;
+        std::vector<OscArg> args;
+        expect("unsupported type tag is rejected cleanly",
+               !osc_parse_message(pkt, address, args));
+        // The 'i' arg preceding the unsupported tag is still parsed before
+        // the parser bails -- callers (dispatch()) discard args on failure,
+        // but pinning this documents the exact current behavior.
+        expect("args parsed before the bad tag are preserved",
+               args.size() == 1 && args[0].i == 7);
+    }
+
+    // ── Truncated buffers (numeric args silently read as 0, not rejected) ──
+    {
+        // Type tag says one int32 arg follows, but the buffer ends right
+        // after the type-tag string. osc_read_int32() returns 0 without
+        // advancing the offset or failing the parse -- this mirrors the
+        // original zoom-osc-server.cpp behavior exactly.
+        QByteArray pkt = raw_osc_string("/zoom/trunc") + raw_osc_string(",i");
+        QString address;
+        std::vector<OscArg> args;
+        expect("truncated int32 arg does not fail the parse",
+               osc_parse_message(pkt, address, args));
+        expect("truncated int32 arg reads as 0",
+               args.size() == 1 && args[0].type == OscArg::Int32 && args[0].i == 0);
+    }
+    {
+        // Same for float32 (implemented in terms of osc_read_int32).
+        QByteArray pkt = raw_osc_string("/zoom/trunc") + raw_osc_string(",f");
+        QString address;
+        std::vector<OscArg> args;
+        expect("truncated float32 arg does not fail the parse",
+               osc_parse_message(pkt, address, args));
+        expect("truncated float32 arg reads as 0",
+               args.size() == 1 && args[0].type == OscArg::Float32 && args[0].f == 0.0f);
+    }
+    {
+        // A type-tag string itself can be truncated (comma present but no
+        // NUL before the end of the buffer). osc_read_string() then returns
+        // "" and leaves the offset unchanged, so the tag loop (which starts
+        // at index 1) never runs -- the message is treated as valid with
+        // zero args. This is existing, slightly surprising behavior that
+        // this test pins rather than "fixes".
+        QByteArray pkt = raw_osc_string("/zoom/trunc") + QByteArray(",ii", 3);
+        QString address;
+        std::vector<OscArg> args;
+        expect("truncated type-tag string does not fail the parse",
+               osc_parse_message(pkt, address, args));
+        expect("truncated type-tag string yields no args", args.empty());
+    }
+
+    // Truncated string arg (no NUL before end of buffer): read_osc_string
+    // returns "" for that arg; since it's the only tag, the message is
+    // still reported as parsed.
+    {
+        QByteArray pkt = raw_osc_string("/zoom/trunc") + raw_osc_string(",s") + QByteArray("abc");
+        QString address;
+        std::vector<OscArg> args;
+        expect("truncated string arg does not fail the parse",
+               osc_parse_message(pkt, address, args));
+        expect("truncated string arg reads as empty",
+               args.size() == 1 && args[0].type == OscArg::String && args[0].s.empty());
+    }
+
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/zoom-reconnect-backoff-test.cpp
+++ b/tests/zoom-reconnect-backoff-test.cpp
@@ -1,0 +1,63 @@
+#include "zoom-reconnect-backoff.h"
+
+#include <cmath>
+#include <iostream>
+
+static int g_failures = 0;
+
+static void expect_near(const char *name, double actual, double expected, double tol = 1e-6)
+{
+    if (std::fabs(actual - expected) > tol) {
+        std::cerr << name << ": expected " << expected << ", got " << actual << "\n";
+        ++g_failures;
+    }
+}
+
+int main()
+{
+    // Unjittered exponential growth: base=2000, multiplier=2.0, max=30000.
+    expect_near("attempt 0, no jitter",
+                compute_backoff_delay_ms(0, 2000, 2.0, 30000, 1.0), 2000);
+    expect_near("attempt 1, no jitter",
+                compute_backoff_delay_ms(1, 2000, 2.0, 30000, 1.0), 4000);
+    expect_near("attempt 2, no jitter",
+                compute_backoff_delay_ms(2, 2000, 2.0, 30000, 1.0), 8000);
+    expect_near("attempt 3, no jitter",
+                compute_backoff_delay_ms(3, 2000, 2.0, 30000, 1.0), 16000);
+
+    // attempt 4 would be 32000 pre-clamp; clamps to max_delay_ms.
+    expect_near("attempt 4 clamps to max",
+                compute_backoff_delay_ms(4, 2000, 2.0, 30000, 1.0), 30000);
+    expect_near("attempt 10 stays clamped",
+                compute_backoff_delay_ms(10, 2000, 2.0, 30000, 1.0), 30000);
+
+    // Jitter is applied multiplicatively after the pre-jitter clamp.
+    expect_near("attempt 0 with 0.8x jitter",
+                compute_backoff_delay_ms(0, 2000, 2.0, 30000, 0.8), 1600);
+    expect_near("attempt 0 with 1.2x jitter",
+                compute_backoff_delay_ms(0, 2000, 2.0, 30000, 1.2), 2400);
+
+    // Jitter must not push the delay above max_delay_ms even though the
+    // pre-jitter value (16000) was already under the cap: 16000 * 1.2 =
+    // 19200, still under 30000, so this just checks the multiply is right...
+    expect_near("attempt 3 with 1.2x jitter",
+                compute_backoff_delay_ms(3, 2000, 2.0, 30000, 1.2), 19200);
+
+    // ...whereas an attempt whose pre-jitter delay is already at the cap
+    // must stay at the cap even after a >1.0 jitter factor (the second
+    // clamp in compute_backoff_delay_ms is load-bearing here).
+    expect_near("attempt 4 with 1.2x jitter still clamps",
+                compute_backoff_delay_ms(4, 2000, 2.0, 30000, 1.2), 30000);
+
+    // Boundary: attempt 0 with base_delay_ms already above max_delay_ms
+    // clamps immediately, before jitter is even applied.
+    expect_near("base delay above cap clamps pre-jitter",
+                compute_backoff_delay_ms(0, 50000, 2.0, 30000, 1.0), 30000);
+
+    // Different policy shape (smaller multiplier, matches a "gentler"
+    // backoff policy) still follows the same formula.
+    expect_near("multiplier 1.5, attempt 2",
+                compute_backoff_delay_ms(2, 1000, 1.5, 60000, 1.0), 2250);
+
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/zoom-reconnect-schedule-test.cpp
+++ b/tests/zoom-reconnect-schedule-test.cpp
@@ -1,0 +1,103 @@
+#include "zoom-reconnect-schedule.h"
+
+#include <iostream>
+
+static int g_failures = 0;
+
+static void expect(const char *name, bool cond)
+{
+    if (!cond) {
+        std::cerr << name << ": failed\n";
+        ++g_failures;
+    }
+}
+
+int main()
+{
+    // Initial state: nothing pending, generation 0.
+    {
+        ZoomReconnectSchedule s;
+        expect("initial not pending", !s.pending());
+        expect("initial generation is 0", s.generation() == 0);
+        expect("initial generation 0 is current", s.is_current(0));
+        expect("generation 1 is not yet current", !s.is_current(1));
+    }
+
+    // schedule() sets pending and bumps generation.
+    {
+        ZoomReconnectSchedule s;
+        const uint64_t gen = s.schedule();
+        expect("schedule sets pending", s.pending());
+        expect("schedule bumps generation to 1", s.generation() == 1);
+        expect("schedule returns the new generation", gen == 1);
+        expect("new generation is current", s.is_current(gen));
+        expect("stale generation 0 is not current", !s.is_current(0));
+    }
+
+    // consume_pending() clears pending but does NOT bump generation --
+    // this is the hand-off from the timer thread to execute_retry(): the
+    // fire-generation captured right after consume_pending() must still
+    // read as current.
+    {
+        ZoomReconnectSchedule s;
+        const uint64_t gen = s.schedule();
+        s.consume_pending();
+        expect("consume_pending clears pending", !s.pending());
+        expect("consume_pending does not bump generation", s.generation() == gen);
+        expect("fire generation still current after consume", s.is_current(gen));
+    }
+
+    // reset() (cancel / give-up / success) clears pending state.
+    {
+        ZoomReconnectSchedule s;
+        s.schedule();
+        const uint64_t reset_gen = s.reset();
+        expect("reset clears pending", !s.pending());
+        expect("reset bumps generation again", reset_gen == 2);
+        expect("reset generation is current", s.is_current(reset_gen));
+    }
+
+    // Generation-guard: a fire-generation captured before a cancel/reset
+    // must be recognized as stale afterwards (this is what makes
+    // execute_retry() a no-op after cancel() races with the timer firing).
+    {
+        ZoomReconnectSchedule s;
+        const uint64_t fire_gen = s.schedule();
+        s.consume_pending(); // timer thread hands off to execute_retry
+        expect("fire generation current before cancel", s.is_current(fire_gen));
+
+        s.reset(); // cancel() races in before execute_retry() runs
+        expect("fire generation stale after cancel", !s.is_current(fire_gen));
+        expect("cancel leaves nothing pending", !s.pending());
+    }
+
+    // Generation-guard: rescheduling (a fresh trigger()/on_join_failed()
+    // call) also invalidates any earlier fire-generation, so a slow wake-up
+    // for the old schedule cannot fire a retry that was superseded by a new
+    // one.
+    {
+        ZoomReconnectSchedule s;
+        const uint64_t first_gen = s.schedule();
+        const uint64_t second_gen = s.schedule(); // reschedule before first fires
+        expect("reschedule bumps generation again", second_gen == first_gen + 1);
+        expect("old fire generation is stale", !s.is_current(first_gen));
+        expect("new generation is current", s.is_current(second_gen));
+        expect("still pending after reschedule", s.pending());
+    }
+
+    // Multiple cancel-then-reschedule cycles keep generations monotonically
+    // increasing and never let a stale generation number come back around.
+    {
+        ZoomReconnectSchedule s;
+        uint64_t last_gen = 0;
+        for (int i = 0; i < 5; ++i) {
+            const uint64_t gen = s.schedule();
+            expect("generation strictly increases", gen > last_gen);
+            last_gen = gen;
+            s.reset();
+            expect("reset always clears pending", !s.pending());
+        }
+    }
+
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Partially addresses #109. IPC framing/write-path tests are intentionally **not** included here — that surface (`engine-ipc.h`) is owned by an in-flight IPC-hardening PR, and duplicating work there would conflict.

This PR covers the other three modules called out in #109:

- **`src/zoom-control-server.cpp`** — TCP JSON command parsing
- **`src/zoom-osc-server.cpp`** — OSC message parsing
- **`src/zoom-reconnect.cpp`** — exponential backoff + generation-guard state machine

Since all three are entangled with Qt/OBS/Zoom-SDK singletons, each gets a **minimal, behavior-preserving extraction** of its pure parsing/state logic into a small header, following the existing `tests/output-health-test.cpp` pattern (plain C++, no framework, registered via `add_test`). The `.cpp` files now delegate to the header functions instead of defining them inline — no logic changes, verified by a full local build against the real OBS/Qt6/Zoom SDK toolchain (see Verification below).

### Refactors (all mechanical moves, no behavior change)

- `src/zoom-control-parse.h` — `parse_control_request()` (JSON validity + timing-safe token auth, mirroring the front of `handle_line()`), `json_to_uint32`, `video_resolution_from_json`, `meeting_state_to_string`, and a `known_control_commands()` whitelist now shared by the `help` response and the new "unknown command" test.
- `src/zoom-osc-wire.h` — `OscArg` plus the OSC encode/decode primitives (`osc_parse_message`, `osc_build_message`, `osc_read_string`, `osc_read_int32`, `osc_read_float32`, `osc_write_int32`, `osc_write_string`, `osc_pad4`). `zoom-osc-server.cpp` keeps thin `parse_osc`/`build_osc` wrapper aliases so the rest of the file is untouched.
- `src/zoom-reconnect-backoff.h` — `compute_backoff_delay_ms()`, the clamp→jitter→clamp formula previously inlined in `compute_delay_locked()`.
- `src/zoom-reconnect-schedule.h` — `ZoomReconnectSchedule`, the pending-flag/generation-counter bookkeeping previously stored as raw fields on `ZoomReconnectManager`. Still only ever touched under `m_mtx`, exactly as before — this class centralizes the *rules*, not the locking.

### Test inventory (new `add_test()` targets)

| Test | Covers |
|---|---|
| `CoreVideoControlParse` | valid/invalid/non-object JSON, empty line, trailing garbage, correct/wrong/missing token, `oauth_callback` token bypass, no-server-token passthrough, missing `cmd`, `json_to_uint32` boundary cases (negative, fractional, string, `>UINT32_MAX`, exact max, null), `video_resolution_from_json` mapping, `meeting_state_to_string` incl. out-of-range fallback, known/unknown command whitelist, `ct_equal` correctness |
| `CoreVideoOscWire` | address-only messages, empty type-tag string, all of `i`/`f`/`s`/`T`/`F`, negative int32 round-trip, empty buffer, address missing `/`, truncated address, unsupported type tag (rejects cleanly, documents partial-args state), truncated int32/float32/string args (pins the existing "silently reads as 0/empty, doesn't fail" behavior), truncated type-tag string |
| `CoreVideoReconnectBackoff` | exponential growth across attempts, cap at `max_delay_ms`, jitter multiply-then-clamp (including the case where jitter would push an already-capped delay over the cap), base delay already above cap, alternate policy shape |
| `CoreVideoReconnectSchedule` | `schedule()` bumps generation + sets pending, `consume_pending()` clears pending without bumping generation (the timer→UI-thread hand-off), `reset()` (cancel/give-up/success) clears pending and invalidates any in-flight generation, reschedule invalidates the prior fire-generation, generations stay monotonic across repeated cancel/reschedule cycles |

All four are pure C++ (no OBS/Qt/Zoom SDK needed) except `CoreVideoControlParse` and `CoreVideoOscWire`, which need `Qt6::Core` for `QJsonObject`/`QByteArray`/`QString`. Those two are gated behind `if(TARGET Qt6::Core)` in `CMakeLists.txt` so the Qt-less Linux portability job and any Qt-less configuration keep working unchanged; the reconnect tests build and run everywhere, including that Linux job.

### CI ctest gap

The issue's other ask was making CI actually invoke `ctest`. That's already done — PR #116 wired `ctest --test-dir build -C Release --output-on-failure` into the Windows/macOS/Linux jobs (after build, before packaging). No change needed there; confirmed by inspecting `.github/workflows/build.yml` and by running the full test suite through the same command locally.

## Verification

Built and tested locally on Windows against the real toolchain (VS 2022 BuildTools, OBS libobs/frontend-api, Qt 6.7.3, Zoom SDK 7.0.2.34512, FFmpeg), full plugin + engine + sidecar build, no new warnings on the touched files:

```
ctest --test-dir build -C Release --output-on-failure
...
100% tests passed, 0 tests failed out of 13
Total Test time (real) =   0.25 sec
```

All 13 tests pass, including the 4 new ones plus the 9 pre-existing ones (output-health, speaker-director, join-input, and the 5 sidecar tests).

## Test plan

- [x] `cmake --build build --config Release --parallel` succeeds (plugin, engine, sidecar, all tests)
- [x] `ctest --test-dir build -C Release --output-on-failure` — 13/13 pass
- [x] Forced rebuild of the three touched `.cpp` files — no new compiler warnings
- [x] Manual diff review confirming each extraction is a verbatim move (no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)