### PR TITLE
macOS port — phase 1: real plugin + engine build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,7 +264,10 @@ jobs:
     name: macOS arm64 (plugin + engine scaffold)
     runs-on: macos-14
     permissions:
-      contents: read   # needed for gh api to read the draft SDK release asset
+      # DRAFT releases are only visible to a token with write-level (push)
+      # access; contents: read cannot enumerate them, so the SDK asset lookup
+      # would silently find nothing and the engine would fall back to OFF.
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,13 +249,22 @@ jobs:
           path: build/
           if-no-files-found: ignore
 
-  # macOS
+  # macOS (arm64) - real plugin bundle + engine scaffold
   build-macos:
-    # Host-arch compile validation only - see "Configure" step below for why
-    # plugin/engine stay OFF, and "Package as ZIP" for why this is not a
-    # "universal" build and not a shippable macOS package.
-    name: macOS Compile Validation (host arch)
+    # Builds the ACTUAL obs-zoom-plugin bundle (COREVIDEO_BUILD_PLUGIN=ON) plus
+    # the macOS ZoomObsEngine scaffold linked against the real ZoomSDK.framework
+    # (COREVIDEO_BUILD_ENGINE=ON when the SDK is fetched). This is arm64-only
+    # (host arch on the macos-14 runner) by design - NOT a universal binary and
+    # NOT a signed/notarized shippable package yet (see PR for remaining work).
+    #
+    # The engine is a SCAFFOLD: the macOS Zoom Meeting SDK is Objective-C only,
+    # so the shared C++ engine sources cannot compile here. The scaffold links
+    # the framework (validating fetch + link) and fails loudly at runtime on any
+    # meeting request. See engine/src/main-macos.mm.
+    name: macOS arm64 (plugin + engine scaffold)
     runs-on: macos-14
+    permissions:
+      contents: read   # needed for gh api to read the draft SDK release asset
     steps:
       - uses: actions/checkout@v6
         with:
@@ -306,36 +315,66 @@ jobs:
           echo "=== obs-frontend-apiConfig.cmake ==="
           cat /tmp/obs-sdk/cmake/obs-frontend-api/obs-frontend-apiConfig.cmake
 
-      - name: Download Zoom macOS SDK
+      # The macOS Zoom Meeting SDK is stored as a private draft-release asset.
+      # Draft releases are invisible to the public but visible to the workflow's
+      # own GITHUB_TOKEN; the asset bytes are downloadable via the asset API with
+      # `Accept: application/octet-stream`. `gh api` handles the S3 redirect and
+      # strips the Authorization header on the redirect hop for us. Never commit
+      # the SDK; never publish this draft release.
+      - name: Download Zoom macOS SDK (private draft-release asset)
+        id: zoom_sdk
         env:
-          ZOOM_SDK_DOWNLOAD_URL: ${{ secrets.ZOOM_SDK_MACOS_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "$ZOOM_SDK_DOWNLOAD_URL" ]; then
-              curl -L "$ZOOM_SDK_DOWNLOAD_URL" -o zoom-sdk.zip
-              unzip zoom-sdk.zip -d third_party/zoom-sdk-extracted
-              mv "third_party/zoom-sdk-extracted/$(ls third_party/zoom-sdk-extracted | head -1)" \
-                 third_party/zoom-sdk
+          set -euo pipefail
+          asset_name="zoom-sdk-macos-7.1.5.84750.zip"
+          asset_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
+              --jq ".[] | select(.draft) | .assets[] | select(.name==\"${asset_name}\") | .id" \
+              | head -1)"
+          if [ -z "${asset_id}" ]; then
+              echo "::warning::${asset_name} not found on any draft release; building plugin only (engine OFF)."
+              echo "has_zoom_sdk=false" >> "$GITHUB_OUTPUT"
+              exit 0
           fi
+          echo "Fetching ${asset_name} (asset id ${asset_id})"
+          gh api -H "Accept: application/octet-stream" \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > zoom-sdk.zip
+          echo "Downloaded $(du -h zoom-sdk.zip | cut -f1)"
+          mkdir -p third_party/zoom-sdk-extracted
+          unzip -q zoom-sdk.zip -d third_party/zoom-sdk-extracted
+          # Archive layout: <root>/ZoomSDK/ZoomSDK.framework + sibling frameworks.
+          sdk_root="$(find third_party/zoom-sdk-extracted -maxdepth 3 -type d -name ZoomSDK \
+              -exec test -d '{}/ZoomSDK.framework' ';' -print | head -1)"
+          if [ -z "${sdk_root}" ]; then
+              echo "::error::Could not locate ZoomSDK/ZoomSDK.framework in the SDK archive."
+              find third_party/zoom-sdk-extracted -maxdepth 3 -type d | head -40
+              exit 1
+          fi
+          rm -rf third_party/zoom-sdk
+          mv "${sdk_root}" third_party/zoom-sdk
+          rm -rf third_party/zoom-sdk-extracted zoom-sdk.zip
+          echo "ZoomSDK.framework present:"
+          ls -la third_party/zoom-sdk/ZoomSDK.framework | head
+          echo "has_zoom_sdk=true" >> "$GITHUB_OUTPUT"
 
       - name: Configure
