### PR TITLE
CI: fetch Windows Zoom SDK 7.1.5 from the private draft release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ jobs:
   build-windows:
     name: Windows x64
     runs-on: windows-2022
+    # contents: write so GITHUB_TOKEN can see the draft release that stores the
+    # license-restricted Zoom SDK (drafts are invisible to a read-only token).
+    permissions:
+      contents: write
     outputs:
       has_zoom_runtime: ${{ steps.zoom_sdk.outputs.has_zoom_runtime }}
     steps:
@@ -107,24 +111,33 @@ jobs:
           aqt install-qt windows desktop 6.7.3 win64_msvc2019_64 --outputdir C:\Qt
           "QT_ROOT_DIR=C:\Qt\6.7.3\msvc2019_64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Download Zoom Windows SDK
+      # The Zoom SDK is license-restricted: it lives as an asset on a DRAFT
+      # release in this repo (never publish that release). curl.exe strips the
+      # Authorization header on the S3 redirect hop for us and is binary-safe,
+      # unlike PowerShell 5.1 stdout redirection. Never commit the SDK.
+      - name: Download Zoom Windows SDK (private draft-release asset)
         id: zoom_sdk
         env:
-          ZOOM_SDK_DOWNLOAD_URL: ${{ secrets.ZOOM_SDK_WINDOWS_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: powershell
         run: |
-          if ($env:ZOOM_SDK_DOWNLOAD_URL) {
-              Invoke-WebRequest $env:ZOOM_SDK_DOWNLOAD_URL -OutFile zoom-sdk.zip
-              Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted
-              $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
-              Move-Item $inner.FullName third_party/zoom-sdk
-              "COREVIDEO_HAS_ZOOM_RUNTIME=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-              "has_zoom_runtime=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          } else {
+          $ErrorActionPreference = "Stop"
+          $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
+          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          if (-not $assetId) {
               "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
               "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-              Write-Warning "ZOOM_SDK_WINDOWS_URL is not configured. Building Windows validation artifact without ZoomObsEngine runtime."
+              Write-Warning "$assetName not found on any draft release (or token lacks access). Building Windows validation artifact without ZoomObsEngine runtime."
+              exit 0
           }
+          Write-Host "Fetching $assetName (asset id $assetId)"
+          curl.exe -sSfL -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/octet-stream" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$assetId" -o zoom-sdk.zip
+          if ((Get-Item zoom-sdk.zip).Length -lt 100MB) { throw "Downloaded SDK archive is implausibly small." }
+          Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted
+          $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
+          Move-Item $inner.FullName third_party/zoom-sdk
+          "COREVIDEO_HAS_ZOOM_RUNTIME=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "has_zoom_runtime=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Download FFmpeg (LGPL shared) for HW acceleration
         shell: powershell

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -101,20 +101,28 @@ jobs:
 
           "OBS_SDK_DIR=$sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Download Zoom Windows SDK
+      # The Zoom SDK is license-restricted: it lives as an asset on a DRAFT
+      # release in this repo (never publish that release). curl.exe strips the
+      # Authorization header on the S3 redirect hop and is binary-safe, unlike
+      # PowerShell 5.1 stdout redirection. Never commit the SDK.
+      - name: Download Zoom Windows SDK (private draft-release asset)
         id: zoom_sdk
         env:
-          ZOOM_SDK_DOWNLOAD_URL: ${{ secrets.ZOOM_SDK_WINDOWS_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          if ([string]::IsNullOrWhiteSpace($env:ZOOM_SDK_DOWNLOAD_URL)) {
+          $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
+          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          if (-not $assetId) {
             "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Warning "ZOOM_SDK_WINDOWS_URL is not configured. Building a validation-only package without ZoomObsEngine runtime."
+            Write-Warning "$assetName not found on any draft release (or token lacks access). Building a validation-only package without ZoomObsEngine runtime."
             exit 0
           }
-          Invoke-WebRequest $env:ZOOM_SDK_DOWNLOAD_URL -OutFile zoom-sdk.zip
+          Write-Host "Fetching $assetName (asset id $assetId)"
+          curl.exe -sSfL -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/octet-stream" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$assetId" -o zoom-sdk.zip
+          if ((Get-Item zoom-sdk.zip).Length -lt 100MB) { throw "Downloaded SDK archive is implausibly small." }
           Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted -Force
           $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
           if (-not $inner) {

--- a/README.md
+++ b/README.md
@@ -147,9 +147,12 @@ The CMake project genuinely supports configuring on all of the above (see `build
 
 GitHub Actions can validate the Windows build without the restricted Zoom
 runtime, but public client releases must include `ZoomObsEngine.exe`,
-`zoom-runtime\sdk.dll`, Qt TLS plugins, and the other bundled runtime files. If
-`ZOOM_SDK_WINDOWS_URL` is not configured as a GitHub repository secret, CI skips
-publishing a GitHub Release instead of shipping an incomplete package.
+`zoom-runtime\sdk.dll`, Qt TLS plugins, and the other bundled runtime files.
+CI fetches the license-restricted Zoom SDK from an asset on a **draft** GitHub
+release in this repository (draft releases are not publicly visible; the
+workflow token downloads the asset at build time). If the asset is missing, CI
+skips publishing a GitHub Release instead of shipping an incomplete package.
+Keep that release a draft — publishing it would make the SDK public.
 
 For fast local releases from a machine that already has the Zoom runtime, use:
 


### PR DESCRIPTION
Switches both Windows jobs (build.yml, release-windows.yml) from the external `ZOOM_SDK_WINDOWS_URL` secret to the same draft-release asset fetch the macOS job uses, and upgrades the CI SDK from 7.0.2.34512 to **7.1.5.43953**.

- 7.1.5 was validated locally against main: only doc/additive header changes in the API surface this codebase uses; zero code changes; clean build (0 warnings); 16/16 tests pass.
- Download uses `curl.exe` with the workflow token (binary-safe in PowerShell 5.1; curl strips the Authorization header on the S3 redirect hop).
- `build-windows` gains `permissions: contents: write` so the token can see draft releases; `release-windows.yml` already had it workflow-level.
- Missing-asset fallback preserves the existing validation-only behavior with a warning.
- README release-packaging section updated; the `ZOOM_SDK_WINDOWS_URL` secret is now unused and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)