### PR TITLE
P1: Engine crash-safety audit + clear recovery session on explicit leave (#108)

### DIFF
--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -448,6 +448,12 @@ void ZoomEngineClient::leave()
     if (!m_running.load(std::memory_order_acquire)) return;
     m_user_leaving.store(true, std::memory_order_release);
     ZoomReconnectManager::instance().cancel(); // suppress any in-progress recovery
+    // Explicit user leave is a deliberate end of participation: drop the stored
+    // recovery session so sensitive join credentials (ZAK / on-behalf /
+    // app-privilege tokens) are wiped from memory rather than lingering until
+    // the next join() or stop(). Mirrors stop(); a subsequent rejoin re-stores
+    // a fresh session via join().
+    ZoomReconnectManager::instance().clear_session();
     m_state.store(MeetingState::Leaving, std::memory_order_release);
     {
         std::lock_guard<std::mutex> lk(m_mtx);

--- a/tests/zoom-reconnect-backoff-test.cpp
+++ b/tests/zoom-reconnect-backoff-test.cpp
@@ -1,5 +1,6 @@
 #include "zoom-reconnect-backoff.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 
@@ -58,6 +59,44 @@ int main()
     // backoff policy) still follows the same formula.
     expect_near("multiplier 1.5, attempt 2",
                 compute_backoff_delay_ms(2, 1000, 1.5, 60000, 1.0), 2250);
+
+    // Bounds invariant: for every jitter factor the production RNG can draw
+    // (std::uniform_real_distribution<double>(0.8, 1.2)), the delay must stay
+    // within [0.8 * capped, 1.2 * capped] AND never exceed max_delay_ms. Sweep
+    // the [0.8, 1.2] range across several attempts (both below and at the cap)
+    // to assert the clamp-then-jitter-then-clamp contract holds at the edges.
+    {
+        const double base = 2000, mult = 2.0, cap = 30000;
+        for (int attempt = 0; attempt <= 8; ++attempt) {
+            const double unjittered =
+                compute_backoff_delay_ms(attempt, base, mult, cap, 1.0);
+            for (int k = 0; k <= 40; ++k) {
+                const double jf = 0.8 + (0.4 * k) / 40.0; // walk 0.8 -> 1.2
+                const double d = compute_backoff_delay_ms(attempt, base, mult, cap, jf);
+                if (d < 0.8 * unjittered - 1e-6) {
+                    std::cerr << "jitter bounds: attempt " << attempt
+                              << " factor " << jf << " -> " << d
+                              << " below 0.8x floor " << (0.8 * unjittered) << "\n";
+                    ++g_failures;
+                }
+                // Upper bound is the tighter of (1.2 * pre-jitter delay) and the
+                // cap, since the second clamp re-applies max_delay_ms.
+                const double upper = std::min(1.2 * unjittered, cap);
+                if (d > upper + 1e-6) {
+                    std::cerr << "jitter bounds: attempt " << attempt
+                              << " factor " << jf << " -> " << d
+                              << " above upper bound " << upper << "\n";
+                    ++g_failures;
+                }
+                if (d > cap + 1e-6) {
+                    std::cerr << "jitter bounds: attempt " << attempt
+                              << " factor " << jf << " -> " << d
+                              << " exceeds cap " << cap << "\n";
+                    ++g_failures;
+                }
+            }
+        }
+    }
 
     return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Closes #108

## Summary

Issue #108 was filed on June 13 against a much older engine layout. Auditing it against current `main` shows the substantive work already landed — via the original #108 hardening commit plus PRs #142 (SHM/heartbeat), #145 (centralized join decision) and #146 (extracted `zoom-reconnect-backoff.h` / `zoom-reconnect-schedule.h` with tests). This PR closes the **one real remaining gap** and strengthens the jitter unit test, rather than re-doing finished work.

## Audit: already done on main vs. what this PR adds

| Acceptance criterion | Status on `main` | This PR |
| --- | --- | --- |
| All SDK service getters + participant lookups null/validity-checked before use | **Done.** Every getter in `engine/src/*.cpp` — participants/audio/video/share/recording/livestream/raw-archiving controllers, `createRenderer`, `GetAudioRawdataHelper`, `CreateSettingService`/`GetVideoSettings`, `CreateAuthService`, `CreateMeetingService`, `GetParticipantsList`/`GetUserByUserID`, `GetViewableSharingUserList`/`GetSharingSourceInfoList` — is null-checked with a loud `debug`/`error` IPC event instead of a deref. | No change needed |
| SDK callback params null-checked (teardown/reconnect races) | **Done.** `user_to_info(!u)`, `rebuild_roster` guards `m_ctrl`/`list`, `onUserActiveAudioChange` guards the list, `onRawDataFrameReceived` (video + share) guards `!data` + `valid_i420*`, audio `onMixed/OneWay...` guard `!data`; `attach/detach` `SetEvent(nullptr)` and `onRendererBeDestroyed` null the renderer on the race paths. | No change needed |
| Reconnect back-off includes randomized jitter | **Done (PR #146).** `compute_delay_locked()` draws `std::uniform_real_distribution<double>(0.8, 1.2)` from a once-seeded `std::mt19937` and applies it via the pure, unit-tested `compute_backoff_delay_ms()` (clamp → jitter → clamp). | **Strengthen the bounds test** (see below) |
| Session params persist so recovery survives the UI closing | **Done.** `join()` calls `store_session()` into the process-global `ZoomReconnectManager` (survives dock/UI close); `trigger(EngineCrash)` rejoins from the stored params. | No change needed |
| Session cleared on explicit cancel/leave | **Partial.** `stop()` did `cancel()` + `clear_session()`; **`leave()` cancelled recovery but never cleared the session.** | **Fixed** — `leave()` now clears the session |

## What this PR changes

1. **`src/zoom-engine-client.cpp` — `leave()` now clears the stored recovery session.** An explicit user leave is a deliberate end of participation (it already calls `cancel()` to suppress recovery), but the sensitive join credentials — ZAK, on-behalf token, app-privilege token — were left resident in `ZoomReconnectManager` until the next `join()` or `stop()`. `leave()` now mirrors `stop()` and calls `clear_session()` (which `secure_clear()`s the token strings). A subsequent rejoin re-stores a fresh session via `join()`, and the only consumer of the stored session is `execute_retry()`, which `leave()` has already cancelled — so nothing legitimate depended on the retained copy.

2. **`tests/zoom-reconnect-backoff-test.cpp` — explicit jitter bounds-invariant sweep.** Across attempts both below and at the cap, and every jitter factor the production RNG can draw from `[0.8, 1.2]`, asserts the delay stays within `[0.8*d, min(1.2*d, cap)]` and never exceeds `max_delay_ms` (the load-bearing second clamp).

## Verification

- **Build:** VS 2022 BuildTools, `-G "Visual Studio 17 2022" -A x64`, full **Release** build green — `obs-zoom-plugin`, `ZoomObsEngine`, `ZoomSdkAuthProbe`, and all test targets. (OBS prebuilt deps here are Release-config, so the plugin links against `Release/`.)
- **Tests:** `ctest -C Release` → **16/16 passed**, including `CoreVideoReconnectBackoff` with the new bounds assertions and `CoreVideoReconnectSchedule`.
- **Honest limitation:** the engine SDK-null-check and engine-crash → auto-reconnect paths **cannot be exercised end-to-end from here** — they require a live Zoom meeting and a real SDK crash/late-callback. Item 1 was verified by static audit of every getter/callback deref in `engine/src/*.cpp` (all already guarded); the `leave()` credential-clear fix is verified by build + code inspection of the store/clear/consume call graph, not by a live leave-during-reconnect run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