-        # Plugin/engine stay OFF in CI. The engine links the Zoom SDK
-        # (ZoomSDK.framework), which is not available without the secret SDK
-        # download, so it genuinely cannot be built here. The plugin itself
-        # does not require the Zoom SDK and links OBS symbols lazily
-        # (-undefined dynamic_lookup), but enabling it would add a Qt6 AUTOMOC
-        # build of the full Qt UI that is not exercised by any packaged macOS
-        # artifact today; turning it on only to discard it would add CI time
-        # and a new failure surface without shipping anything. Left OFF
-        # deliberately; revisit if a macOS plugin artifact is ever released.
+        # COREVIDEO_BUILD_PLUGIN=ON builds the real obs-zoom-plugin bundle + the
+        # macOS OAuth callback helper. The plugin links OBS symbols lazily
+        # (-undefined dynamic_lookup), so only OBS headers + Qt6 are needed at
+        # build time. COREVIDEO_BUILD_ENGINE is ON only when the Zoom SDK was
+        # fetched above (otherwise there is no framework to link the engine
+        # scaffold against).
         run: |
           QT_PREFIX="$(brew --prefix qt@6)"
           HOST_ARCH="$(uname -m)"
+          BUILD_ENGINE="${{ steps.zoom_sdk.outputs.has_zoom_sdk == 'true' && 'ON' || 'OFF' }}"
+          echo "Building engine scaffold: ${BUILD_ENGINE}"
           cmake -B build \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_OSX_ARCHITECTURES="$HOST_ARCH" \
               -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
-              -DCOREVIDEO_BUILD_PLUGIN=OFF \
-              -DCOREVIDEO_BUILD_ENGINE=OFF \
+              -DCOREVIDEO_BUILD_PLUGIN=ON \
+              -DCOREVIDEO_BUILD_ENGINE="$BUILD_ENGINE" \
               -DZOOM_SDK_DIR=third_party/zoom-sdk \
               "-DCMAKE_PREFIX_PATH=/tmp/obs-sdk;$QT_PREFIX" \
               "-DLibObs_DIR=/tmp/obs-sdk/cmake/LibObs" \
@@ -354,26 +393,22 @@ jobs:
         run: ctest --test-dir build --output-on-failure
 
       - name: Package as ZIP
-        # NOTE: this is a compile-validation artifact, not a product build.
-        # COREVIDEO_BUILD_PLUGIN and COREVIDEO_BUILD_ENGINE are OFF above, so
-        # `install` contains no obs-zoom-plugin, no ZoomObsEngine, and no
-        # OAuth callback helper - just whatever no-op install rules the
-        # top-level CMakeLists.txt runs with both targets disabled. It is
-        # NOT a "macOS universal" build (CMAKE_OSX_ARCHITECTURES is pinned to
-        # the single runner host-arch, not "arm64;x86_64"), and it is not
-        # uploaded to GitHub Releases (see the release job below). The name
-        # says "tools-unsupported" so nobody mistakes it for an installable
-        # macOS package.
+        # Compile/link-validation artifact for the macOS port. It contains the
+        # real plugin bundle, OAuth helper, and (when built) the engine
+        # SCAFFOLD - which is NOT a functional Zoom engine (see
+        # engine/src/main-macos.mm). arm64-only; unsigned/un-notarized; not a
+        # universal binary; NOT attached to GitHub Releases. The name marks it
+        # "unsigned-arm64" so nobody mistakes it for an installable package.
         run: |
           cmake --install build --prefix install
           ARCH="$(uname -m)"
-          cd install && zip -r "../CoreVideo-macOS-${ARCH}-tools-unsupported.zip" .
+          cd install && zip -r "../CoreVideo-macOS-${ARCH}-unsigned.zip" .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: CoreVideo-macOS-compile-validation
-          path: CoreVideo-macOS-*-tools-unsupported.zip
+          path: CoreVideo-macOS-*-unsigned.zip
           if-no-files-found: warn
 
       - name: Upload build logs on failure

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ Makefile
 !third_party/**/*.so
 !third_party/**/*.dylib
 
+# Zoom SDK: fetched at build time (CI or release-local), NEVER committed.
+third_party/zoom-sdk/
+third_party/zoom-sdk-extracted/
+
 # Local package/dependency output
 node_modules/
 .npm-cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,8 +287,12 @@ if(COREVIDEO_BUILD_PLUGIN)
             "-framework CoreFoundation"
             "-framework Foundation"
         )
-        # Symbols provided by OBS at plugin load time; no link-time libobs needed.
-        target_link_options(obs-zoom-plugin PRIVATE "-undefined dynamic_lookup")
+        # Symbols provided by OBS at plugin load time; no link-time libobs
+        # needed. The SHELL: prefix is required so CMake passes these as TWO
+        # separate linker arguments ("-undefined" "dynamic_lookup"); without it
+        # the space-containing string is forwarded as a single argument and the
+        # flag never takes effect (obs_*/blog/config_* stay undefined at link).
+        target_link_options(obs-zoom-plugin PRIVATE "SHELL:-undefined dynamic_lookup")
     endif()
 
     set_target_properties(obs-zoom-plugin PROPERTIES PREFIX "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ if(COREVIDEO_BUILD_PLUGIN)
         target_link_libraries(obs-zoom-plugin PRIVATE
             "-framework CoreFoundation"
             "-framework Foundation"
+            "-framework Security"   # Keychain token storage (zoom-settings.cpp)
         )
         # Symbols provided by OBS at plugin load time; no link-time libobs
         # needed. The SHELL: prefix is required so CMake passes these as TWO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,8 +370,12 @@ if(BUILD_ZOOM_ENGINE)
             BUILD_WITH_INSTALL_RPATH OFF
             INSTALL_RPATH "@loader_path/zoom-runtime"
         )
