### PR TITLE
Triage cppcheck code-quality findings from issue #105

### DIFF
--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -1142,6 +1142,11 @@ int main()
             for (int i = 0; i < 20 && running.load(std::memory_order_acquire); ++i)
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             if (!running.load(std::memory_order_acquire)) break;
+            // cppcheck-suppress knownConditionTrueFalse ; false positive --
+            // cppcheck's bounded (--check-level=normal) branch analysis of
+            // ipc_write_line() (engine-ipc.h), which has multiple return
+            // points inside a retry loop, misreads it as always returning
+            // false. It legitimately returns true on a successful write.
             if (!EngineIpc::write(R"({"cmd":"ping"})")) break;
         }
     });

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -599,20 +599,23 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
         const QString display_name = req.value("display_name").toString("OBS");
 
         // Accept either a numeric ID or a full Zoom URL in meeting_id.
-        const auto parsed = zoom_join_utils::parse_join_input(meeting_id.toStdString());
-        if (parsed.meeting_id.empty()) {
+        // Named distinctly from the outer `parsed` (the ParsedControlRequest
+        // for this whole dispatch call) -- they are different types and
+        // reusing the name shadowed the outer variable (cppcheck shadowVariable).
+        const auto join_input = zoom_join_utils::parse_join_input(meeting_id.toStdString());
+        if (join_input.meeting_id.empty()) {
             write_response(socket, {{"ok", false}, {"error", "invalid_meeting_id"}});
             return;
         }
         std::string passcode = passcode_in.toStdString();
-        if (passcode.empty()) passcode = parsed.passcode;
+        if (passcode.empty()) passcode = join_input.passcode;
         ZoomJoinAuthTokens tokens;
         tokens.on_behalf_token = req.value("on_behalf_token").toString(
-            QString::fromStdString(parsed.on_behalf_token)).toStdString();
+            QString::fromStdString(join_input.on_behalf_token)).toStdString();
         tokens.user_zak = req.value("user_zak").toString(
-            QString::fromStdString(parsed.user_zak)).toStdString();
+            QString::fromStdString(join_input.user_zak)).toStdString();
         tokens.app_privilege_token = req.value("app_privilege_token").toString(
-            QString::fromStdString(parsed.app_privilege_token)).toStdString();
+            QString::fromStdString(join_input.app_privilege_token)).toStdString();
         ZoomPluginSettings settings = ZoomPluginSettings::load();
         const bool needs_oauth_zak =
             tokens.user_zak.empty() &&
@@ -630,7 +633,7 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
 
             std::string zak;
             QString zak_error;
