### PR TITLE
Bake production broker URL into all builds (closes the dev-creds leak path)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ set(ZOOM_EMBED_SDK_KEY          "" CACHE STRING "Pre-embedded Zoom SDK key")
 set(ZOOM_EMBED_SDK_SECRET       "" CACHE STRING "Pre-embedded Zoom SDK secret")
 set(ZOOM_EMBED_JWT_TOKEN        "" CACHE STRING "Pre-embedded Zoom JWT token")
 set(ZOOM_EMBED_OAUTH_CLIENT_ID  "y6sIWSwiTZe1JygMx4C9EQ" CACHE STRING "Pre-embedded Zoom OAuth public client ID")
-set(ZOOM_EMBED_OAUTH_AUTHORIZATION_URL "" CACHE STRING "Pre-embedded Zoom OAuth authorization URL")
+# Default to the production broker start URL so every build — including local
+# release builds — carries the full production OAuth identity. A blank broker
+# URL makes the plugin honor developer credential overrides from local OBS
+# config, which is how dev credentials leaked into tester sessions.
+set(ZOOM_EMBED_OAUTH_AUTHORIZATION_URL "https://corevideo.iamfatness.us/oauth/start" CACHE STRING "Pre-embedded Zoom OAuth authorization URL")
 set(ZOOM_EMBED_MEETING_SDK_PUBLIC_APP_KEY "y6sIWSwiTZe1JygMx4C9EQ" CACHE STRING "Pre-embedded Zoom Meeting SDK public app key")
 configure_file(src/zoom-credentials.h.in
                "${CMAKE_CURRENT_BINARY_DIR}/zoom-credentials.h" @ONLY)


### PR DESCRIPTION
Zoom's marketplace review flagged a test session using development credentials. Audit result:

- Sign-in via the broker already presents the production Public Client ID (verified live against /oauth/start).
- Builds since v0.1.27 force `public_app_key` SDK auth with the embedded production Public Client ID.
- The leak paths were: (a) the broker worker's `/oauth/sdk-jwt` route minting SDK JWTs from dev-era `ZOOM_MEETING_SDK_*` secrets — its client ID is now updated to the production Client ID server-side (fixes even old installed builds); and (b) locally-built releases embedding a blank broker URL, which makes the plugin honor developer credential overrides from local OBS config.

This PR closes (b): the production broker start URL is now the CMake default, so every build — local or CI — carries the full production OAuth identity and ignores local dev overrides. The matching CI secret `ZOOM_EMBED_OAUTH_AUTHORIZATION_URL` is set to the same value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)