+        # Relative DESTINATION (resolved against the install prefix). An
+        # absolute "${CMAKE_INSTALL_PREFIX}/..." expands to the configure-time
+        # default (/usr/local) and ignores `cmake --install --prefix`, which
+        # fails with "cannot create directory: /usr/local/...".
         install(TARGETS ZoomObsEngine
-            RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+            RUNTIME DESTINATION "obs-plugins/64bit"
         )
     elseif(UNIX)
         add_executable(ZoomObsEngine ${ENGINE_SOURCES})
@@ -381,7 +385,7 @@ if(BUILD_ZOOM_ENGINE)
             rt
         )
         install(TARGETS ZoomObsEngine
-            RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"
+            RUNTIME DESTINATION "obs-plugins/64bit"
         )
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,10 @@ if(BUILD_ZOOM_ENGINE)
         # header resolution and `-framework ZoomSDK` linking.
         add_executable(ZoomObsEngine engine/src/main-macos.mm)
         target_include_directories(ZoomObsEngine PRIVATE src engine/src)
+        # -F must be on BOTH the compile line (so `#import <ZoomSDK/ZoomSDK.h>`
+        # resolves via the framework's Headers dir) and the link line (so
+        # `-framework ZoomSDK` finds the framework binary).
+        target_compile_options(ZoomObsEngine PRIVATE "-F${ZOOM_SDK_ACTIVE_DIR}")
         target_link_libraries(ZoomObsEngine PRIVATE
             "-F${ZOOM_SDK_ACTIVE_DIR}"
             "-framework ZoomSDK"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,11 +170,13 @@ elseif(WIN32)
             "until the Zoom SDK bin/ runtime DLLs are available.")
     endif()
 elseif(APPLE)
-    if(EXISTS "${ZOOM_SDK_DIR}/ZoomSDK.framework")
+    # Resolve against the absolute active dir: if(EXISTS) requires an absolute
+    # path, and ZOOM_SDK_DIR is usually the relative "third_party/zoom-sdk".
+    if(EXISTS "${ZOOM_SDK_ACTIVE_DIR}/ZoomSDK.framework")
         set(BUILD_ZOOM_ENGINE ON)
     else()
         message(WARNING
-            "Zoom SDK framework not found at '${ZOOM_SDK_DIR}/ZoomSDK.framework'. "
+            "Zoom SDK framework not found at '${ZOOM_SDK_ACTIVE_DIR}/ZoomSDK.framework'. "
             "Building plugin bundle only; ZoomObsEngine will not be produced.")
     endif()
 elseif(UNIX)
@@ -336,12 +338,29 @@ if(BUILD_ZOOM_ENGINE)
         target_link_libraries(ZoomSdkAuthProbe PRIVATE ${ZOOM_SDK_LIBRARY})
         set_target_properties(ZoomSdkAuthProbe PROPERTIES WIN32_EXECUTABLE FALSE)
     elseif(APPLE)
