### PR TITLE
Show plugin version in the Settings dialog

### DIFF
--- a/src/cv-style.h
+++ b/src/cv-style.h
@@ -149,6 +149,7 @@ QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal { width: 0; }
 /* ─── Named Widgets ─────────────────────────────────────────────────────────── */
 QLabel#speakerValue { color: #999999; font-style: italic; }
 QLabel#errorLabel   { color: #ee5555; font-size: 11px; }
+QLabel[role="muted"] { color: #8a8a8a; font-size: 11px; }
 
 QFrame#recoveryPanel {
     background-color: rgba(240,160,0,0.10);

--- a/src/zoom-settings-dialog.cpp
+++ b/src/zoom-settings-dialog.cpp
@@ -1,5 +1,6 @@
 #include "zoom-settings-dialog.h"
 #include "cv-style.h"
+#include "obs-zoom-version.h"
 #include "zoom-settings.h"
 #include "zoom-control-server.h"
 #include "zoom-oauth.h"
@@ -185,6 +186,12 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     if (auto *save_btn = buttons->button(QDialogButtonBox::Save))
         save_btn->setProperty("role", "primary");
 
+    auto *version_label =
+        new QLabel(QString("CoreVideo v%1").arg(OBS_ZOOM_PLUGIN_VERSION), this);
+    version_label->setProperty("role", "muted");
+    version_label->setAlignment(Qt::AlignRight);
+    version_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
     auto *layout = new QVBoxLayout(this);
     layout->setSpacing(8);
     layout->addWidget(oauth_group);
@@ -193,6 +200,7 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     layout->addWidget(hw_group);
     layout->addWidget(updates_group);
     layout->addWidget(rc_group);
+    layout->addWidget(version_label);
     layout->addWidget(buttons);
 
     // Apply stylesheet last so all widget properties are already set


### PR DESCRIPTION
Adds a muted, selectable "CoreVideo vX.Y.Z" label above the Settings dialog buttons (with a matching `QLabel[role=muted]` style). Until now the version existed only in the OBS log, the support bundle, and the installer filename — flagged while writing the beta bug-report template, which needs users to self-report their version.

Verified: Release build of obs-zoom-plugin clean against SDK 7.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)