### PR TITLE
Docs: readable architecture diagrams + real Plugin Docs design integration

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,18 +41,17 @@
 
     #sidebar {
       position: fixed; top: 52px; left: 0; bottom: 0; width: 260px;
-      background: var(--surface); border-right: 1px solid var(--border);
-      padding: 24px 0; overflow-y: auto; z-index: 100;
+      background: var(--bg); border-right: 1px solid var(--border);
+      padding: 18px 0 32px; overflow-y: auto; z-index: 100;
     }
-    .nav-logo { padding: 0 20px 20px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-    .nav-logo h1 { font-size: 1.1rem; color: var(--accent); font-weight: 700; }
-    .nav-logo p  { font-size: 0.75rem; color: var(--muted); margin-top: 2px; }
     #sidebar a {
-      display: block; padding: 7px 20px; color: var(--muted); text-decoration: none;
-      font-size: 0.95rem; border-left: 2px solid transparent; transition: all 0.15s;
+      display: block; padding: 6px 20px; color: var(--muted); text-decoration: none;
+      font-size: 0.88rem; border-left: 2px solid transparent; transition: color .15s, background .15s, border-color .15s;
     }
-    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.1); }
-    .nav-section { padding: 14px 20px 4px; font-size: 0.78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); }
+    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.08); }
+    .nav-section { padding: 18px 20px 6px; font-family: "IBM Plex Mono", ui-monospace, monospace;
+      font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: .14em; color: #77828a; }
+    .nav-section-first { padding-top: 4px; }
     main { margin-left: 260px; max-width: 960px; padding: 48px 56px; }
     section[id] { scroll-margin-top: 72px; }
 
@@ -116,12 +115,16 @@
     .card h4 { margin: 0 0 6px; font-size: 0.9rem; }
     .card p { font-size: 0.8rem; color: var(--muted); margin: 0; }
 
+    .diagram-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     .diagram-wrap {
       background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
-      padding: 28px; margin: 20px 0; overflow-x: auto;
+      padding: 24px; margin: 20px 0; overflow-x: auto;
     }
-    .diagram-wrap .mermaid { display: flex; justify-content: center; }
-    .diagram-caption { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 12px; font-style: italic; }
+    .diagram-wrap .mermaid { display: flex; justify-content: safe center; min-width: min-content; }
+    .diagram-wrap .mermaid svg { max-width: none; }
+    .diagram-wrap > svg.arch { display: block; width: 100%; height: auto; min-width: 720px; }
+    .diagram-caption { font-size: 0.85rem; color: var(--muted); text-align: center; margin-top: 14px;
+      font-family: "IBM Plex Mono", ui-monospace, monospace; }
 
     table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.875rem; }
     th { background: #16191b; border: 1px solid var(--border); padding: 10px 14px; text-align: left; font-weight: 600; color: var(--muted); }
@@ -146,9 +149,16 @@
 
     section { scroll-margin-top: 24px; }
 
-    @media (max-width: 768px) {
-      #sidebar { display: none; }
-      main { margin-left: 0; padding: 24px 20px; }
+    @media (max-width: 960px) {
+      /* Sidebar becomes a horizontal on-page index instead of disappearing. */
+      #sidebar { position: static; width: auto; bottom: auto; display: flex; align-items: center;
+        overflow-x: auto; white-space: nowrap; padding: 10px 12px; gap: 2px;
+        border-right: none; border-bottom: 1px solid var(--border); }
+      .nav-section { padding: 0 6px 0 14px; }
+      .nav-section-first { padding-left: 6px; }
+      #sidebar a { padding: 6px 10px; border-left: none; border-radius: 6px; font-size: 0.82rem; }
+      #sidebar a:hover, #sidebar a.active { background: rgba(34,200,110,.12); }
+      main { margin-left: 0; padding: 28px 20px; }
       .site-topbar { flex-direction: column; align-items: flex-start; gap: 10px; }
       .site-topbar .topnav { justify-content: flex-start; }
       main > footer { margin-left: 0 !important; }
@@ -172,12 +182,8 @@
   </nav>
 </header>
 
-<nav id="sidebar">
-  <div class="nav-logo">
-    <h1>📹 CoreVideo</h1>
-    <p>OBS Plugin for Live Zoom Video</p>
-  </div>
-  <div class="nav-section">Overview</div>
+<nav id="sidebar" aria-label="On this page">
+  <div class="nav-section nav-section-first">Overview</div>
   <a href="#overview">Introduction</a>
   <a href="#features">Features</a>
   <div class="nav-section">Get Started</div>
@@ -556,65 +562,89 @@
       which feed they subscribe to: a fixed participant, the active speaker, a
       spotlight slot, or the active screen share.
     </p>
-    <div class="diagram-wrap">
-      <div class="mermaid">
-graph TB
-    subgraph Machine["User's Machine"]
-      subgraph OBS["OBS Studio"]
-        Canvas["Canvas / Output"]
-        VSrc["Zoom Participant\nSource"]
-        Canvas --> VSrc
-      end
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
+      <svg class="arch" viewBox="0 0 1140 600" role="img" aria-labelledby="fig1-t fig1-d" xmlns="http://www.w3.org/2000/svg">
+  <title id="fig1-t">CoreVideo system overview</title>
+  <desc id="fig1-d">Zoom Cloud feeds the ZoomObsEngine child process over HTTPS/WSS. The engine owns all Zoom SDK access and writes I420 video and PCM audio into shared memory, which the obs-zoom-plugin reads and hands to OBS Studio sources. Plugin and engine exchange JSON IPC over a named pipe or Unix socket. External controllers reach the plugin over TCP 19870 and OSC 19871.</desc>
+  <defs>
+    <marker id="ar-g" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#22c86e"/></marker>
+    <marker id="ar-n" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#8b949b"/></marker>
+    <marker id="ar-nr" markerWidth="9" markerHeight="8" refX="0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M8,0 L8,6 L0,3 z" fill="#8b949b"/></marker>
+  </defs>
+  <style>
+    .p-title { font: 700 13px "Space Grotesk", sans-serif; letter-spacing: .1em; fill: #e9edef; }
+    .p-tag   { font: 400 9.5px "IBM Plex Mono", monospace; letter-spacing: .06em; fill: #77828a; }
+    .chip    { fill: #1a2025; stroke: #2c343b; }
+    .c-txt   { font: 400 12px "IBM Plex Mono", monospace; fill: #dbe3e8; }
+    .e-lab   { font: 600 11px "IBM Plex Mono", monospace; letter-spacing: .08em; fill: #8b949b; }
+    .e-lab.g { fill: #4fd88f; }
+    .e-sub   { font: 400 10px "IBM Plex Mono", monospace; fill: #6d777d; }
+  </style>
 
-      subgraph Plugin["obs-zoom-plugin  (no SDK dependency)"]
-        ZDock["ZoomDock\n(Control UI · CvStatusDot · CvBanner)"]
-        ZEC["ZoomEngineClient\n★ central singleton"]
-        ZRM["ZoomReconnectManager\n(auto-reconnect)"]
-        ZOAuth["ZoomOAuthManager\n(OAuth broker · ZAK fetch · DPAPI)"]
-        ZS["ZoomSource\n(ShmRegion · AssignmentMode)"]
-        ZOM["ZoomOutputManager"]
-        ZCS["ZoomControlServer :19870"]
-        ZOSC["ZoomOscServer :19871"]
+  <!-- Zoom Cloud -->
+  <rect x="16" y="210" width="160" height="128" rx="12" fill="#10151a" stroke="rgba(188,140,255,.38)" stroke-width="1.5"/>
+  <circle cx="34" cy="234" r="4" fill="#bc8cff"/>
+  <text class="p-title" x="46" y="238">ZOOM CLOUD</text>
+  <text class="p-tag" x="30" y="258">RAW A/V SOURCE</text>
+  <rect class="chip" x="30" y="274" width="132" height="30" rx="7"/>
+  <text class="c-txt" x="42" y="293">Live meeting</text>
 
-        ZDock --> ZEC
-        ZDock --> ZOAuth
-        ZRM --> ZEC
-        ZEC --> ZS
-        ZCS & ZOSC --> ZOM & ZEC
-        ZEC --> ZRM
-        ZOAuth -->|"ZAK + publicAppKey"| ZEC
-      end
+  <!-- Engine -->
+  <rect x="252" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(34,200,110,.5)" stroke-width="1.5"/>
+  <circle cx="270" cy="94" r="4" fill="#22c86e"/>
+  <text class="p-title" x="282" y="98">ZOOMOBSENGINE</text>
+  <text class="p-tag" x="266" y="118">ALL ZOOM SDK ACCESS &#183; CHILD PROCESS</text>
+  <rect class="chip" x="266" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="155">Zoom SDK &#183; auth / meeting / raw</text>
+  <rect class="chip" x="266" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="197">Participant + spotlight tracking</text>
+  <rect class="chip" x="266" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="239">EngineVideo &#8212; I420 &#8594; SHM</text>
+  <rect class="chip" x="266" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="281">EngineAudio &#8212; PCM &#8594; SHM</text>
+  <rect class="chip" x="266" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="323">ISO recorder &#8212; FFmpeg</text>
+  <rect class="chip" x="266" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="365">IPC loop</text>
 
-      subgraph Engine["ZoomObsEngine  (ALL SDK access)"]
-        ELoop["IPC Loop"]
-        EVid["EngineVideo\n(SHM write)"]
-        EAud["EngineAudio\n(SHM write)"]
-        EPart["Participant &amp; Spotlight\ntracking"]
-        SDK["Zoom SDK\nAuth · Meeting · Webinar · Raw data"]
-        ELoop --> EVid & EAud & EPart --> SDK
-      end
+  <!-- Plugin -->
+  <rect x="632" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="650" cy="94" r="4" fill="#e9edef"/>
+  <text class="p-title" x="662" y="98">OBS-ZOOM-PLUGIN</text>
+  <text class="p-tag" x="646" y="118">OBS MODULE &#183; NO SDK DEPENDENCY</text>
+  <rect class="chip" x="646" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="155">ZoomEngineClient &#183; singleton</text>
+  <rect class="chip" x="646" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="197">ZoomSource &#215;N &#8212; SHM read</text>
+  <rect class="chip" x="646" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="239">ZoomDock &#8212; control UI</text>
+  <rect class="chip" x="646" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="281">OAuth manager &#8212; PKCE &#183; ZAK</text>
+  <rect class="chip" x="646" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="323">Output manager &#183; reconnect</text>
+  <rect class="chip" x="646" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="365">Control APIs &#8212; TCP &#183; OSC</text>
 
-      subgraph ZoomCloud["Zoom Cloud"]
-        Mtg["Live Meeting / Webinar"]
-      end
+  <!-- OBS Studio -->
+  <rect x="972" y="199" width="152" height="150" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="990" cy="223" r="4" fill="#e9edef"/>
+  <text class="p-title" x="1002" y="227">OBS STUDIO</text>
+  <rect class="chip" x="986" y="244" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="263">Zoom sources</text>
+  <rect class="chip" x="986" y="286" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="305">Program out</text>
 
-      subgraph External["External Control"]
-        Ctrl["Script / Dashboard"]
-      end
-    end
+  <!-- External control -->
+  <rect x="632" y="506" width="280" height="64" rx="12" fill="#10151a" stroke="rgba(232,164,31,.4)" stroke-width="1.5"/>
+  <circle cx="650" cy="530" r="4" fill="#e8a41f"/>
+  <text class="p-title" x="662" y="534">EXTERNAL CONTROL</text>
+  <text class="p-tag" x="646" y="554">COMPANION &#183; SCRIPTS &#183; CONSOLES</text>
 
-    OBS -->|loads| Plugin
-    VSrc <--> ZS
-    Plugin <-->|"JSON IPC\n(named pipe / Unix socket)"| ELoop
-    EVid & EAud -->|"Named Shared Memory\nI420 frames · PCM audio"| ZS
-    SDK <-->|HTTPS/WSS| Mtg
-    Ctrl <-->|"TCP :19870\nUDP OSC :19871"| ZCS & ZOSC
-    style OBS fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Plugin fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style ZoomCloud fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style External fill:#2d2000,stroke:#d29922,color:#e6edf3
-      </div>
+  <!-- Edges -->
+  <path d="M176,274 L244,274" stroke="#8b949b" stroke-width="2" fill="none" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="210" y="252" text-anchor="middle">HTTPS</text>
+  <text class="e-sub" x="210" y="264" text-anchor="middle">/ WSS</text>
+
+  <path d="M532,250 L624,250" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="582" y="226" text-anchor="middle">SHARED MEMORY</text>
+  <text class="e-sub" x="582" y="240" text-anchor="middle">I420 &#183; PCM</text>
+
+  <path d="M540,340 L624,340" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="582" y="316" text-anchor="middle">JSON IPC</text>
+  <text class="e-sub" x="582" y="330" text-anchor="middle">pipe / socket</text>
+
+  <path d="M912,274 L964,274" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="938" y="258" text-anchor="middle">FRAMES</text>
+
+  <path d="M772,498 L772,478" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-sub" x="786" y="492" text-anchor="start">TCP :19870 &#183; UDP OSC :19871</text>
+</svg>
       <div class="diagram-caption">Fig 1 - All SDK access is in ZoomObsEngine. ZoomOAuthManager handles broker-backed OAuth PKCE, token storage, and ZAK fetches. TCP and OSC provide external control without linking the Zoom SDK into OBS.</div>
     </div>
   </section>
@@ -628,39 +658,26 @@ graph TB
       New additions: <code>ZoomDock</code> (join UI), <code>ZoomReconnectManager</code>
       (auto-reconnect), and <code>HwVideoPipeline</code> (hardware I420→NV12).
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 classDiagram
     class ZoomEngineClient {
         &lt;&lt;Singleton&gt;&gt;
-        +start(auth_token, public_app_key) / stop() / stop_for_reconnect()
-        +join(id, pass, name, kind: MeetingKind)
-        +leave()
-        +subscribe(uuid, pid, isolate_audio)
+        +start() / stop()
+        +join() / leave()
+        +subscribe(uuid, pid)
         +subscribe_spotlight(uuid, slot)
         +subscribe_screenshare(uuid)
-        +unsubscribe(uuid)
-        +state() MeetingState
-        +is_authenticated() bool
-        +active_speaker_id() uint32_t
-        +roster() vector~ParticipantInfo~
+        +state() / roster()
         +register_source(uuid, callbacks)
-        +add_roster_callback(key, cb)
     }
     class ZoomSource {
         +assignment : AssignmentMode
-        +participant_id : atomic~uint32_t~
-        +spotlight_slot : atomic~uint32_t~
-        +failover_participant_id : atomic~uint32_t~
         +resolution : VideoResolution
         +video_loss_mode : VideoLossMode
-        +hw_accel_override : int
-        +speaker_sensitivity_ms, speaker_hold_ms
-        +configure_output_ex(mode, pid, slot, failover, …)
+        +configure_output_ex(...)
         +on_engine_frame(w, h)
-        +on_engine_audio(byte_len)
-        +m_hk_active_on_id, m_hk_active_off_id
-        +m_hw_pipeline : HwVideoPipeline
+        +on_engine_audio(bytes)
     }
     class ZoomOAuthManager {
         &lt;&lt;Singleton&gt;&gt;
@@ -669,29 +686,19 @@ classDiagram
         +register_url_scheme() bool
         +refresh_access_token_blocking() bool
         +fetch_user_zak_blocking(zak) bool
-        -m_pending_state : QString
-        -m_pending_verifier : QString
     }
     class ZoomDock {
         +on_join_clicked()
         +on_leave_clicked()
         +on_cancel_recovery_clicked()
         +update_state_indicator()
-        +update_recovery_panel()
-        +update_credentials_banner()
-        -m_state_dot : CvStatusDot
-        -m_credentials_banner : CvBanner
-        -m_join_token_type : QComboBox
-        -m_output_table : QTableWidget
     }
     class ZoomReconnectManager {
         &lt;&lt;Singleton&gt;&gt;
         +set_policy(policy)
-        +store_session(auth_token, id, pass, name)
-        +trigger(reason: RecoveryReason)
-        +cancel()
-        +on_join_success() / on_join_failed(permanent)
-        +is_recovering() bool
+        +store_session(...)
+        +trigger(reason) / cancel()
+        +on_join_success() / on_join_failed()
         +next_retry_ms() int
     }
     class HwVideoPipeline {
@@ -742,23 +749,17 @@ classDiagram
       All Zoom SDK state (auth, meeting, roster, active speaker) is owned by the
       engine; the client tracks it locally by processing the event stream.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 graph TB
     subgraph Plugin["obs-zoom-plugin process"]
         ZEC["ZoomEngineClient\n★ singleton"]
         Reader["reader_loop()\n(dedicated thread)"]
-        S1["ZoomSource A\n(ShmRegion video+audio)"]
-        S2["ZoomSource B\n(ShmRegion video+audio)"]
+        S1["ZoomSource A"]
+        S2["ZoomSource B"]
         ZEC --> Reader
-        ZEC -->|"on_frame / on_audio callbacks"| S1
-        ZEC -->|"on_frame / on_audio callbacks"| S2
-    end
-
-    subgraph IPC["IPC"]
-        P2E["Plugin → Engine\njson cmds"]
-        E2P["Engine → Plugin\njson events"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        ZEC -->|"frame / audio callbacks"| S1
+        ZEC -->|"frame / audio callbacks"| S2
     end
 
     subgraph Engine["ZoomObsEngine process"]
@@ -767,14 +768,11 @@ graph TB
         SDK3 --- ETrack
     end
 
-    ZEC -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> Engine
-    Engine -- "ready · auth_ok · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> Reader
-    Engine -- "write frames" --> SHM
+    ZEC -- "commands · JSON" --> SDK3
+    SDK3 -- "events · JSON" --> Reader
+    SDK3 -- "frame write" --> SHM["Named shared memory"]
     S1 & S2 -- "mmap read" --> SHM
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 3 — ZoomEngineClient launches the engine, owns IPC channels, and dispatches callbacks to each ZoomSource.</div>
     </div>
@@ -826,35 +824,23 @@ graph TB
       Frame data flows through named shared memory to avoid copying large buffers.
       <code>ZoomEngineClient</code> in the plugin abstracts all IPC details.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-graph LR
+flowchart LR
     subgraph Plugin["obs-zoom-plugin"]
         ZEC2["ZoomEngineClient"]
-        SHM_R["ZoomSource\nShmRegion (mmap read)"]
-    end
-
-    subgraph IPC["IPC Channels"]
-        P2E["Plugin → Engine\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        E2P["Engine → Plugin\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        SHM_R["ZoomSource\nSHM read (mmap)"]
     end
 
     subgraph Engine["ZoomObsEngine"]
-        ELoop["IPC Loop\n+ reader_loop"]
-        EVid["EngineVideo"]
-        EAud["EngineAudio"]
-        SDK2["Zoom SDK\n(all SDK access)"]
-        ELoop --> EVid & EAud --> SDK2
+        ELoop["IPC loop"]
+        EMed["EngineVideo · EngineAudio"]
     end
 
-    ZEC2 -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> ELoop
-    ELoop -- "ready · auth_ok · auth_fail · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> ZEC2
-    EVid & EAud -- "write I420 + PCM" --> SHM --> SHM_R
+    ZEC2 -- "commands · JSON" --> ELoop
+    ELoop -- "events · JSON" --> ZEC2
+    EMed -- "I420 + PCM" --> SHM["Named shared memory"] --> SHM_R
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 4 — Cross-platform IPC: JSON over named pipes (Windows) or Unix sockets (macOS/Linux); frames through shared memory.</div>
     </div>
@@ -867,9 +853,9 @@ graph LR
 
   <section id="arch-video">
     <h2>Architecture: Video Pipeline</h2>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     CAM["Participant\nCamera"] --> ZC["Zoom Cloud"]
     ZC -->|decoded I420| EV["Engine EngineVideo\n(IZoomSDKRenderer)"]
     EV -->|"write I420 to\nShmRegion"| SHM2["Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
@@ -878,14 +864,6 @@ flowchart LR
     ZS5 -->|"VideoLossMode:\nLastFrame / Black"| LOSS["Loss handling"]
     LOSS -->|"I420 planar\nPreviewCallback ≤5fps"| OBS_V["OBS Video\nobs_source_output_video()"]
 
-    style CAM fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EV fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM2 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC3 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZS5 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style LOSS fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style OBS_V fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 5 — Video path: engine writes I420 to shared memory; ZoomSource reads via ShmRegion and forwards to OBS.</div>
     </div>
@@ -909,7 +887,7 @@ flowchart LR
       pushes it to OBS. Stereo sources use an internal <code>m_stereo_buf</code> to
       interleave channels before output.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart TB
     SDK4["Zoom SDK\n(inside engine)"]
@@ -922,10 +900,6 @@ flowchart TB
 
     ZS6 -->|"Mono: direct S16\nStereo: interleaved"| OBS_A["OBS Audio\nobs_source_output_audio()"]
 
-    style SDK4 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EAud2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM3 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZS6 fill:#0d2137,stroke:#22c86e,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 6 — Audio pipeline: engine mixes/isolates audio in-process and delivers chunks through shared memory.</div>
     </div>
@@ -949,9 +923,9 @@ flowchart TB
       <code>frame</code> events on the share source UUID and forwards them to OBS
       exactly like participant video.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     SC2["Screen Share\nIn Meeting"] --> ZC3["Zoom Cloud"]
     ZC3 -->|onSharingStatus| EShare["Engine\nShareDelegate\n(inside ZoomObsEngine)"]
     EShare -->|subscribe share renderer| Rnd["IZoomSDKRenderer"]
@@ -959,12 +933,6 @@ flowchart LR
     SHM4 -->|"frame event"| ZEC4["ZoomEngineClient\n→ ZoomSource (share)"]
     ZEC4 -->|obs_source_output_video| OBS_SS["OBS Zoom\nShare Source"]
 
-    style SC2 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC3 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EShare fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM4 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC4 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style OBS_SS fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 7 — Screen share: engine-side delegate writes I420 to shared memory; plugin receives via ZoomEngineClient frame callback.</div>
     </div>
@@ -981,7 +949,7 @@ flowchart LR
       the helper with <code>AuthContext.publicAppKey</code>. The engine is not
       started on module load; it is launched the first time a join is requested.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant OBS as OBS Studio
@@ -997,7 +965,7 @@ sequenceDiagram
     PM->>ZOA2: load OAuth tokens and broker URL
     PM->>ZoomControlServer: start(control_server_port)
     PM->>ZoomOscServer: start(osc_server_port)
-    PM->>ZDock: ensure_zoom_dock() [after OBS_FRONTEND_EVENT_FINISHED_LOADING]
+    PM->>ZDock: ensure_zoom_dock() after frontend loaded
 
     Note over ZDock: User clicks Join or API sends join cmd
 
@@ -1067,7 +1035,7 @@ sequenceDiagram
     </div>
 
     <h3>Authorization Flow</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant User
@@ -1085,17 +1053,17 @@ sequenceDiagram
     ZOA->>Browser: QDesktopServices::openUrl(/oauth/start?state=…)
     Browser->>Broker2: GET /oauth/start
     Broker2->>Broker2: generate PKCE verifier/challenge
-    Broker2->>ZoomCloud2: redirect to /v2/authorize?client_id=…&code_challenge=…
+    Broker2->>ZoomCloud2: redirect → /v2/authorize (PKCE)
     ZoomCloud2-->>Browser: consent screen
     User->>Browser: approve
     ZoomCloud2-->>Broker2: redirect to /oauth/callback?code=…&state=…
-    Broker2-->>Browser: redirect to corevideo://oauth/callback?broker_token=…&state=…
-    Browser->>Helper: launch CoreVideoOAuthCallback (Windows: .exe / macOS: .app)
-    Helper->>ZCS2: POST {"cmd":"oauth_callback","url":"corevideo://oauth/callback?broker_token=…&state=…"}
+    Broker2-->>Browser: redirect → corevideo://oauth/callback
+    Browser->>Helper: launch CoreVideoOAuthCallback helper
+    Helper->>ZCS2: POST {"cmd":"oauth_callback", url}
     ZCS2->>ZOA: handle_redirect_url(url)
     ZOA->>ZOA: verify state matches m_pending_state
     ZOA->>Broker2: POST /oauth/redeem broker_token=…
-    Broker2->>ZoomCloud2: POST /oauth/token client_id + code_verifier, no secret
+    Broker2->>ZoomCloud2: POST /oauth/token (PKCE, no secret)
     Broker2-->>ZOA: {access_token, refresh_token, expires_in}
     ZOA->>ZOA: store tokens (DPAPI on Windows)
     Note over ZOA: Ready to fetch ZAK on next join
@@ -1104,7 +1072,7 @@ sequenceDiagram
     </div>
 
     <h3>ZAK Fetch and publicAppKey SDK Auth (before each join)</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZDock4 as ZoomDock
@@ -1114,12 +1082,12 @@ sequenceDiagram
     participant ZEC8 as ZoomEngineClient
 
     ZDock4->>ZOA2: fetch_user_zak_blocking(zak)
-    ZOA2->>ZOA2: check token expiry\nrefresh_access_token_blocking() if expired
-    ZOA2->>ZoomAPI: GET /v2/users/me/token?type=zak\nAuthorization: Bearer {access_token}
+    ZOA2->>ZOA2: refresh access token if expired
+    ZOA2->>ZoomAPI: GET /users/me/token?type=zak
     ZoomAPI-->>ZOA2: signed-in user ZAK
     ZOA2-->>ZDock4: zak string
-    ZDock4->>ZEC8: start(public_app_key), then join(id, pass, name, kind, zak)
-    ZEC8->>Engine: {"cmd":"init","public_app_key":"…"} then {"cmd":"join","meeting_id":"…","user_zak":"…"}
+    ZDock4->>ZEC8: start(publicAppKey) → join(…, zak)
+    ZEC8->>Engine: {"cmd":"init"} then {"cmd":"join"}
       </div>
       <div class="diagram-caption">Fig 8c - A user ZAK is fetched before each join using the stored OAuth access token; token refresh is automatic when expired.</div>
     </div>
@@ -1149,7 +1117,7 @@ sequenceDiagram
       Joining is centralized in <code>ZoomDock</code> (or the TCP/OSC control APIs) —
       not in individual sources. Sources subscribe to the already-joined meeting.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant U as User / Control API
@@ -1159,23 +1127,23 @@ sequenceDiagram
     participant ZS3 as ZoomSource
     participant Engine as ZoomObsEngine
 
-    U->>ZDock2: click Join (meeting_id, passcode, display_name, [webinar])
+    U->>ZDock2: click Join
     ZDock2->>ZRM2: store_session(auth_token, id, pass, name)
-    ZDock2->>ZEC6: start(public_app_key) [launches engine if not running]
+    ZDock2->>ZEC6: start() — launch engine if needed
     ZDock2->>ZEC6: join(id, pass, name, kind=Meeting|Webinar)
-    ZEC6->>Engine: {"cmd":"join","meeting_id":"…","kind":"meeting|webinar"}
+    ZEC6->>Engine: {"cmd":"join", kind}
     Engine-->>ZEC6: {"cmd":"joined"}
     ZEC6-->>ZRM2: on_join_success()
 
     Note over ZS3: ZoomSource.activate() when OBS activates source
 
-    ZS3->>ZEC6: subscribe(uuid, pid, isolate) OR subscribe_spotlight(uuid, slot)
-    ZEC6->>Engine: {"cmd":"subscribe","source_uuid":"…","participant_id":N}
+    ZS3->>ZEC6: subscribe() / subscribe_spotlight()
+    ZEC6->>Engine: {"cmd":"subscribe", uuid, pid}
 
     loop Live capture
         Engine-->>ZEC6: {"cmd":"frame","uuid":"…","w":W,"h":H}
         ZEC6-->>ZS3: on_engine_frame(w, h)
-        ZS3->>ZS3: read I420 from video shm, process with HwVideoPipeline if enabled
+        ZS3->>ZS3: read I420 from SHM (+HW pipeline)
         ZS3->>OBS: obs_source_output_video()
         Engine-->>ZEC6: {"cmd":"audio","uuid":"…","byte_len":B}
         ZEC6-->>ZS3: on_engine_audio(byte_len)
@@ -1259,7 +1227,7 @@ sequenceDiagram
       This mirrors the ZoomISO "Spotlight 1/2/3" output model.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart LR
     subgraph Source["ZoomSource (AssignmentMode)"]
@@ -1276,9 +1244,6 @@ flowchart LR
 
     ZEC7 -->|JSON IPC| Engine2["ZoomObsEngine\n(resolves → SDK renderer)"]
 
-    style Source fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZEC7 fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
       </div>
       <div class="diagram-caption">Assignment modes map to different ZoomEngineClient subscribe calls; the engine resolves each to the correct SDK renderer.</div>
     </div>
@@ -1328,7 +1293,7 @@ flowchart LR
       <code>obs_queue_task(OBS_TASK_UI, …)</code> to re-evaluate on the OBS UI thread.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 stateDiagram-v2
     [*] --> Idle : active_speaker_mode = off
@@ -1360,7 +1325,7 @@ stateDiagram-v2
     </div>
 
     <h3>Switch Sequence</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZP as ZoomEngineClient\n(roster_callback)
@@ -1369,8 +1334,8 @@ sequenceDiagram
     participant UI as OBS UI Thread
     participant VD as VideoDelegate
 
-    ZP-->>ZS4: roster callback\n(active_speaker_id from engine event = X)
-    ZS4->>ZS4: on_active_speaker_changed()\npending = X, candidate_since = now
+    ZP-->>ZS4: roster callback: active_speaker = X
+    ZS4->>ZS4: pending = X, start hold timer
 
     alt delay == 0
         ZS4->>ZS4: do_speaker_switch(X)
@@ -1529,7 +1494,7 @@ sequenceDiagram
       position in OBS. It is the primary UI for meeting management.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-obs-workspace.svg" alt="CoreVideo OBS workspace with Zoom Control dock" style="max-width:100%;height:auto;">
       <div class="diagram-caption">CoreVideo runs as normal OBS UI: the Zoom Control dock manages meeting state and raw media while Zoom Participant sources render inside OBS scenes.</div>
     </div>
@@ -1731,7 +1696,7 @@ sequenceDiagram
       <tr><td><code>ZoomOutputProfile::remove(name)</code></td><td>Deletes profile JSON file</td></tr>
     </table>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-output-manager.svg" alt="CoreVideo Output Manager with participant and output mapping" style="max-width:100%;height:auto;">
       <div class="diagram-caption">The Output Manager mirrors the dock assignment controls and remains useful for named profile save/load workflows.</div>
     </div>
@@ -1820,7 +1785,7 @@ sequenceDiagram
     </table>
 
     <h3>Zoom Participant Source Properties</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-source-properties.svg" alt="CoreVideo Zoom Participant source properties" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Each Zoom Participant source keeps its own assignment mode, audio routing, requested resolution, and failover behavior.</div>
     </div>
@@ -1887,7 +1852,7 @@ sequenceDiagram
       state in the panel and TCP status payload.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/iso-recording-flow.svg" alt="CoreVideo ISO recording flow" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Assignments resolve the participant IDs. Each assigned Zoom source can feed an FFmpeg writer for video/audio ISO files while OBS continues to own the program output.</div>
     </div>
@@ -1980,27 +1945,38 @@ sequenceDiagram
 </main>
 
 <script>
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
   mermaid.initialize({
     startOnLoad: true,
-    theme: 'dark',
+    theme: 'base',
     themeVariables: {
       darkMode: true,
-      background: '#0d1117',
-      mainBkg: '#1e2a35', primaryColor: '#1e2a35', primaryTextColor: '#eaf2f6',
-      primaryBorderColor: '#2fd07f', nodeBorder: '#2fd07f',
-      secondaryColor: '#26313c', tertiaryColor: '#1a222b',
-      lineColor: '#aeb7bf', textColor: '#eaf2f6', nodeTextColor: '#eaf2f6',
-      edgeLabelBackground: '#0d1117', clusterBkg: '#161d25', clusterBorder: '#3a4650', titleColor: '#eaf2f6',
-      actorBkg: '#1e2a35', actorBorder: '#2fd07f', actorTextColor: '#ffffff',
-      actorLineColor: '#aeb7bf', signalColor: '#aeb7bf', signalTextColor: '#eaf2f6',
-      noteBkgColor: '#2a3742', noteTextColor: '#eaf2f6', noteBorderColor: '#4a5762',
-      activationBorderColor: '#2fd07f', activationBkgColor: '#183a2a',
-      sequenceNumberColor: '#0d1117', labelBoxBkgColor: '#1e2a35',
-      labelBoxBorderColor: '#4a5762', labelTextColor: '#eaf2f6', loopTextColor: '#eaf2f6',
-      fontFamily: 'Space Grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     },
-    flowchart: { curve: 'basis', htmlLabels: true },
-    sequence: { actorMargin: 60, messageMargin: 30 },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
   });
 
   const sections = document.querySelectorAll('section[id]');

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -41,18 +41,17 @@
 
     #sidebar {
       position: fixed; top: 52px; left: 0; bottom: 0; width: 260px;
-      background: var(--surface); border-right: 1px solid var(--border);
-      padding: 24px 0; overflow-y: auto; z-index: 100;
+      background: var(--bg); border-right: 1px solid var(--border);
+      padding: 18px 0 32px; overflow-y: auto; z-index: 100;
     }
-    .nav-logo { padding: 0 20px 20px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-    .nav-logo h1 { font-size: 1.1rem; color: var(--accent); font-weight: 700; }
-    .nav-logo p  { font-size: 0.75rem; color: var(--muted); margin-top: 2px; }
     #sidebar a {
-      display: block; padding: 7px 20px; color: var(--muted); text-decoration: none;
-      font-size: 0.95rem; border-left: 2px solid transparent; transition: all 0.15s;
+      display: block; padding: 6px 20px; color: var(--muted); text-decoration: none;
+      font-size: 0.88rem; border-left: 2px solid transparent; transition: color .15s, background .15s, border-color .15s;
     }
-    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.1); }
-    .nav-section { padding: 14px 20px 4px; font-size: 0.78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); }
+    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.08); }
+    .nav-section { padding: 18px 20px 6px; font-family: "IBM Plex Mono", ui-monospace, monospace;
+      font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: .14em; color: #77828a; }
+    .nav-section-first { padding-top: 4px; }
     main { margin-left: 260px; max-width: 960px; padding: 48px 56px; }
     section[id] { scroll-margin-top: 72px; }
 
@@ -116,12 +115,16 @@
     .card h4 { margin: 0 0 6px; font-size: 0.9rem; }
     .card p { font-size: 0.8rem; color: var(--muted); margin: 0; }
 
+    .diagram-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     .diagram-wrap {
       background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
-      padding: 28px; margin: 20px 0; overflow-x: auto;
+      padding: 24px; margin: 20px 0; overflow-x: auto;
     }
-    .diagram-wrap .mermaid { display: flex; justify-content: center; }
-    .diagram-caption { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 12px; font-style: italic; }
+    .diagram-wrap .mermaid { display: flex; justify-content: safe center; min-width: min-content; }
+    .diagram-wrap .mermaid svg { max-width: none; }
+    .diagram-wrap > svg.arch { display: block; width: 100%; height: auto; min-width: 720px; }
+    .diagram-caption { font-size: 0.85rem; color: var(--muted); text-align: center; margin-top: 14px;
+      font-family: "IBM Plex Mono", ui-monospace, monospace; }
 
     table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.875rem; }
     th { background: #16191b; border: 1px solid var(--border); padding: 10px 14px; text-align: left; font-weight: 600; color: var(--muted); }
@@ -146,9 +149,16 @@
 
     section { scroll-margin-top: 24px; }
 
-    @media (max-width: 768px) {
-      #sidebar { display: none; }
-      main { margin-left: 0; padding: 24px 20px; }
+    @media (max-width: 960px) {
+      /* Sidebar becomes a horizontal on-page index instead of disappearing. */
+      #sidebar { position: static; width: auto; bottom: auto; display: flex; align-items: center;
+        overflow-x: auto; white-space: nowrap; padding: 10px 12px; gap: 2px;
+        border-right: none; border-bottom: 1px solid var(--border); }
+      .nav-section { padding: 0 6px 0 14px; }
+      .nav-section-first { padding-left: 6px; }
+      #sidebar a { padding: 6px 10px; border-left: none; border-radius: 6px; font-size: 0.82rem; }
+      #sidebar a:hover, #sidebar a.active { background: rgba(34,200,110,.12); }
+      main { margin-left: 0; padding: 28px 20px; }
       .site-topbar { flex-direction: column; align-items: flex-start; gap: 10px; }
       .site-topbar .topnav { justify-content: flex-start; }
       main > footer { margin-left: 0 !important; }
@@ -173,12 +183,8 @@
   </nav>
 </header>
 
-<nav id="sidebar">
-  <div class="nav-logo">
-    <h1>📹 CoreVideo</h1>
-    <p>OBS Plugin for Live Zoom Video</p>
-  </div>
-  <div class="nav-section">Overview</div>
+<nav id="sidebar" aria-label="On this page">
+  <div class="nav-section nav-section-first">Overview</div>
   <a href="#overview">Introduction</a>
   <a href="#features">Features</a>
   <div class="nav-section">Get Started</div>
@@ -557,65 +563,89 @@
       which feed they subscribe to: a fixed participant, the active speaker, a
       spotlight slot, or the active screen share.
     </p>
-    <div class="diagram-wrap">
-      <div class="mermaid">
-graph TB
-    subgraph Machine["User's Machine"]
-      subgraph OBS["OBS Studio"]
-        Canvas["Canvas / Output"]
-        VSrc["Zoom Participant\nSource"]
-        Canvas --> VSrc
-      end
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
+      <svg class="arch" viewBox="0 0 1140 600" role="img" aria-labelledby="fig1-t fig1-d" xmlns="http://www.w3.org/2000/svg">
+  <title id="fig1-t">CoreVideo system overview</title>
+  <desc id="fig1-d">Zoom Cloud feeds the ZoomObsEngine child process over HTTPS/WSS. The engine owns all Zoom SDK access and writes I420 video and PCM audio into shared memory, which the obs-zoom-plugin reads and hands to OBS Studio sources. Plugin and engine exchange JSON IPC over a named pipe or Unix socket. External controllers reach the plugin over TCP 19870 and OSC 19871.</desc>
+  <defs>
+    <marker id="ar-g" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#22c86e"/></marker>
+    <marker id="ar-n" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#8b949b"/></marker>
+    <marker id="ar-nr" markerWidth="9" markerHeight="8" refX="0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M8,0 L8,6 L0,3 z" fill="#8b949b"/></marker>
+  </defs>
+  <style>
+    .p-title { font: 700 13px "Space Grotesk", sans-serif; letter-spacing: .1em; fill: #e9edef; }
+    .p-tag   { font: 400 9.5px "IBM Plex Mono", monospace; letter-spacing: .06em; fill: #77828a; }
+    .chip    { fill: #1a2025; stroke: #2c343b; }
+    .c-txt   { font: 400 12px "IBM Plex Mono", monospace; fill: #dbe3e8; }
+    .e-lab   { font: 600 11px "IBM Plex Mono", monospace; letter-spacing: .08em; fill: #8b949b; }
+    .e-lab.g { fill: #4fd88f; }
+    .e-sub   { font: 400 10px "IBM Plex Mono", monospace; fill: #6d777d; }
+  </style>
 
-      subgraph Plugin["obs-zoom-plugin  (no SDK dependency)"]
-        ZDock["ZoomDock\n(Control UI · CvStatusDot · CvBanner)"]
-        ZEC["ZoomEngineClient\n★ central singleton"]
-        ZRM["ZoomReconnectManager\n(auto-reconnect)"]
-        ZOAuth["ZoomOAuthManager\n(OAuth broker · ZAK fetch · DPAPI)"]
-        ZS["ZoomSource\n(ShmRegion · AssignmentMode)"]
-        ZOM["ZoomOutputManager"]
-        ZCS["ZoomControlServer :19870"]
-        ZOSC["ZoomOscServer :19871"]
+  <!-- Zoom Cloud -->
+  <rect x="16" y="210" width="160" height="128" rx="12" fill="#10151a" stroke="rgba(188,140,255,.38)" stroke-width="1.5"/>
+  <circle cx="34" cy="234" r="4" fill="#bc8cff"/>
+  <text class="p-title" x="46" y="238">ZOOM CLOUD</text>
+  <text class="p-tag" x="30" y="258">RAW A/V SOURCE</text>
+  <rect class="chip" x="30" y="274" width="132" height="30" rx="7"/>
+  <text class="c-txt" x="42" y="293">Live meeting</text>
 
-        ZDock --> ZEC
-        ZDock --> ZOAuth
-        ZRM --> ZEC
-        ZEC --> ZS
-        ZCS & ZOSC --> ZOM & ZEC
-        ZEC --> ZRM
-        ZOAuth -->|"ZAK + publicAppKey"| ZEC
-      end
+  <!-- Engine -->
+  <rect x="252" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(34,200,110,.5)" stroke-width="1.5"/>
+  <circle cx="270" cy="94" r="4" fill="#22c86e"/>
+  <text class="p-title" x="282" y="98">ZOOMOBSENGINE</text>
+  <text class="p-tag" x="266" y="118">ALL ZOOM SDK ACCESS &#183; CHILD PROCESS</text>
+  <rect class="chip" x="266" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="155">Zoom SDK &#183; auth / meeting / raw</text>
+  <rect class="chip" x="266" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="197">Participant + spotlight tracking</text>
+  <rect class="chip" x="266" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="239">EngineVideo &#8212; I420 &#8594; SHM</text>
+  <rect class="chip" x="266" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="281">EngineAudio &#8212; PCM &#8594; SHM</text>
+  <rect class="chip" x="266" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="323">ISO recorder &#8212; FFmpeg</text>
+  <rect class="chip" x="266" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="365">IPC loop</text>
 
-      subgraph Engine["ZoomObsEngine  (ALL SDK access)"]
-        ELoop["IPC Loop"]
-        EVid["EngineVideo\n(SHM write)"]
-        EAud["EngineAudio\n(SHM write)"]
-        EPart["Participant &amp; Spotlight\ntracking"]
-        SDK["Zoom SDK\nAuth · Meeting · Webinar · Raw data"]
-        ELoop --> EVid & EAud & EPart --> SDK
-      end
+  <!-- Plugin -->
+  <rect x="632" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="650" cy="94" r="4" fill="#e9edef"/>
+  <text class="p-title" x="662" y="98">OBS-ZOOM-PLUGIN</text>
+  <text class="p-tag" x="646" y="118">OBS MODULE &#183; NO SDK DEPENDENCY</text>
+  <rect class="chip" x="646" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="155">ZoomEngineClient &#183; singleton</text>
+  <rect class="chip" x="646" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="197">ZoomSource &#215;N &#8212; SHM read</text>
+  <rect class="chip" x="646" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="239">ZoomDock &#8212; control UI</text>
+  <rect class="chip" x="646" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="281">OAuth manager &#8212; PKCE &#183; ZAK</text>
+  <rect class="chip" x="646" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="323">Output manager &#183; reconnect</text>
+  <rect class="chip" x="646" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="365">Control APIs &#8212; TCP &#183; OSC</text>
 
-      subgraph ZoomCloud["Zoom Cloud"]
-        Mtg["Live Meeting / Webinar"]
-      end
+  <!-- OBS Studio -->
+  <rect x="972" y="199" width="152" height="150" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="990" cy="223" r="4" fill="#e9edef"/>
+  <text class="p-title" x="1002" y="227">OBS STUDIO</text>
+  <rect class="chip" x="986" y="244" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="263">Zoom sources</text>
+  <rect class="chip" x="986" y="286" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="305">Program out</text>
 
-      subgraph External["External Control"]
-        Ctrl["Script / Dashboard"]
-      end
-    end
+  <!-- External control -->
+  <rect x="632" y="506" width="280" height="64" rx="12" fill="#10151a" stroke="rgba(232,164,31,.4)" stroke-width="1.5"/>
+  <circle cx="650" cy="530" r="4" fill="#e8a41f"/>
+  <text class="p-title" x="662" y="534">EXTERNAL CONTROL</text>
+  <text class="p-tag" x="646" y="554">COMPANION &#183; SCRIPTS &#183; CONSOLES</text>
 
-    OBS -->|loads| Plugin
-    VSrc <--> ZS
-    Plugin <-->|"JSON IPC\n(named pipe / Unix socket)"| ELoop
-    EVid & EAud -->|"Named Shared Memory\nI420 frames · PCM audio"| ZS
-    SDK <-->|HTTPS/WSS| Mtg
-    Ctrl <-->|"TCP :19870\nUDP OSC :19871"| ZCS & ZOSC
-    style OBS fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Plugin fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style ZoomCloud fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style External fill:#2d2000,stroke:#d29922,color:#e6edf3
-      </div>
+  <!-- Edges -->
+  <path d="M176,274 L244,274" stroke="#8b949b" stroke-width="2" fill="none" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="210" y="252" text-anchor="middle">HTTPS</text>
+  <text class="e-sub" x="210" y="264" text-anchor="middle">/ WSS</text>
+
+  <path d="M532,250 L624,250" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="582" y="226" text-anchor="middle">SHARED MEMORY</text>
+  <text class="e-sub" x="582" y="240" text-anchor="middle">I420 &#183; PCM</text>
+
+  <path d="M540,340 L624,340" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="582" y="316" text-anchor="middle">JSON IPC</text>
+  <text class="e-sub" x="582" y="330" text-anchor="middle">pipe / socket</text>
+
+  <path d="M912,274 L964,274" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="938" y="258" text-anchor="middle">FRAMES</text>
+
+  <path d="M772,498 L772,478" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-sub" x="786" y="492" text-anchor="start">TCP :19870 &#183; UDP OSC :19871</text>
+</svg>
       <div class="diagram-caption">Fig 1 - All SDK access is in ZoomObsEngine. ZoomOAuthManager handles broker-backed OAuth PKCE, token storage, and ZAK fetches. TCP and OSC provide external control without linking the Zoom SDK into OBS.</div>
     </div>
   </section>
@@ -629,39 +659,26 @@ graph TB
       New additions: <code>ZoomDock</code> (join UI), <code>ZoomReconnectManager</code>
       (auto-reconnect), and <code>HwVideoPipeline</code> (hardware I420→NV12).
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 classDiagram
     class ZoomEngineClient {
         &lt;&lt;Singleton&gt;&gt;
-        +start(auth_token, public_app_key) / stop() / stop_for_reconnect()
-        +join(id, pass, name, kind: MeetingKind)
-        +leave()
-        +subscribe(uuid, pid, isolate_audio)
+        +start() / stop()
+        +join() / leave()
+        +subscribe(uuid, pid)
         +subscribe_spotlight(uuid, slot)
         +subscribe_screenshare(uuid)
-        +unsubscribe(uuid)
-        +state() MeetingState
-        +is_authenticated() bool
-        +active_speaker_id() uint32_t
-        +roster() vector~ParticipantInfo~
+        +state() / roster()
         +register_source(uuid, callbacks)
-        +add_roster_callback(key, cb)
     }
     class ZoomSource {
         +assignment : AssignmentMode
-        +participant_id : atomic~uint32_t~
-        +spotlight_slot : atomic~uint32_t~
-        +failover_participant_id : atomic~uint32_t~
         +resolution : VideoResolution
         +video_loss_mode : VideoLossMode
-        +hw_accel_override : int
-        +speaker_sensitivity_ms, speaker_hold_ms
-        +configure_output_ex(mode, pid, slot, failover, …)
+        +configure_output_ex(...)
         +on_engine_frame(w, h)
-        +on_engine_audio(byte_len)
-        +m_hk_active_on_id, m_hk_active_off_id
-        +m_hw_pipeline : HwVideoPipeline
+        +on_engine_audio(bytes)
     }
     class ZoomOAuthManager {
         &lt;&lt;Singleton&gt;&gt;
@@ -670,29 +687,19 @@ classDiagram
         +register_url_scheme() bool
         +refresh_access_token_blocking() bool
         +fetch_user_zak_blocking(zak) bool
-        -m_pending_state : QString
-        -m_pending_verifier : QString
     }
     class ZoomDock {
         +on_join_clicked()
         +on_leave_clicked()
         +on_cancel_recovery_clicked()
         +update_state_indicator()
-        +update_recovery_panel()
-        +update_credentials_banner()
-        -m_state_dot : CvStatusDot
-        -m_credentials_banner : CvBanner
-        -m_join_token_type : QComboBox
-        -m_output_table : QTableWidget
     }
     class ZoomReconnectManager {
         &lt;&lt;Singleton&gt;&gt;
         +set_policy(policy)
-        +store_session(auth_token, id, pass, name)
-        +trigger(reason: RecoveryReason)
-        +cancel()
-        +on_join_success() / on_join_failed(permanent)
-        +is_recovering() bool
+        +store_session(...)
+        +trigger(reason) / cancel()
+        +on_join_success() / on_join_failed()
         +next_retry_ms() int
     }
     class HwVideoPipeline {
@@ -743,23 +750,17 @@ classDiagram
       All Zoom SDK state (auth, meeting, roster, active speaker) is owned by the
       engine; the client tracks it locally by processing the event stream.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 graph TB
     subgraph Plugin["obs-zoom-plugin process"]
         ZEC["ZoomEngineClient\n★ singleton"]
         Reader["reader_loop()\n(dedicated thread)"]
-        S1["ZoomSource A\n(ShmRegion video+audio)"]
-        S2["ZoomSource B\n(ShmRegion video+audio)"]
+        S1["ZoomSource A"]
+        S2["ZoomSource B"]
         ZEC --> Reader
-        ZEC -->|"on_frame / on_audio callbacks"| S1
-        ZEC -->|"on_frame / on_audio callbacks"| S2
-    end
-
-    subgraph IPC["IPC"]
-        P2E["Plugin → Engine\njson cmds"]
-        E2P["Engine → Plugin\njson events"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        ZEC -->|"frame / audio callbacks"| S1
+        ZEC -->|"frame / audio callbacks"| S2
     end
 
     subgraph Engine["ZoomObsEngine process"]
@@ -768,14 +769,11 @@ graph TB
         SDK3 --- ETrack
     end
 
-    ZEC -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> Engine
-    Engine -- "ready · auth_ok · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> Reader
-    Engine -- "write frames" --> SHM
+    ZEC -- "commands · JSON" --> SDK3
+    SDK3 -- "events · JSON" --> Reader
+    SDK3 -- "frame write" --> SHM["Named shared memory"]
     S1 & S2 -- "mmap read" --> SHM
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 3 — ZoomEngineClient launches the engine, owns IPC channels, and dispatches callbacks to each ZoomSource.</div>
     </div>
@@ -827,35 +825,23 @@ graph TB
       Frame data flows through named shared memory to avoid copying large buffers.
       <code>ZoomEngineClient</code> in the plugin abstracts all IPC details.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-graph LR
+flowchart LR
     subgraph Plugin["obs-zoom-plugin"]
         ZEC2["ZoomEngineClient"]
-        SHM_R["ZoomSource\nShmRegion (mmap read)"]
-    end
-
-    subgraph IPC["IPC Channels"]
-        P2E["Plugin → Engine\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        E2P["Engine → Plugin\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        SHM_R["ZoomSource\nSHM read (mmap)"]
     end
 
     subgraph Engine["ZoomObsEngine"]
-        ELoop["IPC Loop\n+ reader_loop"]
-        EVid["EngineVideo"]
-        EAud["EngineAudio"]
-        SDK2["Zoom SDK\n(all SDK access)"]
-        ELoop --> EVid & EAud --> SDK2
+        ELoop["IPC loop"]
+        EMed["EngineVideo · EngineAudio"]
     end
 
-    ZEC2 -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> ELoop
-    ELoop -- "ready · auth_ok · auth_fail · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> ZEC2
-    EVid & EAud -- "write I420 + PCM" --> SHM --> SHM_R
+    ZEC2 -- "commands · JSON" --> ELoop
+    ELoop -- "events · JSON" --> ZEC2
+    EMed -- "I420 + PCM" --> SHM["Named shared memory"] --> SHM_R
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 4 — Cross-platform IPC: JSON over named pipes (Windows) or Unix sockets (macOS/Linux); frames through shared memory.</div>
     </div>
@@ -868,9 +854,9 @@ graph LR
 
   <section id="arch-video">
     <h2>Architecture: Video Pipeline</h2>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     CAM["Participant\nCamera"] --> ZC["Zoom Cloud"]
     ZC -->|decoded I420| EV["Engine EngineVideo\n(IZoomSDKRenderer)"]
     EV -->|"write I420 to\nShmRegion"| SHM2["Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
@@ -879,14 +865,6 @@ flowchart LR
     ZS5 -->|"VideoLossMode:\nLastFrame / Black"| LOSS["Loss handling"]
     LOSS -->|"I420 planar\nPreviewCallback ≤5fps"| OBS_V["OBS Video\nobs_source_output_video()"]
 
-    style CAM fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EV fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM2 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC3 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZS5 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style LOSS fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style OBS_V fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 5 — Video path: engine writes I420 to shared memory; ZoomSource reads via ShmRegion and forwards to OBS.</div>
     </div>
@@ -910,7 +888,7 @@ flowchart LR
       pushes it to OBS. Stereo sources use an internal <code>m_stereo_buf</code> to
       interleave channels before output.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart TB
     SDK4["Zoom SDK\n(inside engine)"]
@@ -923,10 +901,6 @@ flowchart TB
 
     ZS6 -->|"Mono: direct S16\nStereo: interleaved"| OBS_A["OBS Audio\nobs_source_output_audio()"]
 
-    style SDK4 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EAud2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM3 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZS6 fill:#0d2137,stroke:#22c86e,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 6 — Audio pipeline: engine mixes/isolates audio in-process and delivers chunks through shared memory.</div>
     </div>
@@ -950,9 +924,9 @@ flowchart TB
       <code>frame</code> events on the share source UUID and forwards them to OBS
       exactly like participant video.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     SC2["Screen Share\nIn Meeting"] --> ZC3["Zoom Cloud"]
     ZC3 -->|onSharingStatus| EShare["Engine\nShareDelegate\n(inside ZoomObsEngine)"]
     EShare -->|subscribe share renderer| Rnd["IZoomSDKRenderer"]
@@ -960,12 +934,6 @@ flowchart LR
     SHM4 -->|"frame event"| ZEC4["ZoomEngineClient\n→ ZoomSource (share)"]
     ZEC4 -->|obs_source_output_video| OBS_SS["OBS Zoom\nShare Source"]
 
-    style SC2 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC3 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EShare fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM4 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC4 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style OBS_SS fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 7 — Screen share: engine-side delegate writes I420 to shared memory; plugin receives via ZoomEngineClient frame callback.</div>
     </div>
@@ -982,7 +950,7 @@ flowchart LR
       the helper with <code>AuthContext.publicAppKey</code>. The engine is not
       started on module load; it is launched the first time a join is requested.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant OBS as OBS Studio
@@ -998,7 +966,7 @@ sequenceDiagram
     PM->>ZOA2: load OAuth tokens and broker URL
     PM->>ZoomControlServer: start(control_server_port)
     PM->>ZoomOscServer: start(osc_server_port)
-    PM->>ZDock: ensure_zoom_dock() [after OBS_FRONTEND_EVENT_FINISHED_LOADING]
+    PM->>ZDock: ensure_zoom_dock() after frontend loaded
 
     Note over ZDock: User clicks Join or API sends join cmd
 
@@ -1068,7 +1036,7 @@ sequenceDiagram
     </div>
 
     <h3>Authorization Flow</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant User
@@ -1086,17 +1054,17 @@ sequenceDiagram
     ZOA->>Browser: QDesktopServices::openUrl(/oauth/start?state=…)
     Browser->>Broker2: GET /oauth/start
     Broker2->>Broker2: generate PKCE verifier/challenge
-    Broker2->>ZoomCloud2: redirect to /v2/authorize?client_id=…&code_challenge=…
+    Broker2->>ZoomCloud2: redirect → /v2/authorize (PKCE)
     ZoomCloud2-->>Browser: consent screen
     User->>Browser: approve
     ZoomCloud2-->>Broker2: redirect to /oauth/callback?code=…&state=…
-    Broker2-->>Browser: redirect to corevideo://oauth/callback?broker_token=…&state=…
-    Browser->>Helper: launch CoreVideoOAuthCallback (Windows: .exe / macOS: .app)
-    Helper->>ZCS2: POST {"cmd":"oauth_callback","url":"corevideo://oauth/callback?broker_token=…&state=…"}
+    Broker2-->>Browser: redirect → corevideo://oauth/callback
+    Browser->>Helper: launch CoreVideoOAuthCallback helper
+    Helper->>ZCS2: POST {"cmd":"oauth_callback", url}
     ZCS2->>ZOA: handle_redirect_url(url)
     ZOA->>ZOA: verify state matches m_pending_state
     ZOA->>Broker2: POST /oauth/redeem broker_token=…
-    Broker2->>ZoomCloud2: POST /oauth/token client_id + code_verifier, no secret
+    Broker2->>ZoomCloud2: POST /oauth/token (PKCE, no secret)
     Broker2-->>ZOA: {access_token, refresh_token, expires_in}
     ZOA->>ZOA: store tokens (DPAPI on Windows)
     Note over ZOA: Ready to fetch ZAK on next join
@@ -1105,7 +1073,7 @@ sequenceDiagram
     </div>
 
     <h3>ZAK Fetch and publicAppKey SDK Auth (before each join)</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZDock4 as ZoomDock
@@ -1115,12 +1083,12 @@ sequenceDiagram
     participant ZEC8 as ZoomEngineClient
 
     ZDock4->>ZOA2: fetch_user_zak_blocking(zak)
-    ZOA2->>ZOA2: check token expiry\nrefresh_access_token_blocking() if expired
-    ZOA2->>ZoomAPI: GET /v2/users/me/token?type=zak\nAuthorization: Bearer {access_token}
+    ZOA2->>ZOA2: refresh access token if expired
+    ZOA2->>ZoomAPI: GET /users/me/token?type=zak
     ZoomAPI-->>ZOA2: signed-in user ZAK
     ZOA2-->>ZDock4: zak string
-    ZDock4->>ZEC8: start(public_app_key), then join(id, pass, name, kind, zak)
-    ZEC8->>Engine: {"cmd":"init","public_app_key":"…"} then {"cmd":"join","meeting_id":"…","user_zak":"…"}
+    ZDock4->>ZEC8: start(publicAppKey) → join(…, zak)
+    ZEC8->>Engine: {"cmd":"init"} then {"cmd":"join"}
       </div>
       <div class="diagram-caption">Fig 8c - A user ZAK is fetched before each join using the stored OAuth access token; token refresh is automatic when expired.</div>
     </div>
@@ -1150,7 +1118,7 @@ sequenceDiagram
       Joining is centralized in <code>ZoomDock</code> (or the TCP/OSC control APIs) —
       not in individual sources. Sources subscribe to the already-joined meeting.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant U as User / Control API
@@ -1160,23 +1128,23 @@ sequenceDiagram
     participant ZS3 as ZoomSource
     participant Engine as ZoomObsEngine
 
-    U->>ZDock2: click Join (meeting_id, passcode, display_name, [webinar])
+    U->>ZDock2: click Join
     ZDock2->>ZRM2: store_session(auth_token, id, pass, name)
-    ZDock2->>ZEC6: start(public_app_key) [launches engine if not running]
+    ZDock2->>ZEC6: start() — launch engine if needed
     ZDock2->>ZEC6: join(id, pass, name, kind=Meeting|Webinar)
-    ZEC6->>Engine: {"cmd":"join","meeting_id":"…","kind":"meeting|webinar"}
+    ZEC6->>Engine: {"cmd":"join", kind}
     Engine-->>ZEC6: {"cmd":"joined"}
     ZEC6-->>ZRM2: on_join_success()
 
     Note over ZS3: ZoomSource.activate() when OBS activates source
 
-    ZS3->>ZEC6: subscribe(uuid, pid, isolate) OR subscribe_spotlight(uuid, slot)
-    ZEC6->>Engine: {"cmd":"subscribe","source_uuid":"…","participant_id":N}
+    ZS3->>ZEC6: subscribe() / subscribe_spotlight()
+    ZEC6->>Engine: {"cmd":"subscribe", uuid, pid}
 
     loop Live capture
         Engine-->>ZEC6: {"cmd":"frame","uuid":"…","w":W,"h":H}
         ZEC6-->>ZS3: on_engine_frame(w, h)
-        ZS3->>ZS3: read I420 from video shm, process with HwVideoPipeline if enabled
+        ZS3->>ZS3: read I420 from SHM (+HW pipeline)
         ZS3->>OBS: obs_source_output_video()
         Engine-->>ZEC6: {"cmd":"audio","uuid":"…","byte_len":B}
         ZEC6-->>ZS3: on_engine_audio(byte_len)
@@ -1260,7 +1228,7 @@ sequenceDiagram
       This mirrors the ZoomISO "Spotlight 1/2/3" output model.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart LR
     subgraph Source["ZoomSource (AssignmentMode)"]
@@ -1277,9 +1245,6 @@ flowchart LR
 
     ZEC7 -->|JSON IPC| Engine2["ZoomObsEngine\n(resolves → SDK renderer)"]
 
-    style Source fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZEC7 fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
       </div>
       <div class="diagram-caption">Assignment modes map to different ZoomEngineClient subscribe calls; the engine resolves each to the correct SDK renderer.</div>
     </div>
@@ -1329,7 +1294,7 @@ flowchart LR
       <code>obs_queue_task(OBS_TASK_UI, …)</code> to re-evaluate on the OBS UI thread.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 stateDiagram-v2
     [*] --> Idle : active_speaker_mode = off
@@ -1361,7 +1326,7 @@ stateDiagram-v2
     </div>
 
     <h3>Switch Sequence</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZP as ZoomEngineClient\n(roster_callback)
@@ -1370,8 +1335,8 @@ sequenceDiagram
     participant UI as OBS UI Thread
     participant VD as VideoDelegate
 
-    ZP-->>ZS4: roster callback\n(active_speaker_id from engine event = X)
-    ZS4->>ZS4: on_active_speaker_changed()\npending = X, candidate_since = now
+    ZP-->>ZS4: roster callback: active_speaker = X
+    ZS4->>ZS4: pending = X, start hold timer
 
     alt delay == 0
         ZS4->>ZS4: do_speaker_switch(X)
@@ -1530,7 +1495,7 @@ sequenceDiagram
       position in OBS. It is the primary UI for meeting management.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-obs-workspace.svg" alt="CoreVideo OBS workspace with Zoom Control dock" style="max-width:100%;height:auto;">
       <div class="diagram-caption">CoreVideo runs as normal OBS UI: the Zoom Control dock manages meeting state and raw media while Zoom Participant sources render inside OBS scenes.</div>
     </div>
@@ -1732,7 +1697,7 @@ sequenceDiagram
       <tr><td><code>ZoomOutputProfile::remove(name)</code></td><td>Deletes profile JSON file</td></tr>
     </table>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-output-manager.svg" alt="CoreVideo Output Manager with participant and output mapping" style="max-width:100%;height:auto;">
       <div class="diagram-caption">The Output Manager mirrors the dock assignment controls and remains useful for named profile save/load workflows.</div>
     </div>
@@ -1821,7 +1786,7 @@ sequenceDiagram
     </table>
 
     <h3>Zoom Participant Source Properties</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-source-properties.svg" alt="CoreVideo Zoom Participant source properties" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Each Zoom Participant source keeps its own assignment mode, audio routing, requested resolution, and failover behavior.</div>
     </div>
@@ -1888,7 +1853,7 @@ sequenceDiagram
       state in the panel and TCP status payload.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/iso-recording-flow.svg" alt="CoreVideo ISO recording flow" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Assignments resolve the participant IDs. Each assigned Zoom source can feed an FFmpeg writer for video/audio ISO files while OBS continues to own the program output.</div>
     </div>
@@ -1981,27 +1946,38 @@ sequenceDiagram
 </main>
 
 <script>
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
   mermaid.initialize({
     startOnLoad: true,
-    theme: 'dark',
+    theme: 'base',
     themeVariables: {
       darkMode: true,
-      background: '#0d1117',
-      mainBkg: '#1e2a35', primaryColor: '#1e2a35', primaryTextColor: '#eaf2f6',
-      primaryBorderColor: '#2fd07f', nodeBorder: '#2fd07f',
-      secondaryColor: '#26313c', tertiaryColor: '#1a222b',
-      lineColor: '#aeb7bf', textColor: '#eaf2f6', nodeTextColor: '#eaf2f6',
-      edgeLabelBackground: '#0d1117', clusterBkg: '#161d25', clusterBorder: '#3a4650', titleColor: '#eaf2f6',
-      actorBkg: '#1e2a35', actorBorder: '#2fd07f', actorTextColor: '#ffffff',
-      actorLineColor: '#aeb7bf', signalColor: '#aeb7bf', signalTextColor: '#eaf2f6',
-      noteBkgColor: '#2a3742', noteTextColor: '#eaf2f6', noteBorderColor: '#4a5762',
-      activationBorderColor: '#2fd07f', activationBkgColor: '#183a2a',
-      sequenceNumberColor: '#0d1117', labelBoxBkgColor: '#1e2a35',
-      labelBoxBorderColor: '#4a5762', labelTextColor: '#eaf2f6', loopTextColor: '#eaf2f6',
-      fontFamily: 'Space Grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     },
-    flowchart: { curve: 'basis', htmlLabels: true },
-    sequence: { actorMargin: 60, messageMargin: 30 },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
   });
 
   const sections = document.querySelectorAll('section[id]');

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -41,18 +41,17 @@
 
     #sidebar {
       position: fixed; top: 52px; left: 0; bottom: 0; width: 260px;
-      background: var(--surface); border-right: 1px solid var(--border);
-      padding: 24px 0; overflow-y: auto; z-index: 100;
+      background: var(--bg); border-right: 1px solid var(--border);
+      padding: 18px 0 32px; overflow-y: auto; z-index: 100;
     }
-    .nav-logo { padding: 0 20px 20px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-    .nav-logo h1 { font-size: 1.1rem; color: var(--accent); font-weight: 700; }
-    .nav-logo p  { font-size: 0.75rem; color: var(--muted); margin-top: 2px; }
     #sidebar a {
-      display: block; padding: 7px 20px; color: var(--muted); text-decoration: none;
-      font-size: 0.95rem; border-left: 2px solid transparent; transition: all 0.15s;
+      display: block; padding: 6px 20px; color: var(--muted); text-decoration: none;
+      font-size: 0.88rem; border-left: 2px solid transparent; transition: color .15s, background .15s, border-color .15s;
     }
-    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.1); }
-    .nav-section { padding: 14px 20px 4px; font-size: 0.78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); }
+    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.08); }
+    .nav-section { padding: 18px 20px 6px; font-family: "IBM Plex Mono", ui-monospace, monospace;
+      font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: .14em; color: #77828a; }
+    .nav-section-first { padding-top: 4px; }
     main { margin-left: 260px; max-width: 960px; padding: 48px 56px; }
     section[id] { scroll-margin-top: 72px; }
 
@@ -116,12 +115,16 @@
     .card h4 { margin: 0 0 6px; font-size: 0.9rem; }
     .card p { font-size: 0.8rem; color: var(--muted); margin: 0; }
 
+    .diagram-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     .diagram-wrap {
       background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
-      padding: 28px; margin: 20px 0; overflow-x: auto;
+      padding: 24px; margin: 20px 0; overflow-x: auto;
     }
-    .diagram-wrap .mermaid { display: flex; justify-content: center; }
-    .diagram-caption { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 12px; font-style: italic; }
+    .diagram-wrap .mermaid { display: flex; justify-content: safe center; min-width: min-content; }
+    .diagram-wrap .mermaid svg { max-width: none; }
+    .diagram-wrap > svg.arch { display: block; width: 100%; height: auto; min-width: 720px; }
+    .diagram-caption { font-size: 0.85rem; color: var(--muted); text-align: center; margin-top: 14px;
+      font-family: "IBM Plex Mono", ui-monospace, monospace; }
 
     table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.875rem; }
     th { background: #16191b; border: 1px solid var(--border); padding: 10px 14px; text-align: left; font-weight: 600; color: var(--muted); }
@@ -146,9 +149,16 @@
 
     section { scroll-margin-top: 24px; }
 
-    @media (max-width: 768px) {
-      #sidebar { display: none; }
-      main { margin-left: 0; padding: 24px 20px; }
+    @media (max-width: 960px) {
+      /* Sidebar becomes a horizontal on-page index instead of disappearing. */
+      #sidebar { position: static; width: auto; bottom: auto; display: flex; align-items: center;
+        overflow-x: auto; white-space: nowrap; padding: 10px 12px; gap: 2px;
+        border-right: none; border-bottom: 1px solid var(--border); }
+      .nav-section { padding: 0 6px 0 14px; }
+      .nav-section-first { padding-left: 6px; }
+      #sidebar a { padding: 6px 10px; border-left: none; border-radius: 6px; font-size: 0.82rem; }
+      #sidebar a:hover, #sidebar a.active { background: rgba(34,200,110,.12); }
+      main { margin-left: 0; padding: 28px 20px; }
       .site-topbar { flex-direction: column; align-items: flex-start; gap: 10px; }
       .site-topbar .topnav { justify-content: flex-start; }
       main > footer { margin-left: 0 !important; }
@@ -173,12 +183,8 @@
   </nav>
 </header>
 
-<nav id="sidebar">
-  <div class="nav-logo">
-    <h1>📹 CoreVideo</h1>
-    <p>OBS Plugin for Live Zoom Video</p>
-  </div>
-  <div class="nav-section">Overview</div>
+<nav id="sidebar" aria-label="On this page">
+  <div class="nav-section nav-section-first">Overview</div>
   <a href="#overview">Introduction</a>
   <a href="#features">Features</a>
   <div class="nav-section">Get Started</div>
@@ -557,65 +563,89 @@
       which feed they subscribe to: a fixed participant, the active speaker, a
       spotlight slot, or the active screen share.
     </p>
-    <div class="diagram-wrap">
-      <div class="mermaid">
-graph TB
-    subgraph Machine["User's Machine"]
-      subgraph OBS["OBS Studio"]
-        Canvas["Canvas / Output"]
-        VSrc["Zoom Participant\nSource"]
-        Canvas --> VSrc
-      end
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
+      <svg class="arch" viewBox="0 0 1140 600" role="img" aria-labelledby="fig1-t fig1-d" xmlns="http://www.w3.org/2000/svg">
+  <title id="fig1-t">CoreVideo system overview</title>
+  <desc id="fig1-d">Zoom Cloud feeds the ZoomObsEngine child process over HTTPS/WSS. The engine owns all Zoom SDK access and writes I420 video and PCM audio into shared memory, which the obs-zoom-plugin reads and hands to OBS Studio sources. Plugin and engine exchange JSON IPC over a named pipe or Unix socket. External controllers reach the plugin over TCP 19870 and OSC 19871.</desc>
+  <defs>
+    <marker id="ar-g" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#22c86e"/></marker>
+    <marker id="ar-n" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#8b949b"/></marker>
+    <marker id="ar-nr" markerWidth="9" markerHeight="8" refX="0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M8,0 L8,6 L0,3 z" fill="#8b949b"/></marker>
+  </defs>
+  <style>
+    .p-title { font: 700 13px "Space Grotesk", sans-serif; letter-spacing: .1em; fill: #e9edef; }
+    .p-tag   { font: 400 9.5px "IBM Plex Mono", monospace; letter-spacing: .06em; fill: #77828a; }
+    .chip    { fill: #1a2025; stroke: #2c343b; }
+    .c-txt   { font: 400 12px "IBM Plex Mono", monospace; fill: #dbe3e8; }
+    .e-lab   { font: 600 11px "IBM Plex Mono", monospace; letter-spacing: .08em; fill: #8b949b; }
+    .e-lab.g { fill: #4fd88f; }
+    .e-sub   { font: 400 10px "IBM Plex Mono", monospace; fill: #6d777d; }
+  </style>
 
-      subgraph Plugin["obs-zoom-plugin  (no SDK dependency)"]
-        ZDock["ZoomDock\n(Control UI · CvStatusDot · CvBanner)"]
-        ZEC["ZoomEngineClient\n★ central singleton"]
-        ZRM["ZoomReconnectManager\n(auto-reconnect)"]
-        ZOAuth["ZoomOAuthManager\n(OAuth broker · ZAK fetch · DPAPI)"]
-        ZS["ZoomSource\n(ShmRegion · AssignmentMode)"]
-        ZOM["ZoomOutputManager"]
-        ZCS["ZoomControlServer :19870"]
-        ZOSC["ZoomOscServer :19871"]
+  <!-- Zoom Cloud -->
+  <rect x="16" y="210" width="160" height="128" rx="12" fill="#10151a" stroke="rgba(188,140,255,.38)" stroke-width="1.5"/>
+  <circle cx="34" cy="234" r="4" fill="#bc8cff"/>
+  <text class="p-title" x="46" y="238">ZOOM CLOUD</text>
+  <text class="p-tag" x="30" y="258">RAW A/V SOURCE</text>
+  <rect class="chip" x="30" y="274" width="132" height="30" rx="7"/>
+  <text class="c-txt" x="42" y="293">Live meeting</text>
 
-        ZDock --> ZEC
-        ZDock --> ZOAuth
-        ZRM --> ZEC
-        ZEC --> ZS
-        ZCS & ZOSC --> ZOM & ZEC
-        ZEC --> ZRM
-        ZOAuth -->|"ZAK + publicAppKey"| ZEC
-      end
+  <!-- Engine -->
+  <rect x="252" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(34,200,110,.5)" stroke-width="1.5"/>
+  <circle cx="270" cy="94" r="4" fill="#22c86e"/>
+  <text class="p-title" x="282" y="98">ZOOMOBSENGINE</text>
+  <text class="p-tag" x="266" y="118">ALL ZOOM SDK ACCESS &#183; CHILD PROCESS</text>
+  <rect class="chip" x="266" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="155">Zoom SDK &#183; auth / meeting / raw</text>
+  <rect class="chip" x="266" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="197">Participant + spotlight tracking</text>
+  <rect class="chip" x="266" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="239">EngineVideo &#8212; I420 &#8594; SHM</text>
+  <rect class="chip" x="266" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="281">EngineAudio &#8212; PCM &#8594; SHM</text>
+  <rect class="chip" x="266" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="323">ISO recorder &#8212; FFmpeg</text>
+  <rect class="chip" x="266" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="365">IPC loop</text>
 
-      subgraph Engine["ZoomObsEngine  (ALL SDK access)"]
-        ELoop["IPC Loop"]
-        EVid["EngineVideo\n(SHM write)"]
-        EAud["EngineAudio\n(SHM write)"]
-        EPart["Participant &amp; Spotlight\ntracking"]
-        SDK["Zoom SDK\nAuth · Meeting · Webinar · Raw data"]
-        ELoop --> EVid & EAud & EPart --> SDK
-      end
+  <!-- Plugin -->
+  <rect x="632" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="650" cy="94" r="4" fill="#e9edef"/>
+  <text class="p-title" x="662" y="98">OBS-ZOOM-PLUGIN</text>
+  <text class="p-tag" x="646" y="118">OBS MODULE &#183; NO SDK DEPENDENCY</text>
+  <rect class="chip" x="646" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="155">ZoomEngineClient &#183; singleton</text>
+  <rect class="chip" x="646" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="197">ZoomSource &#215;N &#8212; SHM read</text>
+  <rect class="chip" x="646" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="239">ZoomDock &#8212; control UI</text>
+  <rect class="chip" x="646" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="281">OAuth manager &#8212; PKCE &#183; ZAK</text>
+  <rect class="chip" x="646" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="323">Output manager &#183; reconnect</text>
+  <rect class="chip" x="646" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="365">Control APIs &#8212; TCP &#183; OSC</text>
 
-      subgraph ZoomCloud["Zoom Cloud"]
-        Mtg["Live Meeting / Webinar"]
-      end
+  <!-- OBS Studio -->
+  <rect x="972" y="199" width="152" height="150" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="990" cy="223" r="4" fill="#e9edef"/>
+  <text class="p-title" x="1002" y="227">OBS STUDIO</text>
+  <rect class="chip" x="986" y="244" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="263">Zoom sources</text>
+  <rect class="chip" x="986" y="286" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="305">Program out</text>
 
-      subgraph External["External Control"]
-        Ctrl["Script / Dashboard"]
-      end
-    end
+  <!-- External control -->
+  <rect x="632" y="506" width="280" height="64" rx="12" fill="#10151a" stroke="rgba(232,164,31,.4)" stroke-width="1.5"/>
+  <circle cx="650" cy="530" r="4" fill="#e8a41f"/>
+  <text class="p-title" x="662" y="534">EXTERNAL CONTROL</text>
+  <text class="p-tag" x="646" y="554">COMPANION &#183; SCRIPTS &#183; CONSOLES</text>
 
-    OBS -->|loads| Plugin
-    VSrc <--> ZS
-    Plugin <-->|"JSON IPC\n(named pipe / Unix socket)"| ELoop
-    EVid & EAud -->|"Named Shared Memory\nI420 frames · PCM audio"| ZS
-    SDK <-->|HTTPS/WSS| Mtg
-    Ctrl <-->|"TCP :19870\nUDP OSC :19871"| ZCS & ZOSC
-    style OBS fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Plugin fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style ZoomCloud fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style External fill:#2d2000,stroke:#d29922,color:#e6edf3
-      </div>
+  <!-- Edges -->
+  <path d="M176,274 L244,274" stroke="#8b949b" stroke-width="2" fill="none" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="210" y="252" text-anchor="middle">HTTPS</text>
+  <text class="e-sub" x="210" y="264" text-anchor="middle">/ WSS</text>
+
+  <path d="M532,250 L624,250" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="582" y="226" text-anchor="middle">SHARED MEMORY</text>
+  <text class="e-sub" x="582" y="240" text-anchor="middle">I420 &#183; PCM</text>
+
+  <path d="M540,340 L624,340" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="582" y="316" text-anchor="middle">JSON IPC</text>
+  <text class="e-sub" x="582" y="330" text-anchor="middle">pipe / socket</text>
+
+  <path d="M912,274 L964,274" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="938" y="258" text-anchor="middle">FRAMES</text>
+
+  <path d="M772,498 L772,478" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-sub" x="786" y="492" text-anchor="start">TCP :19870 &#183; UDP OSC :19871</text>
+</svg>
       <div class="diagram-caption">Fig 1 - All SDK access is in ZoomObsEngine. ZoomOAuthManager handles broker-backed OAuth PKCE, token storage, and ZAK fetches. TCP and OSC provide external control without linking the Zoom SDK into OBS.</div>
     </div>
   </section>
@@ -629,39 +659,26 @@ graph TB
       New additions: <code>ZoomDock</code> (join UI), <code>ZoomReconnectManager</code>
       (auto-reconnect), and <code>HwVideoPipeline</code> (hardware I420→NV12).
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 classDiagram
     class ZoomEngineClient {
         &lt;&lt;Singleton&gt;&gt;
-        +start(auth_token, public_app_key) / stop() / stop_for_reconnect()
-        +join(id, pass, name, kind: MeetingKind)
-        +leave()
-        +subscribe(uuid, pid, isolate_audio)
+        +start() / stop()
+        +join() / leave()
+        +subscribe(uuid, pid)
         +subscribe_spotlight(uuid, slot)
         +subscribe_screenshare(uuid)
-        +unsubscribe(uuid)
-        +state() MeetingState
-        +is_authenticated() bool
-        +active_speaker_id() uint32_t
-        +roster() vector~ParticipantInfo~
+        +state() / roster()
         +register_source(uuid, callbacks)
-        +add_roster_callback(key, cb)
     }
     class ZoomSource {
         +assignment : AssignmentMode
-        +participant_id : atomic~uint32_t~
-        +spotlight_slot : atomic~uint32_t~
-        +failover_participant_id : atomic~uint32_t~
         +resolution : VideoResolution
         +video_loss_mode : VideoLossMode
-        +hw_accel_override : int
-        +speaker_sensitivity_ms, speaker_hold_ms
-        +configure_output_ex(mode, pid, slot, failover, …)
+        +configure_output_ex(...)
         +on_engine_frame(w, h)
-        +on_engine_audio(byte_len)
-        +m_hk_active_on_id, m_hk_active_off_id
-        +m_hw_pipeline : HwVideoPipeline
+        +on_engine_audio(bytes)
     }
     class ZoomOAuthManager {
         &lt;&lt;Singleton&gt;&gt;
@@ -670,29 +687,19 @@ classDiagram
         +register_url_scheme() bool
         +refresh_access_token_blocking() bool
         +fetch_user_zak_blocking(zak) bool
-        -m_pending_state : QString
-        -m_pending_verifier : QString
     }
     class ZoomDock {
         +on_join_clicked()
         +on_leave_clicked()
         +on_cancel_recovery_clicked()
         +update_state_indicator()
-        +update_recovery_panel()
-        +update_credentials_banner()
-        -m_state_dot : CvStatusDot
-        -m_credentials_banner : CvBanner
-        -m_join_token_type : QComboBox
-        -m_output_table : QTableWidget
     }
     class ZoomReconnectManager {
         &lt;&lt;Singleton&gt;&gt;
         +set_policy(policy)
-        +store_session(auth_token, id, pass, name)
-        +trigger(reason: RecoveryReason)
-        +cancel()
-        +on_join_success() / on_join_failed(permanent)
-        +is_recovering() bool
+        +store_session(...)
+        +trigger(reason) / cancel()
+        +on_join_success() / on_join_failed()
         +next_retry_ms() int
     }
     class HwVideoPipeline {
@@ -743,23 +750,17 @@ classDiagram
       All Zoom SDK state (auth, meeting, roster, active speaker) is owned by the
       engine; the client tracks it locally by processing the event stream.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 graph TB
     subgraph Plugin["obs-zoom-plugin process"]
         ZEC["ZoomEngineClient\n★ singleton"]
         Reader["reader_loop()\n(dedicated thread)"]
-        S1["ZoomSource A\n(ShmRegion video+audio)"]
-        S2["ZoomSource B\n(ShmRegion video+audio)"]
+        S1["ZoomSource A"]
+        S2["ZoomSource B"]
         ZEC --> Reader
-        ZEC -->|"on_frame / on_audio callbacks"| S1
-        ZEC -->|"on_frame / on_audio callbacks"| S2
-    end
-
-    subgraph IPC["IPC"]
-        P2E["Plugin → Engine\njson cmds"]
-        E2P["Engine → Plugin\njson events"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        ZEC -->|"frame / audio callbacks"| S1
+        ZEC -->|"frame / audio callbacks"| S2
     end
 
     subgraph Engine["ZoomObsEngine process"]
@@ -768,14 +769,11 @@ graph TB
         SDK3 --- ETrack
     end
 
-    ZEC -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> Engine
-    Engine -- "ready · auth_ok · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> Reader
-    Engine -- "write frames" --> SHM
+    ZEC -- "commands · JSON" --> SDK3
+    SDK3 -- "events · JSON" --> Reader
+    SDK3 -- "frame write" --> SHM["Named shared memory"]
     S1 & S2 -- "mmap read" --> SHM
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 3 — ZoomEngineClient launches the engine, owns IPC channels, and dispatches callbacks to each ZoomSource.</div>
     </div>
@@ -827,35 +825,23 @@ graph TB
       Frame data flows through named shared memory to avoid copying large buffers.
       <code>ZoomEngineClient</code> in the plugin abstracts all IPC details.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-graph LR
+flowchart LR
     subgraph Plugin["obs-zoom-plugin"]
         ZEC2["ZoomEngineClient"]
-        SHM_R["ZoomSource\nShmRegion (mmap read)"]
-    end
-
-    subgraph IPC["IPC Channels"]
-        P2E["Plugin → Engine\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        E2P["Engine → Plugin\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        SHM_R["ZoomSource\nSHM read (mmap)"]
     end
 
     subgraph Engine["ZoomObsEngine"]
-        ELoop["IPC Loop\n+ reader_loop"]
-        EVid["EngineVideo"]
-        EAud["EngineAudio"]
-        SDK2["Zoom SDK\n(all SDK access)"]
-        ELoop --> EVid & EAud --> SDK2
+        ELoop["IPC loop"]
+        EMed["EngineVideo · EngineAudio"]
     end
 
-    ZEC2 -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> ELoop
-    ELoop -- "ready · auth_ok · auth_fail · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> ZEC2
-    EVid & EAud -- "write I420 + PCM" --> SHM --> SHM_R
+    ZEC2 -- "commands · JSON" --> ELoop
+    ELoop -- "events · JSON" --> ZEC2
+    EMed -- "I420 + PCM" --> SHM["Named shared memory"] --> SHM_R
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 4 — Cross-platform IPC: JSON over named pipes (Windows) or Unix sockets (macOS/Linux); frames through shared memory.</div>
     </div>
@@ -868,9 +854,9 @@ graph LR
 
   <section id="arch-video">
     <h2>Architecture: Video Pipeline</h2>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     CAM["Participant\nCamera"] --> ZC["Zoom Cloud"]
     ZC -->|decoded I420| EV["Engine EngineVideo\n(IZoomSDKRenderer)"]
     EV -->|"write I420 to\nShmRegion"| SHM2["Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
@@ -879,14 +865,6 @@ flowchart LR
     ZS5 -->|"VideoLossMode:\nLastFrame / Black"| LOSS["Loss handling"]
     LOSS -->|"I420 planar\nPreviewCallback ≤5fps"| OBS_V["OBS Video\nobs_source_output_video()"]
 
-    style CAM fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EV fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM2 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC3 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZS5 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style LOSS fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style OBS_V fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 5 — Video path: engine writes I420 to shared memory; ZoomSource reads via ShmRegion and forwards to OBS.</div>
     </div>
@@ -910,7 +888,7 @@ flowchart LR
       pushes it to OBS. Stereo sources use an internal <code>m_stereo_buf</code> to
       interleave channels before output.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart TB
     SDK4["Zoom SDK\n(inside engine)"]
@@ -923,10 +901,6 @@ flowchart TB
 
     ZS6 -->|"Mono: direct S16\nStereo: interleaved"| OBS_A["OBS Audio\nobs_source_output_audio()"]
 
-    style SDK4 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EAud2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM3 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZS6 fill:#0d2137,stroke:#22c86e,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 6 — Audio pipeline: engine mixes/isolates audio in-process and delivers chunks through shared memory.</div>
     </div>
@@ -950,9 +924,9 @@ flowchart TB
       <code>frame</code> events on the share source UUID and forwards them to OBS
       exactly like participant video.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     SC2["Screen Share\nIn Meeting"] --> ZC3["Zoom Cloud"]
     ZC3 -->|onSharingStatus| EShare["Engine\nShareDelegate\n(inside ZoomObsEngine)"]
     EShare -->|subscribe share renderer| Rnd["IZoomSDKRenderer"]
@@ -960,12 +934,6 @@ flowchart LR
     SHM4 -->|"frame event"| ZEC4["ZoomEngineClient\n→ ZoomSource (share)"]
     ZEC4 -->|obs_source_output_video| OBS_SS["OBS Zoom\nShare Source"]
 
-    style SC2 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC3 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EShare fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM4 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC4 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style OBS_SS fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 7 — Screen share: engine-side delegate writes I420 to shared memory; plugin receives via ZoomEngineClient frame callback.</div>
     </div>
@@ -982,7 +950,7 @@ flowchart LR
       the helper with <code>AuthContext.publicAppKey</code>. The engine is not
       started on module load; it is launched the first time a join is requested.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant OBS as OBS Studio
@@ -998,7 +966,7 @@ sequenceDiagram
     PM->>ZOA2: load OAuth tokens and broker URL
     PM->>ZoomControlServer: start(control_server_port)
     PM->>ZoomOscServer: start(osc_server_port)
-    PM->>ZDock: ensure_zoom_dock() [after OBS_FRONTEND_EVENT_FINISHED_LOADING]
+    PM->>ZDock: ensure_zoom_dock() after frontend loaded
 
     Note over ZDock: User clicks Join or API sends join cmd
 
@@ -1068,7 +1036,7 @@ sequenceDiagram
     </div>
 
     <h3>Authorization Flow</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant User
@@ -1086,17 +1054,17 @@ sequenceDiagram
     ZOA->>Browser: QDesktopServices::openUrl(/oauth/start?state=…)
     Browser->>Broker2: GET /oauth/start
     Broker2->>Broker2: generate PKCE verifier/challenge
-    Broker2->>ZoomCloud2: redirect to /v2/authorize?client_id=…&code_challenge=…
+    Broker2->>ZoomCloud2: redirect → /v2/authorize (PKCE)
     ZoomCloud2-->>Browser: consent screen
     User->>Browser: approve
     ZoomCloud2-->>Broker2: redirect to /oauth/callback?code=…&state=…
-    Broker2-->>Browser: redirect to corevideo://oauth/callback?broker_token=…&state=…
-    Browser->>Helper: launch CoreVideoOAuthCallback (Windows: .exe / macOS: .app)
-    Helper->>ZCS2: POST {"cmd":"oauth_callback","url":"corevideo://oauth/callback?broker_token=…&state=…"}
+    Broker2-->>Browser: redirect → corevideo://oauth/callback
+    Browser->>Helper: launch CoreVideoOAuthCallback helper
+    Helper->>ZCS2: POST {"cmd":"oauth_callback", url}
     ZCS2->>ZOA: handle_redirect_url(url)
     ZOA->>ZOA: verify state matches m_pending_state
     ZOA->>Broker2: POST /oauth/redeem broker_token=…
-    Broker2->>ZoomCloud2: POST /oauth/token client_id + code_verifier, no secret
+    Broker2->>ZoomCloud2: POST /oauth/token (PKCE, no secret)
     Broker2-->>ZOA: {access_token, refresh_token, expires_in}
     ZOA->>ZOA: store tokens (DPAPI on Windows)
     Note over ZOA: Ready to fetch ZAK on next join
@@ -1105,7 +1073,7 @@ sequenceDiagram
     </div>
 
     <h3>ZAK Fetch and publicAppKey SDK Auth (before each join)</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZDock4 as ZoomDock
@@ -1115,12 +1083,12 @@ sequenceDiagram
     participant ZEC8 as ZoomEngineClient
 
     ZDock4->>ZOA2: fetch_user_zak_blocking(zak)
-    ZOA2->>ZOA2: check token expiry\nrefresh_access_token_blocking() if expired
-    ZOA2->>ZoomAPI: GET /v2/users/me/token?type=zak\nAuthorization: Bearer {access_token}
+    ZOA2->>ZOA2: refresh access token if expired
+    ZOA2->>ZoomAPI: GET /users/me/token?type=zak
     ZoomAPI-->>ZOA2: signed-in user ZAK
     ZOA2-->>ZDock4: zak string
-    ZDock4->>ZEC8: start(public_app_key), then join(id, pass, name, kind, zak)
-    ZEC8->>Engine: {"cmd":"init","public_app_key":"…"} then {"cmd":"join","meeting_id":"…","user_zak":"…"}
+    ZDock4->>ZEC8: start(publicAppKey) → join(…, zak)
+    ZEC8->>Engine: {"cmd":"init"} then {"cmd":"join"}
       </div>
       <div class="diagram-caption">Fig 8c - A user ZAK is fetched before each join using the stored OAuth access token; token refresh is automatic when expired.</div>
     </div>
@@ -1150,7 +1118,7 @@ sequenceDiagram
       Joining is centralized in <code>ZoomDock</code> (or the TCP/OSC control APIs) —
       not in individual sources. Sources subscribe to the already-joined meeting.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant U as User / Control API
@@ -1160,23 +1128,23 @@ sequenceDiagram
     participant ZS3 as ZoomSource
     participant Engine as ZoomObsEngine
 
-    U->>ZDock2: click Join (meeting_id, passcode, display_name, [webinar])
+    U->>ZDock2: click Join
     ZDock2->>ZRM2: store_session(auth_token, id, pass, name)
-    ZDock2->>ZEC6: start(public_app_key) [launches engine if not running]
+    ZDock2->>ZEC6: start() — launch engine if needed
     ZDock2->>ZEC6: join(id, pass, name, kind=Meeting|Webinar)
-    ZEC6->>Engine: {"cmd":"join","meeting_id":"…","kind":"meeting|webinar"}
+    ZEC6->>Engine: {"cmd":"join", kind}
     Engine-->>ZEC6: {"cmd":"joined"}
     ZEC6-->>ZRM2: on_join_success()
 
     Note over ZS3: ZoomSource.activate() when OBS activates source
 
-    ZS3->>ZEC6: subscribe(uuid, pid, isolate) OR subscribe_spotlight(uuid, slot)
-    ZEC6->>Engine: {"cmd":"subscribe","source_uuid":"…","participant_id":N}
+    ZS3->>ZEC6: subscribe() / subscribe_spotlight()
+    ZEC6->>Engine: {"cmd":"subscribe", uuid, pid}
 
     loop Live capture
         Engine-->>ZEC6: {"cmd":"frame","uuid":"…","w":W,"h":H}
         ZEC6-->>ZS3: on_engine_frame(w, h)
-        ZS3->>ZS3: read I420 from video shm, process with HwVideoPipeline if enabled
+        ZS3->>ZS3: read I420 from SHM (+HW pipeline)
         ZS3->>OBS: obs_source_output_video()
         Engine-->>ZEC6: {"cmd":"audio","uuid":"…","byte_len":B}
         ZEC6-->>ZS3: on_engine_audio(byte_len)
@@ -1260,7 +1228,7 @@ sequenceDiagram
       This mirrors the ZoomISO "Spotlight 1/2/3" output model.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart LR
     subgraph Source["ZoomSource (AssignmentMode)"]
@@ -1277,9 +1245,6 @@ flowchart LR
 
     ZEC7 -->|JSON IPC| Engine2["ZoomObsEngine\n(resolves → SDK renderer)"]
 
-    style Source fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZEC7 fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
       </div>
       <div class="diagram-caption">Assignment modes map to different ZoomEngineClient subscribe calls; the engine resolves each to the correct SDK renderer.</div>
     </div>
@@ -1329,7 +1294,7 @@ flowchart LR
       <code>obs_queue_task(OBS_TASK_UI, …)</code> to re-evaluate on the OBS UI thread.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 stateDiagram-v2
     [*] --> Idle : active_speaker_mode = off
@@ -1361,7 +1326,7 @@ stateDiagram-v2
     </div>
 
     <h3>Switch Sequence</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZP as ZoomEngineClient\n(roster_callback)
@@ -1370,8 +1335,8 @@ sequenceDiagram
     participant UI as OBS UI Thread
     participant VD as VideoDelegate
 
-    ZP-->>ZS4: roster callback\n(active_speaker_id from engine event = X)
-    ZS4->>ZS4: on_active_speaker_changed()\npending = X, candidate_since = now
+    ZP-->>ZS4: roster callback: active_speaker = X
+    ZS4->>ZS4: pending = X, start hold timer
 
     alt delay == 0
         ZS4->>ZS4: do_speaker_switch(X)
@@ -1530,7 +1495,7 @@ sequenceDiagram
       position in OBS. It is the primary UI for meeting management.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-obs-workspace.svg" alt="CoreVideo OBS workspace with Zoom Control dock" style="max-width:100%;height:auto;">
       <div class="diagram-caption">CoreVideo runs as normal OBS UI: the Zoom Control dock manages meeting state and raw media while Zoom Participant sources render inside OBS scenes.</div>
     </div>
@@ -1732,7 +1697,7 @@ sequenceDiagram
       <tr><td><code>ZoomOutputProfile::remove(name)</code></td><td>Deletes profile JSON file</td></tr>
     </table>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-output-manager.svg" alt="CoreVideo Output Manager with participant and output mapping" style="max-width:100%;height:auto;">
       <div class="diagram-caption">The Output Manager mirrors the dock assignment controls and remains useful for named profile save/load workflows.</div>
     </div>
@@ -1821,7 +1786,7 @@ sequenceDiagram
     </table>
 
     <h3>Zoom Participant Source Properties</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-source-properties.svg" alt="CoreVideo Zoom Participant source properties" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Each Zoom Participant source keeps its own assignment mode, audio routing, requested resolution, and failover behavior.</div>
     </div>
@@ -1888,7 +1853,7 @@ sequenceDiagram
       state in the panel and TCP status payload.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/iso-recording-flow.svg" alt="CoreVideo ISO recording flow" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Assignments resolve the participant IDs. Each assigned Zoom source can feed an FFmpeg writer for video/audio ISO files while OBS continues to own the program output.</div>
     </div>
@@ -1981,27 +1946,38 @@ sequenceDiagram
 </main>
 
 <script>
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
   mermaid.initialize({
     startOnLoad: true,
-    theme: 'dark',
+    theme: 'base',
     themeVariables: {
       darkMode: true,
-      background: '#0d1117',
-      mainBkg: '#1e2a35', primaryColor: '#1e2a35', primaryTextColor: '#eaf2f6',
-      primaryBorderColor: '#2fd07f', nodeBorder: '#2fd07f',
-      secondaryColor: '#26313c', tertiaryColor: '#1a222b',
-      lineColor: '#aeb7bf', textColor: '#eaf2f6', nodeTextColor: '#eaf2f6',
-      edgeLabelBackground: '#0d1117', clusterBkg: '#161d25', clusterBorder: '#3a4650', titleColor: '#eaf2f6',
-      actorBkg: '#1e2a35', actorBorder: '#2fd07f', actorTextColor: '#ffffff',
-      actorLineColor: '#aeb7bf', signalColor: '#aeb7bf', signalTextColor: '#eaf2f6',
-      noteBkgColor: '#2a3742', noteTextColor: '#eaf2f6', noteBorderColor: '#4a5762',
-      activationBorderColor: '#2fd07f', activationBkgColor: '#183a2a',
-      sequenceNumberColor: '#0d1117', labelBoxBkgColor: '#1e2a35',
-      labelBoxBorderColor: '#4a5762', labelTextColor: '#eaf2f6', loopTextColor: '#eaf2f6',
-      fontFamily: 'Space Grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     },
-    flowchart: { curve: 'basis', htmlLabels: true },
-    sequence: { actorMargin: 60, messageMargin: 30 },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
   });
 
   const sections = document.querySelectorAll('section[id]');


### PR DESCRIPTION
Fixes the two complaints about /documentation/:

**Diagrams were unreadable.** Root cause: Mermaid v10 ignores custom `themeVariables` unless `theme:'base'` — the page used `theme:'dark'`, so the intended dark palette never applied (hence khaki clusters), and diagrams shrank to fit the column (~8px text). Now: Fig 1 is a hand-authored signal-flow SVG in the site design language (pattern borrowed from the Pro page); the remaining 13 Mermaid figures render dark-themed at natural size with 16px text and scroll inside their panel. Oversized figures were restructured (flat LR chains verticalized, class-diagram member walls trimmed, sequence messages shortened).

**Header was bolted on.** The sidebar no longer re-brands the page under the site topbar (duplicate 📹 logo removed); section labels use the site's mono-uppercase system; on narrow screens the sidebar becomes a horizontal on-page index instead of disappearing.

Verified locally in Chrome: all 13 Mermaid figures render without errors; axe-core reports **zero WCAG A/AA violations** (scrollable diagram panels are now keyboard-focusable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)