-        add_executable(ZoomObsEngine ${ENGINE_SOURCES})
-        target_include_directories(ZoomObsEngine PRIVATE ${ENGINE_INCLUDES})
+        # SCAFFOLD ONLY — the macOS engine is NOT the C++ engine. The macOS Zoom
+        # Meeting SDK (ZoomSDK.framework) is a pure Objective-C framework and
+        # exposes none of the ZOOMSDK:: C++ interfaces the shared ENGINE_SOURCES
+        # are written against (no zoom_sdk.h, no IMeetingService, ...). Those
+        # sources cannot compile here. Build a small Objective-C++ scaffold that
+        # links the real framework (validating the SDK fetch + link path) and
+        # fails loudly at runtime on any meeting request. A functional macOS
+        # engine requires an Objective-C++ rewrite — tracked as a PR gap.
+        #
+        # -F<dir> adds the framework search path for both `#import <ZoomSDK/...>`
+        # header resolution and `-framework ZoomSDK` linking.
+        add_executable(ZoomObsEngine engine/src/main-macos.mm)
+        target_include_directories(ZoomObsEngine PRIVATE src engine/src)
         target_link_libraries(ZoomObsEngine PRIVATE
-            "-framework ${ZOOM_SDK_FRAMEWORK}"
-            "-framework CoreFoundation"
+            "-F${ZOOM_SDK_ACTIVE_DIR}"
+            "-framework ZoomSDK"
             "-framework Foundation"
+        )
+        # rpath so the linker/loader can resolve ZoomSDK.framework from where the
+        # SDK was fetched (CI compile/link validation only; not a shippable rpath).
+        set_target_properties(ZoomObsEngine PROPERTIES
+            BUILD_WITH_INSTALL_RPATH OFF
+            INSTALL_RPATH "@loader_path/zoom-runtime"
         )
         install(TARGETS ZoomObsEngine
             RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/obs-plugins/64bit"

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -1,0 +1,149 @@
+// ── macOS ZoomObsEngine — SCAFFOLD, NOT YET FUNCTIONAL ───────────────────────
+//
+// The Windows/Linux ZoomObsEngine (engine/src/main.cpp + engine-video.cpp /
+// engine-share.cpp / engine-audio.cpp) is written entirely against the Zoom
+// Meeting SDK's **C++** interface surface: <zoom_sdk.h>, the `ZOOMSDK`
+// namespace, IAuthService / IMeetingService / IMeetingParticipantsController,
+// SDKAuth(AuthContext), InitSDK(InitParam), the raw-recording + raw-data
+// controllers, etc.
+//
+// The macOS Meeting SDK (ZoomSDK.framework, v7.1.5.84750) exposes **none** of
+// that. It is a pure Objective-C framework: ZoomSDKAuthService,
+// ZoomSDKMeetingService, ZoomSDKRawDataVideoSourceController,
+// ZoomSDKRawDataAudioSourceController and Objective-C delegate protocols. There
+// is no zoom_sdk.h and no ZOOMSDK:: C++ API anywhere in the archive. Porting the
+// engine is therefore a full Objective-C++ rewrite, not a set of #ifdef fixes —
+// it is tracked as an explicit gap in the macOS-port PR.
+//
+// This translation unit exists so that macOS CI compiles AND links a real
+// ZoomObsEngine binary against the real ZoomSDK.framework — proving the SDK
+// fetch, framework detection, header parsing, and link path end-to-end — WHILE
+// REFUSING to fake any meeting functionality. It performs the platform-shared
+// POSIX IPC handshake (identical wire protocol to the Windows/Linux engine),
+// then, on any init/join request, reports a loud, explicit error over IPC and
+// exits with a non-zero code. It NEVER silently pretends a meeting joined.
+//
+// When the Objective-C++ engine is written, it should replace this file (or be
+// gated behind it) and implement the same IPC contract in engine-ipc.h.
+
+#import <ZoomSDK/ZoomSDK.h>
+
+#include "../../src/engine-ipc.h"
+#include "engine-writer.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <poll.h>
+#include <unistd.h>
+#include <cstring>
+#include <string>
+
+// ── POSIX IPC setup (mirrors engine/src/main.cpp's POSIX branch) ─────────────
+static int unix_listen(const char *path)
+{
+    int srv = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (srv < 0)
+        return -1;
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+    unlink(path); // remove stale socket file
+    if (bind(srv, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) < 0 ||
+        listen(srv, 1) < 0) {
+        close(srv);
+        return -1;
+    }
+    return srv;
+}
+
+static int unix_accept_timeout(int srv, int timeout_ms)
+{
+    struct pollfd pfd = {srv, POLLIN, 0};
+    if (poll(&pfd, 1, timeout_ms) <= 0)
+        return -1;
+    return accept(srv, nullptr, nullptr);
+}
+
+static bool ipc_setup(IpcFd &p2e, IpcFd &e2p)
+{
+    int srv_p2e = unix_listen(SOCK_P2E);
+    int srv_e2p = unix_listen(SOCK_E2P);
+    if (srv_p2e < 0 || srv_e2p < 0) {
+        if (srv_p2e >= 0)
+            close(srv_p2e);
+        if (srv_e2p >= 0)
+            close(srv_e2p);
+        return false;
+    }
+    constexpr int kConnectTimeoutMs = 30000; // 30 s
+    p2e = unix_accept_timeout(srv_p2e, kConnectTimeoutMs);
+    e2p = unix_accept_timeout(srv_e2p, kConnectTimeoutMs);
+    close(srv_p2e);
+    close(srv_e2p);
+    return p2e >= 0 && e2p >= 0;
+}
+
+static void ipc_teardown(IpcFd p2e, IpcFd e2p)
+{
+    close(p2e);
+    close(e2p);
+    unlink(SOCK_P2E);
+    unlink(SOCK_E2P);
+}
+
+// Reference a real Objective-C class from ZoomSDK.framework so this binary is
+// genuinely linked against the framework (forces resolution of the ObjC class
+// symbol) and the framework's headers are exercised at compile time. This does
+// NOT initialize the SDK, join a meeting, or start any Zoom activity.
+static void link_check_zoom_framework(void)
+{
+    @autoreleasepool {
+        ZoomSDKInitParams *params = [[ZoomSDKInitParams alloc] init];
+        (void)params;
+    }
+}
+
+int main()
+{
+    IpcFd p2e = kIpcInvalidFd;
+    IpcFd e2p = kIpcInvalidFd;
+    if (!ipc_setup(p2e, e2p))
+        return 1;
+    EngineIpc::init(e2p); // must be called before any writes
+
+    EngineIpc::write(R"({"cmd":"ready"})");
+    link_check_zoom_framework();
+
+    std::string line;
+    while (ipc_read_line(p2e, line)) {
+        if (line.empty())
+            continue;
+
+        if (line.find(IPC_CMD_QUIT) != std::string::npos)
+            break;
+
+        // Any real Zoom operation is unimplemented on macOS. Fail loudly with an
+        // actionable message and a non-zero exit code so the plugin surfaces it
+        // (ZoomEngineClient maps exit code 3 to RecoveryReason::SdkError) rather
+        // than spinning as if a meeting were about to start.
+        if (line.find(IPC_CMD_INIT) != std::string::npos ||
+            line.find(IPC_CMD_JOIN) != std::string::npos) {
+            EngineIpc::write(
+                R"({"cmd":"auth_fail","stage":"macos_engine_unimplemented",)"
+                R"("code":3,"name":"MACOS_ENGINE_NOT_IMPLEMENTED",)"
+                R"("auth_mode":"unknown"})");
+            EngineIpc::write(
+                R"({"cmd":"error","msg":"macos_engine_unimplemented",)"
+                R"("reason":"The macOS ZoomObsEngine is not yet implemented. The )"
+                R"(macOS Zoom Meeting SDK is Objective-C only and requires an )"
+                R"(Objective-C++ rewrite of the engine; see the CoreVideo macOS )"
+                R"(port PR for the tracked gap."})");
+            ipc_teardown(p2e, e2p);
+            return 3; // SdkError — plugin treats this as a permanent SDK failure
+        }
+    }
+
+    ipc_teardown(p2e, e2p);
+    return 0;
+}