-            if (!ZoomOAuthManager::instance().fetch_zak_blocking(zak, parsed.meeting_id, &zak_error)) {
+            if (!ZoomOAuthManager::instance().fetch_zak_blocking(zak, join_input.meeting_id, &zak_error)) {
                 blog(LOG_WARNING, "[obs-zoom-plugin] Control join OAuth ZAK fetch failed: %s",
                      zak_error.toUtf8().constData());
                 write_response(socket, {
@@ -673,7 +676,7 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
              settings.use_broker_sdk_jwt() ? 1 : 0);
         const bool ok =
             ZoomEngineClient::instance().start(jwt, public_app_key) &&
-            ZoomEngineClient::instance().join(parsed.meeting_id, passcode,
+            ZoomEngineClient::instance().join(join_input.meeting_id, passcode,
                                               display_name.toStdString(),
                                               MeetingKind::Meeting, tokens);
         write_response(socket, {{"ok", ok}});

--- a/src/zoom-iso-panel.cpp
+++ b/src/zoom-iso-panel.cpp
@@ -274,8 +274,12 @@ static qint64 estimated_iso_bytes_per_second(
     const std::vector<ZoomOutputInfo> &outputs, bool record_program)
 {
     qint64 bytes_per_second = 0;
+    // Accumulation is conditional (filtered by is_iso_eligible_output), so
+    // std::accumulate would need an equivalent-or-more-convoluted lambda
+    // here with no readability gain over the plain loop.
     for (const auto &output : outputs) {
         if (is_iso_eligible_output(output))
+            // cppcheck-suppress useStlAlgorithm
             bytes_per_second += estimated_output_bytes_per_second(output);
     }
     if (record_program)

--- a/src/zoom-output-dialog.cpp
+++ b/src/zoom-output-dialog.cpp
@@ -677,9 +677,8 @@ void ZoomOutputDialog::refresh()
                 audio_role->currentData(),
             };
         }
+        m_table->setUpdatesEnabled(false);
     }
-
-    if (m_table) m_table->setUpdatesEnabled(false);
     if (m_participant_table) m_participant_table->setUpdatesEnabled(false);
 
     refresh_participants();

--- a/src/zoom-output-health.h
+++ b/src/zoom-output-health.h
@@ -9,21 +9,25 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
                                 const std::vector<ParticipantInfo> &roster,
                                 bool raw_media_active)
 {
+    // Loop variables are named `out` rather than `output` because a test
+    // translation unit that includes this header (tests/output-health-test.cpp)
+    // defines a file-static helper function named `output()`; a local
+    // `output` here shadowed it (cppcheck shadowFunction).
     std::unordered_map<uint32_t, size_t> assigned_counts;
-    for (const auto &output : outputs) {
-        if (output.assignment == AssignmentMode::Participant &&
-            output.participant_id != 0) {
-            ++assigned_counts[output.participant_id];
+    for (const auto &out : outputs) {
+        if (out.assignment == AssignmentMode::Participant &&
+            out.participant_id != 0) {
+            ++assigned_counts[out.participant_id];
         }
     }
 
-    for (auto &output : outputs) {
-        output.duplicate_participant_assignment = false;
-        output.health_reason = ZoomOutputHealthReason::Ok;
-        if (output.assignment == AssignmentMode::Participant &&
-            output.participant_id != 0) {
-            output.duplicate_participant_assignment =
-                assigned_counts[output.participant_id] > 1;
+    for (auto &out : outputs) {
+        out.duplicate_participant_assignment = false;
+        out.health_reason = ZoomOutputHealthReason::Ok;
+        if (out.assignment == AssignmentMode::Participant &&
+            out.participant_id != 0) {
+            out.duplicate_participant_assignment =
+                assigned_counts[out.participant_id] > 1;
         }
     }
 
@@ -45,55 +49,55 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
             });
     };
 
-    for (auto &output : outputs) {
+    for (auto &out : outputs) {
         const bool wants_media =
-            output.assignment == AssignmentMode::Participant ||
-            output.assignment == AssignmentMode::ActiveSpeaker ||
-            output.assignment == AssignmentMode::SpotlightIndex ||
-            output.assignment == AssignmentMode::ScreenShare;
+            out.assignment == AssignmentMode::Participant ||
+            out.assignment == AssignmentMode::ActiveSpeaker ||
+            out.assignment == AssignmentMode::SpotlightIndex ||
+            out.assignment == AssignmentMode::ScreenShare;
         if (!raw_media_active) {
-            output.health_reason = wants_media
+            out.health_reason = wants_media
                 ? ZoomOutputHealthReason::RawMediaNotReady
                 : ZoomOutputHealthReason::Ok;
-        } else if (output.duplicate_participant_assignment) {
-            output.health_reason = ZoomOutputHealthReason::DuplicateAssignment;
-        } else if (output.assignment == AssignmentMode::ScreenShare &&
+        } else if (out.duplicate_participant_assignment) {
+            out.health_reason = ZoomOutputHealthReason::DuplicateAssignment;
+        } else if (out.assignment == AssignmentMode::ScreenShare &&
                    !screen_share_available) {
-            output.health_reason = ZoomOutputHealthReason::ScreenShareUnavailable;
-        } else if (output.assignment == AssignmentMode::ActiveSpeaker &&
-                   output.participant_id == 0 &&
+            out.health_reason = ZoomOutputHealthReason::ScreenShareUnavailable;
+        } else if (out.assignment == AssignmentMode::ActiveSpeaker &&
+                   out.participant_id == 0 &&
                    !active_video_speaker_available) {
-            output.health_reason = ZoomOutputHealthReason::ActiveSpeakerUnavailable;
-        } else if (output.assignment == AssignmentMode::SpotlightIndex &&
-                   output.spotlight_slot > 0) {
+            out.health_reason = ZoomOutputHealthReason::ActiveSpeakerUnavailable;
+        } else if (out.assignment == AssignmentMode::SpotlightIndex &&
+                   out.spotlight_slot > 0) {
             const auto spotlight_it = std::find_if(
                 roster.begin(), roster.end(),
-                [&output](const ParticipantInfo &participant) {
-                    return participant.spotlight_index == output.spotlight_slot;
+                [&out](const ParticipantInfo &participant) {
+                    return participant.spotlight_index == out.spotlight_slot;
                 });
             if (spotlight_it == roster.end()) {
-                output.health_reason = ZoomOutputHealthReason::SpotlightUnavailable;
+                out.health_reason = ZoomOutputHealthReason::SpotlightUnavailable;
             } else if (!spotlight_it->has_video) {
-                output.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
+                out.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
             }
-        } else if (output.assignment == AssignmentMode::Participant &&
-                   output.participant_id != 0) {
-            const auto participant_it = find_participant(output.participant_id);
+        } else if (out.assignment == AssignmentMode::Participant &&
+                   out.participant_id != 0) {
+            const auto participant_it = find_participant(out.participant_id);
             if (participant_it == roster.end()) {
-                output.health_reason = ZoomOutputHealthReason::ParticipantMissing;
+                out.health_reason = ZoomOutputHealthReason::ParticipantMissing;
             } else if (!participant_it->has_video) {
-                output.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
+                out.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
             }
         }
 
-        if (output.health_reason != ZoomOutputHealthReason::Ok)
+        if (out.health_reason != ZoomOutputHealthReason::Ok)
             continue;
-        if (output.video_stale) {
-            output.health_reason = ZoomOutputHealthReason::StaleFrame;
-        } else if (output.observed_width == 0 || output.observed_height == 0) {
-            output.health_reason = ZoomOutputHealthReason::WaitingForFirstFrame;
-        } else if (output_signal_below_requested(output)) {
-            output.health_reason = ZoomOutputHealthReason::ZoomDeliveredLowerResolution;
+        if (out.video_stale) {
+            out.health_reason = ZoomOutputHealthReason::StaleFrame;
+        } else if (out.observed_width == 0 || out.observed_height == 0) {
+            out.health_reason = ZoomOutputHealthReason::WaitingForFirstFrame;
+        } else if (output_signal_below_requested(out)) {
+            out.health_reason = ZoomOutputHealthReason::ZoomDeliveredLowerResolution;
         }
     }
 }

--- a/tests/output-health-test.cpp
+++ b/tests/output-health-test.cpp
@@ -37,7 +37,7 @@ static ZoomOutputInfo output(uint32_t participant_id = 1)
 
 static bool expect_reason(const char *name,
                           ZoomOutputInfo output_info,
-                          std::vector<ParticipantInfo> roster,
+                          const std::vector<ParticipantInfo> &roster,
                           bool raw_media_active,
                           ZoomOutputHealthReason expected)
 {

--- a/tests/zoom-control-parse-test.cpp
+++ b/tests/zoom-control-parse-test.cpp
@@ -135,7 +135,12 @@ static void test_known_commands()
     expect("unknown command is rejected", !is_known_control_command("totally_bogus_cmd"));
     expect("empty command is rejected", !is_known_control_command(""));
     expect("known commands are case sensitive", !is_known_control_command("HELP"));
+    // Intentional regression guard -- known_control_commands() is a fixed
+    // literal list, so cppcheck correctly proves the count is 19 today.
+    // That's the point of this assertion: it forces this test to be updated
+    // whenever a command is added or removed.
     expect("known command list has no duplicates and no gaps",
+           // cppcheck-suppress knownConditionTrueFalse
            known_control_commands().size() == 19);
 }
 

--- a/tests/zoom-osc-wire-test.cpp
+++ b/tests/zoom-osc-wire-test.cpp
@@ -25,11 +25,19 @@ static QByteArray raw_osc_string(const std::string &s)
 
 int main()
 {
-    // pad4 boundary values.
+    // pad4 boundary values. osc_pad4() is a pure function of a literal
+    // argument, so cppcheck's value-flow analysis correctly proves each of
+    // these comparisons is always true -- that is exactly what a regression
+    // assertion on a pure function's known output is supposed to do.
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(0) == 0", osc_pad4(0) == 0);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(1) == 4", osc_pad4(1) == 4);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(3) == 4", osc_pad4(3) == 4);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(4) == 4", osc_pad4(4) == 4);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(5) == 8", osc_pad4(5) == 8);
 
     // ── Address matching / no-type-tag messages ─────────────────────────
@@ -130,9 +138,6 @@ int main()
     // ── Unsupported type tags ────────────────────────────────────────────
     {
         // 'd' (double) is not a supported tag in this implementation.
-        std::vector<OscArg> in(1);
-        in[0].type = OscArg::Int32;
-        in[0].i = 7;
         // Hand-build so the unsupported tag doesn't trip up osc_build_message
         // (which only knows how to encode 'i' and 's').
         QByteArray pkt = raw_osc_string("/zoom/bad") + raw_osc_string(",id");


### PR DESCRIPTION
Closes #105

## Summary

Triaged every finding from the auto-generated Cppcheck code-quality report (1 `performance` + 15 `style` = 16 findings). All 16 are dispositioned below: 8 fixed (including one dead-code removal and a mild shadowing hazard that's now cleaned up), 8 suppressed inline with a one-line reason each (documented false positives or by-design test assertions), 0 not-applicable.

Verified locally with Cppcheck 2.21.0 (`winget install Cppcheck.Cppcheck`), run with the same flags/paths as `.github/workflows/security-scan.yml`'s report step. None of the 16 original findings reproduce after this change. (Note: my local Cppcheck is newer than whatever `apt-get install cppcheck` pulls on `ubuntu-latest` in CI, so it also surfaces a handful of version-specific findings — `functionStatic`, `constVariableReference`, additional `shadowFunction`/`knownConditionTrueFalse` on files not in the original issue, and `information`-level `normalCheckLevelMaxBranches` notes — that were not part of issue #105 and are out of scope here; happy to open a follow-up if desired.)

## Disposition table

| # | Severity | ID | Location | Disposition |
|---|----------|----|----------|-------------|
| 1 | style | `shadowVariable` | `src/zoom-control-server.cpp:602` | **Fixed.** Local `parsed` (result of `parse_join_input`) shadowed the outer `ParsedControlRequest parsed` for the whole dispatch call — different types, genuinely confusing. Renamed the local to `join_input` and updated its ~5 uses in the `join` handler. |
| 2 | style | `useStlAlgorithm` | `src/zoom-iso-panel.cpp:279` | **Suppressed** (`// cppcheck-suppress useStlAlgorithm`). The loop's accumulation is conditional (filtered by `is_iso_eligible_output`); `std::accumulate` would need an equivalent-or-more-convoluted lambda with no readability gain. |
| 3 | style | `duplicateCondition` | `src/zoom-output-dialog.cpp:682` | **Fixed.** Two back-to-back `if (m_table)` guards with nothing in between that could change `m_table`. Merged `m_table->setUpdatesEnabled(false)` into the existing `if (m_table) { ... }` block above it (identical execution order, one guard instead of two). |
| 4 | style | `knownConditionTrueFalse` | `engine/src/main.cpp:1145` | **Suppressed** (documented false positive). `!EngineIpc::write(...)` was flagged as always true. `ipc_write_line()` (`src/engine-ipc.h`) has multiple return points inside a retry loop; Cppcheck's bounded `--check-level=normal` branch analysis misreads it as always returning `false`. It legitimately returns `true` on a successful write — confirmed by reading the implementation. |
| 5 | style | `shadowFunction` | `src/zoom-output-health.h:13` | **Fixed.** Loop variable `output` shadowed a file-static helper function `output()` defined in `tests/output-health-test.cpp` (which includes this header). Renamed all three loop variables in `apply_output_health()` from `output` to `out`. |
| 6 | style | `shadowFunction` | `src/zoom-output-health.h:20` | **Fixed** — same rename as #5 (second loop in the same function). |
| 7 | style | `shadowFunction` | `src/zoom-output-health.h:48` | **Fixed** — same rename as #5 (third loop in the same function, plus the lambda capturing it). |
| 8 | performance | `passedByValue` | `tests/output-health-test.cpp:40` | **Fixed.** `expect_reason()`'s `std::vector<ParticipantInfo> roster` parameter is never mutated (only forwarded to `apply_output_health`, which takes it by const ref). Changed to `const std::vector<ParticipantInfo> &roster`. |
| 9 | style | `knownConditionTrueFalse` | `tests/zoom-control-parse-test.cpp:139` | **Suppressed** — by-design test assertion. `known_control_commands().size() == 19` is an intentional regression guard on a fixed literal list; Cppcheck's constant-folding correctly proves it true today, which is the point (the test is meant to break when a command is added/removed). |
| 10 | style | `knownConditionTrueFalse` | `tests/zoom-osc-wire-test.cpp:29` | **Suppressed** — same rationale as #9. `osc_pad4(0) == 0` is a boundary-value regression assertion on a pure function; the comparison being statically provable is expected. |
| 11 | style | `knownConditionTrueFalse` | `tests/zoom-osc-wire-test.cpp:30` | **Suppressed** — same rationale as #10 (`osc_pad4(1) == 4`). |
| 12 | style | `knownConditionTrueFalse` | `tests/zoom-osc-wire-test.cpp:31` | **Suppressed** — same rationale as #10 (`osc_pad4(3) == 4`). |
| 13 | style | `knownConditionTrueFalse` | `tests/zoom-osc-wire-test.cpp:32` | **Suppressed** — same rationale as #10 (`osc_pad4(4) == 4`). |
| 14 | style | `knownConditionTrueFalse` | `tests/zoom-osc-wire-test.cpp:33` | **Suppressed** — same rationale as #10 (`osc_pad4(5) == 8`). |
| 15 | style | `unreadVariable` | `tests/zoom-osc-wire-test.cpp:134` | **Fixed** (real dead code, not just noise). In the "unsupported type tag" test block, `std::vector<OscArg> in(1); in[0].type = ...;` was set up but the test actually hand-builds its wire packet via `raw_osc_string`/`osc_write_int32` instead of using `in` — a leftover from copy-pasting the block above it. Removed the unused vector and its two assignments. |
| 16 | style | `unreadVariable` | `tests/zoom-osc-wire-test.cpp:135` | **Fixed** — same removal as #15 (`in[0].i = 7;`). |

## Verification

- Cppcheck 2.21.0, same invocation as `.github/workflows/security-scan.yml`'s report step (`--enable=warning,style,performance,portability,information --inline-suppr ... src engine/src sidecar/src sidecar/tests tests`): none of the 16 original findings reproduce.
- Full Release build (VS 2022 BuildTools, `-G "Visual Studio 17 2022" -A x64`) succeeds: `obs-zoom-plugin.dll`, `ZoomObsEngine.exe`, `CoreVideoSidecar.exe` all build clean.
- `ctest -C Release --output-on-failure`: **16/16 tests passed**.

## Notable finding

None of the 16 were security-relevant, but #1 (`shadowVariable` in the `join` control-server handler) and #5-7 (`shadowFunction` in the output-health logic) were genuine shadowing hazards worth fixing rather than suppressing — same-scope variables with the same name but different types/semantics are the kind of thing that bites a future edit (e.g. someone reaching for `parsed.meeting_id` and instead getting the outer `ParsedControlRequest`'s unrelated fields). #15/#16 also turned out to be real leftover dead code from a copy-paste, not just style noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
