### PR TITLE
Docs: fix production-only light diagrams (CSP-blocked inline script)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1983,53 +1983,6 @@ sequenceDiagram
   </footer>
 </main>
 
-<script>
-  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
-  // v10 — with theme:'dark' they are silently ignored (that was the source of
-  // the unreadable khaki clusters).
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      darkMode: true,
-      fontSize: '16px',
-      background: '#16191b',
-      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
-      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
-      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
-      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
-      edgeLabelBackground: '#0a0b0c',
-      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
-      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
-      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
-      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
-      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
-      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
-      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
-      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    },
-    // useMaxWidth:false renders every diagram at its natural size — text stays
-    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
-    // instead of shrinking to fit the column.
-    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
-    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
-      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
-    state: { useMaxWidth: false },
-    class: { useMaxWidth: false },
-  });
-
-  const sections = document.querySelectorAll('section[id]');
-  const navLinks = document.querySelectorAll('#sidebar a');
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting) {
-        navLinks.forEach(a => a.classList.remove('active'));
-        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
-        if (active) active.classList.add('active');
-      }
-    });
-  }, { rootMargin: '-20% 0px -70% 0px' });
-  sections.forEach(s => observer.observe(s));
-</script>
+<script src="/assets/docs-init.js"></script>
 </body>
 </html>

--- a/public/assets/docs-init.js
+++ b/public/assets/docs-init.js
@@ -1,0 +1,46 @@
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      darkMode: true,
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
+  });
+
+  const sections = document.querySelectorAll('section[id]');
+  const navLinks = document.querySelectorAll('#sidebar a');
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        navLinks.forEach(a => a.classList.remove('active'));
+        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
+        if (active) active.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  sections.forEach(s => observer.observe(s));

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -1984,53 +1984,6 @@ sequenceDiagram
   </footer>
 </main>
 
-<script>
-  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
-  // v10 — with theme:'dark' they are silently ignored (that was the source of
-  // the unreadable khaki clusters).
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      darkMode: true,
-      fontSize: '16px',
-      background: '#16191b',
-      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
-      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
-      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
-      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
-      edgeLabelBackground: '#0a0b0c',
-      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
-      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
-      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
-      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
-      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
-      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
-      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
-      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    },
-    // useMaxWidth:false renders every diagram at its natural size — text stays
-    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
-    // instead of shrinking to fit the column.
-    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
-    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
-      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
-    state: { useMaxWidth: false },
-    class: { useMaxWidth: false },
-  });
-
-  const sections = document.querySelectorAll('section[id]');
-  const navLinks = document.querySelectorAll('#sidebar a');
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting) {
-        navLinks.forEach(a => a.classList.remove('active'));
-        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
-        if (active) active.classList.add('active');
-      }
-    });
-  }, { rootMargin: '-20% 0px -70% 0px' });
-  sections.forEach(s => observer.observe(s));
-</script>
+<script src="/assets/docs-init.js"></script>
 </body>
 </html>

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -1984,53 +1984,6 @@ sequenceDiagram
   </footer>
 </main>
 
-<script>
-  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
-  // v10 — with theme:'dark' they are silently ignored (that was the source of
-  // the unreadable khaki clusters).
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      darkMode: true,
-      fontSize: '16px',
-      background: '#16191b',
-      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
-      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
-      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
-      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
-      edgeLabelBackground: '#0a0b0c',
-      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
-      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
-      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
-      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
-      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
-      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
-      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
-      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    },
-    // useMaxWidth:false renders every diagram at its natural size — text stays
-    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
-    // instead of shrinking to fit the column.
-    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
-    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
-      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
-    state: { useMaxWidth: false },
-    class: { useMaxWidth: false },
-  });
-
-  const sections = document.querySelectorAll('section[id]');
-  const navLinks = document.querySelectorAll('#sidebar a');
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting) {
-        navLinks.forEach(a => a.classList.remove('active'));
-        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
-        if (active) active.classList.add('active');
-      }
-    });
-  }, { rootMargin: '-20% 0px -70% 0px' });
-  sections.forEach(s => observer.observe(s));
-</script>
+<script src="/assets/docs-init.js"></script>
 </body>
 </html>

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -753,6 +753,15 @@ writeText(
   fs.readFileSync(path.join(siteAssetsDir, "site.css"), "utf8"),
 );
 
+// Docs-page script (mermaid theme init + sidebar highlighting). Must be an
+// external self-hosted file: the worker's CSP has script-src 'self' + jsdelivr
+// with no 'unsafe-inline', so inline scripts are silently blocked in
+// production (that is how the mermaid theme config never applied for months).
+writeText(
+  "assets/docs-init.js",
+  fs.readFileSync(path.join(siteAssetsDir, "docs-init.js"), "utf8"),
+);
+
 // Bundled application fonts (Space Grotesk + IBM Plex Mono), self-hosted so
 // the CSP font-src 'self' policy allows them.
 const fontsSource = path.join(siteAssetsDir, "fonts");
@@ -777,5 +786,25 @@ writeText("_redirects", `/terms-of-use /terms/ 301
 /oauth/ /documentation/#flow-oauth 301
 `);
 writeText("CNAME", "corevideo.io\n");
+
+// Guard: the production CSP blocks inline scripts, so any inline <script> in
+// built HTML is a page that will silently misbehave in production only.
+// Fail the build loudly instead.
+function findHtmlFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(dir, e.name);
+    return e.isDirectory() ? findHtmlFiles(p) : e.name.endsWith(".html") ? [p] : [];
+  });
+}
+const inlineOffenders = findHtmlFiles(outDir).filter((f) =>
+  /<script(?![^>]*src=)[^>]*>/i.test(fs.readFileSync(f, "utf8")),
+);
+if (inlineOffenders.length) {
+  const list = inlineOffenders.map((f) => path.relative(outDir, f)).join(", ");
+  throw new Error(
+    `Inline <script> blocked by the production CSP found in: ${list}. ` +
+      "Move the code into an external file under assets/ instead.",
+  );
+}
 
 console.log(`Built CoreVideo site in ${path.relative(root, outDir)}`);

--- a/site-assets/docs-init.js
+++ b/site-assets/docs-init.js
@@ -1,0 +1,46 @@
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      darkMode: true,
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
+  });
+
+  const sections = document.querySelectorAll('section[id]');
+  const navLinks = document.querySelectorAll('#sidebar a');
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        navLinks.forEach(a => a.classList.remove('active'));
+        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
+        if (active) active.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  sections.forEach(s => observer.observe(s));


### PR DESCRIPTION
Root cause of the diagrams still rendering khaki/light on corevideo.io after #150: the site worker's CSP has `script-src 'self' https://cdn.jsdelivr.net` with no `'unsafe-inline'`, so the docs page's inline `mermaid.initialize` never ran in production — Mermaid auto-started with its default light theme. Local preview (no CSP) rendered dark, which is why verification passed while the live site didn't. The sidebar active-section highlighter was also silently dead in production.

- Init + nav script moved to self-hosted `/assets/docs-init.js` (CSP-clean, CSP unchanged — no `unsafe-inline` added).
- New build-time guard: the build now fails loudly if any generated HTML contains an inline `<script>`.

Verified locally: 13/13 diagrams render with the dark theme via the external script. Will verify on the live site post-deploy with a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)