--- a/src/zoom-diagnostics-dialog.cpp
+++ b/src/zoom-diagnostics-dialog.cpp
@@ -302,6 +302,9 @@ static QString latest_obs_log_path()
     if (appdata.isEmpty())
         return {};
     QDir logs(QDir(appdata).absoluteFilePath("obs-studio/logs"));
+#elif defined(__APPLE__)
+    QDir logs(QDir::home().absoluteFilePath(
+        "Library/Application Support/obs-studio/logs"));
 #else
     QDir logs(QDir::home().absoluteFilePath(".config/obs-studio/logs"));
 #endif

--- a/src/zoom-oauth.cpp
+++ b/src/zoom-oauth.cpp
@@ -30,6 +30,13 @@ extern "C" IMAGE_DOS_HEADER __ImageBase;
 #elif defined(__APPLE__)
 #include <CoreServices/CoreServices.h>
 #include <dlfcn.h>
+#include <QDir>
+#include <QFileInfo>
+
+// dladdr needs an address that lives inside this plugin binary so it can report
+// the plugin's own path. A pointer-to-member-function cannot be cast to void*
+// (ill-formed in C++), so use the address of this file-local free function.
+static void corevideo_oauth_module_anchor() {}
 #endif
 
 ZoomOAuthManager &ZoomOAuthManager::instance()
@@ -644,7 +651,7 @@ bool ZoomOAuthManager::register_url_scheme(QString *error)
     return true;
 #elif defined(__APPLE__)
     Dl_info info{};
-    if (!dladdr(reinterpret_cast<const void *>(&ZoomOAuthManager::register_url_scheme),
+    if (!dladdr(reinterpret_cast<const void *>(&corevideo_oauth_module_anchor),
                 &info) ||
         !info.dli_fname) {
         if (error) *error = "Could not locate the CoreVideo plugin directory.";

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -11,6 +11,9 @@
 #if defined(_WIN32)
 #include <windows.h>
 #include <dpapi.h>
+#elif defined(__APPLE__)
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
 #endif
 
 static constexpr const char *SECTION = "ZoomPlugin";
@@ -38,11 +41,12 @@ static bool has_embedded_value(const char *value)
     return value && *value;
 }
 
-#if !defined(_WIN32)
-// No OS-level secret store is wired up on this platform yet (macOS Keychain /
-// Linux libsecret are tracked as follow-up work - see README.md "Security").
-// Until then, OAuth tokens are written to OBS's global.ini in plaintext, so
-// warn loudly instead of failing silently. Logged once per process.
+#if !defined(_WIN32) && !defined(__APPLE__)
+// No OS-level secret store is wired up on this platform yet (Windows uses
+// DPAPI, macOS uses the Keychain below; Linux libsecret is tracked as
+// follow-up work - see README.md "Security"). Until then, OAuth tokens are
+// written to OBS's global.ini in plaintext, so warn loudly instead of failing
+// silently. Logged once per process.
 static void warn_plaintext_token_storage_once()
 {
     static bool warned = false;
@@ -51,17 +55,123 @@ static void warn_plaintext_token_storage_once()
     blog(LOG_WARNING,
          "[obs-zoom-plugin] SECURITY: OAuth tokens are stored WITHOUT "
          "OS-level encryption on this platform (DPAPI token protection is "
-         "Windows-only). Access/refresh tokens are written in plaintext to "
-         "OBS's global.ini under the [ZoomPlugin] section. Anyone with "
-         "filesystem or config-file access can read them. See the Security "
-         "section of README.md.");
+         "Windows-only; macOS uses the Keychain). Access/refresh tokens are "
+         "written in plaintext to OBS's global.ini under the [ZoomPlugin] "
+         "section. Anyone with filesystem or config-file access can read "
+         "them. See the Security section of README.md.");
 }
 #endif
 
-static std::string protect_secret(const std::string &secret)
+#if defined(__APPLE__)
+// macOS Keychain-backed secret storage. Secrets live in the login Keychain
+// under the service "CoreVideo OBS Plugin", keyed by an account name (the
+// config key). global.ini stores only an empty placeholder, so tokens are
+// never written to disk in plaintext. Failures are loud and never fall back to
+// plaintext: a failed store leaves no token (re-auth required), and a failed
+// read returns empty (re-auth required) rather than a stale/guessed value.
+static constexpr const char *kKeychainService = "CoreVideo OBS Plugin";
+
+static bool keychain_set_secret(const char *account, const std::string &secret)
 {
-    if (secret.empty()) return {};
+    CFStringRef svc = CFStringCreateWithCString(nullptr, kKeychainService,
+                                                kCFStringEncodingUTF8);
+    CFStringRef acc = CFStringCreateWithCString(nullptr, account,
+                                                kCFStringEncodingUTF8);
+    const void *qkeys[] = {kSecClass, kSecAttrService, kSecAttrAccount};
+    const void *qvals[] = {kSecClassGenericPassword, svc, acc};
+    CFDictionaryRef query = CFDictionaryCreate(
+        nullptr, qkeys, qvals, 3, &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
+
+    OSStatus st;
+    bool ok;
+    if (secret.empty()) {
+        // No value to store: remove any existing item. Not-found is success.
+        st = SecItemDelete(query);
+        ok = (st == errSecSuccess || st == errSecItemNotFound);
+    } else {
+        CFDataRef data = CFDataCreate(
+            nullptr, reinterpret_cast<const UInt8 *>(secret.data()),
+            static_cast<CFIndex>(secret.size()));
+        const void *ukeys[] = {kSecValueData};
+        const void *uvals[] = {data};
+        CFDictionaryRef upd = CFDictionaryCreate(
+            nullptr, ukeys, uvals, 1, &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+        st = SecItemUpdate(query, upd);
+        if (st == errSecItemNotFound) {
+            CFMutableDictionaryRef add =
+                CFDictionaryCreateMutableCopy(nullptr, 0, query);
+            CFDictionarySetValue(add, kSecValueData, data);
+            st = SecItemAdd(add, nullptr);
+            CFRelease(add);
+        }
+        ok = (st == errSecSuccess);
+        CFRelease(upd);
+        CFRelease(data);
+    }
+    if (!ok) {
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] SECURITY: Keychain store failed for '%s' "
+             "(OSStatus %d). Token was NOT persisted - re-authentication will "
+             "be required. The token is never written to disk in plaintext.",
+             account, static_cast<int>(st));
+    }
+    CFRelease(query);
+    CFRelease(acc);
+    CFRelease(svc);
+    return ok;
+}
+
+static std::string keychain_get_secret(const char *account)
+{
+    CFStringRef svc = CFStringCreateWithCString(nullptr, kKeychainService,
+                                                kCFStringEncodingUTF8);
+    CFStringRef acc = CFStringCreateWithCString(nullptr, account,
+                                                kCFStringEncodingUTF8);
+    const void *keys[] = {kSecClass, kSecAttrService, kSecAttrAccount,
+                          kSecReturnData, kSecMatchLimit};
+    const void *vals[] = {kSecClassGenericPassword, svc, acc, kCFBooleanTrue,
+                          kSecMatchLimitOne};
+    CFDictionaryRef query = CFDictionaryCreate(
+        nullptr, keys, vals, 5, &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
+
+    CFTypeRef result = nullptr;
+    OSStatus st = SecItemCopyMatching(query, &result);
+    std::string out;
+    if (st == errSecSuccess && result &&
+        CFGetTypeID(result) == CFDataGetTypeID()) {
+        CFDataRef data = static_cast<CFDataRef>(result);
+        out.assign(reinterpret_cast<const char *>(CFDataGetBytePtr(data)),
+                   static_cast<size_t>(CFDataGetLength(data)));
+    } else if (st != errSecItemNotFound) {
+        // A hard error (not merely "no item") - surface it; caller re-auths.
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] SECURITY: Keychain read failed for '%s' "
+             "(OSStatus %d). Re-authentication will be required.",
+             account, static_cast<int>(st));
+    }
+    if (result)
+        CFRelease(result);
+    CFRelease(query);
+    CFRelease(acc);
+    CFRelease(svc);
+    return out;
+}
+#endif
+
+// Transform a secret into the value stored in global.ini.
+//   Windows: DPAPI-encrypted base64 blob (byte-identical to before).
+//   macOS:   stored in the login Keychain under `account`; returns empty so
+//            the ini holds only a placeholder (never plaintext).
+//   Linux:   plaintext (loud one-time warning).
+// `account` is the config key; used only on macOS as the Keychain account.
+static std::string protect_secret(const std::string &secret, const char *account)
+{
 #if defined(_WIN32)
+    (void)account;
+    if (secret.empty()) return {};
     DATA_BLOB in;
     in.pbData = reinterpret_cast<BYTE *>(const_cast<char *>(secret.data()));
     in.cbData = static_cast<DWORD>(secret.size());
@@ -74,16 +184,24 @@ static std::string protect_secret(const std::string &secret)
                      static_cast<int>(out.cbData));
     LocalFree(out.pbData);
     return bytes.toBase64().toStdString();
+#elif defined(__APPLE__)
+    // Store (or clear) in the Keychain; the ini keeps only an empty
+    // placeholder. keychain_set_secret logs loudly on failure.
+    keychain_set_secret(account, secret);
+    return {};
 #else
+    (void)account;
+    if (secret.empty()) return {};
     warn_plaintext_token_storage_once();
     return secret;
 #endif
 }
 
-static std::string unprotect_secret(const char *stored)
+static std::string unprotect_secret(const char *stored, const char *account)
 {
-    if (!stored || !*stored) return {};
 #if defined(_WIN32)
+    (void)account;
+    if (!stored || !*stored) return {};
     const QByteArray encrypted = QByteArray::fromBase64(QByteArray(stored));
     if (encrypted.isEmpty()) return {};
     DATA_BLOB in;
@@ -96,7 +214,15 @@ static std::string unprotect_secret(const char *stored)
     std::string secret(reinterpret_cast<const char *>(out.pbData), out.cbData);
     LocalFree(out.pbData);
     return secret;
+#elif defined(__APPLE__)
+    // The real token lives in the Keychain; the ini value is only a
+    // placeholder. A missing/corrupt Keychain item yields empty (re-auth),
+    // never a silent stale value.
+    (void)stored;
+    return keychain_get_secret(account);
 #else
+    (void)account;
+    if (!stored || !*stored) return {};
     warn_plaintext_token_storage_once();
     return stored;
 #endif
@@ -148,7 +274,7 @@ ZoomPluginSettings ZoomPluginSettings::load()
             : ((key && *key) ? key : kEmbeddedSdkKey);
 
         const std::string protected_meeting_secret =
-            unprotect_secret(meeting_sdk_client_secret);
+            unprotect_secret(meeting_sdk_client_secret, "MeetingSdkClientSecret");
         if (!protected_meeting_secret.empty()) {
             s.sdk_secret = protected_meeting_secret;
         } else {
@@ -186,9 +312,9 @@ ZoomPluginSettings ZoomPluginSettings::load()
     if (oauth_scopes && *oauth_scopes)
         s.oauth_scopes = oauth_scopes;
     s.oauth_access_token = unprotect_secret(
-        config_get_string(cfg, SECTION, "OAuthAccessToken"));
+        config_get_string(cfg, SECTION, "OAuthAccessToken"), "OAuthAccessToken");
     s.oauth_refresh_token = unprotect_secret(
-        config_get_string(cfg, SECTION, "OAuthRefreshToken"));
+        config_get_string(cfg, SECTION, "OAuthRefreshToken"), "OAuthRefreshToken");
     s.oauth_expires_at = static_cast<int64_t>(
         config_get_int(cfg, SECTION, "OAuthExpiresAt"));
 
@@ -342,7 +468,7 @@ void ZoomPluginSettings::save() const
     config_set_string(cfg, SECTION, "SdkSecret",         saved_sdk_secret.c_str());
     config_set_string(cfg, SECTION, "MeetingSdkClientId", saved_sdk_key.c_str());
     config_set_string(cfg, SECTION, "MeetingSdkClientSecret",
-                      protect_secret(saved_sdk_secret).c_str());
+                      protect_secret(saved_sdk_secret, "MeetingSdkClientSecret").c_str());
     config_set_string(cfg, SECTION, "MeetingSdkPublicAppKey",
                       saved_public_app_key.c_str());
     config_set_string(cfg, SECTION, "MeetingSdkAuthMode",
@@ -361,9 +487,9 @@ void ZoomPluginSettings::save() const
     config_set_string(cfg, SECTION, "OAuthRedirectUri",  oauth_redirect_uri.c_str());
     config_set_string(cfg, SECTION, "OAuthScopes",       oauth_scopes.c_str());
     config_set_string(cfg, SECTION, "OAuthAccessToken",
-                      protect_secret(oauth_access_token).c_str());
+                      protect_secret(oauth_access_token, "OAuthAccessToken").c_str());
     config_set_string(cfg, SECTION, "OAuthRefreshToken",
-                      protect_secret(oauth_refresh_token).c_str());
+                      protect_secret(oauth_refresh_token, "OAuthRefreshToken").c_str());
     config_set_int   (cfg, SECTION, "OAuthExpiresAt",
                       static_cast<int>(oauth_expires_at));
     config_set_uint  (cfg, SECTION, "ControlServerPort", control_server_port);


### PR DESCRIPTION
Starts the macOS port of the CoreVideo OBS plugin. All CI jobs are green on
this branch (Windows, Linux, Companion unchanged; macOS reworked). Nothing here
has been runtime-tested — this is **CI compile + link + ctest only**. Runtime QA
belongs on the owner's Apple Silicon Mac.

Final green run: https://github.com/iamfatness/CoreVideo/actions/runs/30511039438

## Phase 1 — real plugin on the macOS runner ✅

The macOS CI job (`build-macos`, macos-14 / arm64) previously built tools only
with `-DCOREVIDEO_BUILD_PLUGIN=OFF -DCOREVIDEO_BUILD_ENGINE=OFF`. It now builds
the **actual product**:

- `obs-zoom-plugin.so` — the full Qt6 plugin bundle (all 23 source files, AUTOMOC)
- `CoreVideoOAuthCallback.app` — the macOS OAuth callback helper (`.mm`)
- `ctest` — **17/17 pass** on the runner

Compile/POSIX fixes that were never exercised before (all in `#ifdef` paths that
had literally never been compiled):

- `zoom-oauth.cpp` (`register_url_scheme`, macOS branch): missing `<QDir>`
  include; and an illegal `reinterpret_cast` of a **pointer-to-member-function**
  to `void*` for `dladdr` → anchored on a file-local free function instead.
- `zoom-diagnostics-dialog.cpp`: macOS OBS log path corrected to
  `~/Library/Application Support/obs-studio/logs` (was using the Linux path).
- CMake: `-undefined dynamic_lookup` was passed as a single space-containing
  string, so the linker never entered dynamic-lookup mode and every OBS symbol
  (`blog`, `config_*`, `obs_*`) came back undefined. Fixed with the CMake
  `SHELL:` prefix so it's forwarded as two proper linker args.

### OBS dev-tree approach chosen

Kept (and reused) the repo's existing macOS pattern: download the OBS source
tarball for **headers only**, write tiny `INTERFACE IMPORTED` CMake config
files, and link the plugin `MODULE` with `-undefined dynamic_lookup` so `obs_*`
symbols resolve at load time inside OBS. No libobs dylib is needed at link time.
This mirrors the Windows job's philosophy (manufacture an SDK dir from release
bits + sparse-checkout headers) while being simpler on macOS. The deprecation
warning from the new linker is cosmetic; the flag still works when passed
correctly.

## Phase 2 — engine vs. the real macOS Zoom SDK ⚠️ scaffold (honest scoping)

### SDK fetch mechanism

New CI step fetches the private SDK from the **draft release** "SDK assets
(private storage - DO NOT PUBLISH)":

- `gh api .../releases --jq '.[]|select(.draft)|...'` finds the asset id
  (`zoom-sdk-macos-7.1.5.84750.zip`), then
  `gh api -H "Accept: application/octet-stream" .../releases/assets/<id>`
  downloads the bytes (gh handles the S3 redirect + auth stripping).
- Requires **`permissions: contents: write`** on the job — draft releases are
  invisible to a `contents: read` token, which silently returned nothing.
- Extracts, locates `<root>/ZoomSDK/ZoomSDK.framework`, moves it to
  `third_party/zoom-sdk/`. **Never committed** (added to `.gitignore`); the
  draft release is **never published**.
- Fork PRs without the token fall back to a plugin-only build (loud warning),
  so external contributors don't hit a hard failure.

### 🔑 Engine API-divergence scoping — the key finding

**The macOS Zoom Meeting SDK is Objective-C only. It shares *zero* API surface
with the Windows/Linux engine.**

The existing engine (`engine/src/main.cpp` + `engine-video/share/audio.cpp`) is
written entirely against the SDK's **C++** surface: `#include <zoom_sdk.h>`, the
`ZOOMSDK::` namespace, `IAuthService` / `IMeetingService` /
`IMeetingParticipantsController`, `SDKAuth(AuthContext)`, `InitSDK(InitParam)`,
the raw-recording controllers, and the raw-data delegates
(`ZOOMSDK::IZoomSDKRendererDelegate`, `ZOOMSDK::IZoomSDKAudioRawDataDelegate`).

I extracted and read the v7.1.5.84750 framework headers. Findings:

- No `zoom_sdk.h`, no `*_interface.h`, no `ZOOMSDK::` namespace anywhere.
- 58 of 59 headers are Objective-C (`@interface`). The API is
  `ZoomSDKAuthService`, `ZoomSDKMeetingService`,
  `ZoomSDKRawDataVideoSourceController` (`ZoomSDKYUVProcessDataI420`,
  `ZoomSDKRenderer`), `ZoomSDKRawDataAudioSourceController`, and ObjC delegate
  **protocols** — a completely different shape (delegates + `NSObject`
  subclasses, not C++ pure-virtual interfaces).

**Conclusion: the macOS engine is a full Objective-C++ rewrite, not an `#ifdef`
port.** The shared C++ engine sources cannot compile against this framework at
all.

### What the scaffold does (and its runtime-loud guarantee)

`engine/src/main-macos.mm` is a deliberately minimal scaffold that:

- Compiles **and links against the real `ZoomSDK.framework`** — it references a
  real ObjC class (`ZoomSDKInitParams`) to force a genuine link, proving the
  whole SDK fetch → framework detection → header parse → link path works
  end-to-end in CI.
- Performs the platform-shared POSIX IPC handshake (identical wire protocol to
  the real engine) and answers `ready`.
- **Refuses to fake meeting functionality.** On any `init`/`join` request it
  emits a loud `auth_fail` + `error` over IPC ("macOS ZoomObsEngine is not yet
  implemented…") and exits code 3, which `ZoomEngineClient` maps to
  `RecoveryReason::SdkError` and surfaces to the operator. It never silently
  pretends a meeting joined.

CMake `BUILD_ZOOM_ENGINE` on APPLE now detects `ZoomSDK.framework` (via the
absolute active dir), builds `main-macos.mm`, and links `-F<dir> -framework
ZoomSDK -framework Foundation`. Also fixed the APPLE/UNIX engine `install`
DESTINATION (was absolute `${CMAKE_INSTALL_PREFIX}/…` → `/usr/local/…`, which
`--prefix install` can't override; now relative like the plugin/Windows).

## Phase 3 — macOS Keychain token storage ✅ (compiles/links; runtime unverified)

`src/zoom-settings.cpp`: the non-Windows plaintext token storage now uses the
macOS login **Keychain** via `Security.framework`
(`SecItemAdd`/`Update`/`CopyMatching`/`Delete`), service `"CoreVideo OBS
Plugin"`, keyed by config key. `global.ini` stores only an empty placeholder, so
tokens are never written to disk in plaintext.

- **Windows DPAPI path is byte-identical** (added an unused-on-Windows `account`
  arg only).
- **Linux** keeps the loud one-time plaintext-storage warning.
- **Fail loud, never silent:** a failed Keychain store persists no token; a
  missing/corrupt item reads as empty → re-auth required (never a stale/guessed
  value).
- Linked `-framework Security` into the plugin.

## What remains / honest limits

- **Nothing is runtime-tested.** CI proves compile + link + ctest on arm64 only.
  Everything below needs QA on the owner's M3 Max:
  - Plugin actually loads in OBS.app; dock/dialogs/OAuth flow work.
  - Keychain read/write/rotation behaves (SecItem may need a login keychain /
    proper entitlements when run under OBS).
  - `corevideo://` URL-scheme registration + OAuth callback round-trip.
- **The macOS engine is non-functional** — full ObjC++ rewrite required:
  `ZoomSDKAuthService` auth (`init`/`SDKAuth`→ delegate), `ZoomSDKMeetingService`
  join, participants/roster via the ObjC controllers, and raw video/share/audio
  via `ZoomSDKRawDataVideoSourceController` / `…AudioSourceController` +
  `ZoomSDKRenderer`, all writing the existing IPC protocol + SHM regions.
- **Packaging/signing/notarization** not done: arm64-only (no universal binary),
  unsigned, un-notarized; the CI zip is a compile-validation artifact, not an
  installable package. No `.pkg`/DMG, no codesign, no rpath bundling of
  `ZoomSDK.framework` + its ~30 sibling frameworks.
- **Known runtime gap to fix during the engine rewrite:** POSIX shm names on
  macOS are limited to ~31 chars (`PSHMNAMLEN`); `IPC_SHM_PREFIX` + a 64-char
  source UUID would exceed it. Only bites once real frames flow (functional
  engine), so it's deferred, but flagged.
- Support-bundle zip creation is still Windows-only (macOS shows a loud "not
  automatic" warning rather than faking it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
