### PR TITLE
Fix engine-feed leak on outputs assigned to None

### DIFF
--- a/src/zoom-output-health.h
+++ b/src/zoom-output-health.h
@@ -50,11 +50,18 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
     };
 
     for (auto &out : outputs) {
+        // Assignment "None" (Participant mode, participant id 0, not
+        // active-speaker) expects no media: it must not be graded as
+        // waiting/stale or offered recovery actions.
+        const bool unassigned =
+            out.assignment == AssignmentMode::Participant &&
+            out.participant_id == 0 && !out.active_speaker;
         const bool wants_media =
-            out.assignment == AssignmentMode::Participant ||
-            out.assignment == AssignmentMode::ActiveSpeaker ||
-            out.assignment == AssignmentMode::SpotlightIndex ||
-            out.assignment == AssignmentMode::ScreenShare;
+            !unassigned &&
+            (out.assignment == AssignmentMode::Participant ||
+             out.assignment == AssignmentMode::ActiveSpeaker ||
+             out.assignment == AssignmentMode::SpotlightIndex ||
+             out.assignment == AssignmentMode::ScreenShare);
         if (!raw_media_active) {
             out.health_reason = wants_media
                 ? ZoomOutputHealthReason::RawMediaNotReady
@@ -91,6 +98,8 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
         }
 
         if (out.health_reason != ZoomOutputHealthReason::Ok)
+            continue;
+        if (unassigned)
             continue;
         if (out.video_stale) {
             out.health_reason = ZoomOutputHealthReason::StaleFrame;

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -744,6 +744,25 @@ void ZoomSource::subscribe()
                 [&](const ParticipantInfo &p) { return p.user_id == target; });
             if (!primary_present) target = failover;
         }
+        if (target == 0 && !use_active_speaker) {
+            // Assignment cleared ("None"). Tear down any previous engine
+            // subscription: skipping this left the old feed streaming into
+            // shared memory while the UI showed None, and flipping
+            // m_subscribed below made unsubscribe() a permanent no-op, so
+            // the leaked subscription could never be cleaned up.
+            const bool had_subscription =
+                m_subscribed.load(std::memory_order_acquire) ||
+                m_current_subscription_id.load(std::memory_order_acquire) != 0;
+            if (had_subscription) {
+                blog(LOG_INFO,
+                     "[obs-zoom-plugin] Assignment cleared; unsubscribing Zoom source: source=%s uuid=%s",
+                     output_name().c_str(), source_uuid.c_str());
+                clear_subscription_state();
+            }
+            m_subscribed = false;
+            m_current_subscription_id = 0;
+            return;
+        }
         if (target != 0)
             ZoomEngineClient::instance().subscribe(source_uuid, target,
                                                    isolate_audio, audience_audio,
@@ -768,6 +787,11 @@ void ZoomSource::subscribe()
 void ZoomSource::unsubscribe()
 {
     if (!m_subscribed) return;
+    clear_subscription_state();
+}
+
+void ZoomSource::clear_subscription_state()
+{
     ZoomEngineClient::instance().unsubscribe(source_uuid);
     if (!m_director_preview_uuid.empty())
         ZoomEngineClient::instance().unsubscribe(m_director_preview_uuid);

--- a/src/zoom-source.h
+++ b/src/zoom-source.h
@@ -73,6 +73,10 @@ struct ZoomSource {
                              bool new_audience_audio = false);
     void subscribe();
     void unsubscribe();
+    // Sends the engine unsubscribe and resets latched signal state without
+    // consulting m_subscribed — used when an assignment is cleared, where the
+    // subscribed flag may already be false but an engine feed still exists.
+    void clear_subscription_state();
     bool recover_stale_video(uint64_t now_ns, bool force = false);
     bool upgrade_low_quality_video(uint64_t now_ns, bool force = false);
     void activate();

--- a/tests/output-health-test.cpp
+++ b/tests/output-health-test.cpp
@@ -234,6 +234,30 @@ int main()
                        ZoomOutputHealthReason::RawMediaNotReady))
         return 1;
 
+    // Unassigned outputs ("None": participant mode, id 0, not active-speaker)
+    // expect no media and must never be graded waiting/stale or offered
+    // recovery — regression test for None rows showing phantom warnings.
+    ZoomOutputInfo unassigned;
+    unassigned.assignment = AssignmentMode::Participant;
+    unassigned.participant_id = 0;
+    unassigned.active_speaker = false;
+    unassigned.observed_width = 0;
+    unassigned.observed_height = 0;
+    if (!expect_reason("unassigned with no frames is Ok", unassigned,
+                       {participant(1)}, true, ZoomOutputHealthReason::Ok))
+        return 1;
+    unassigned.observed_width = 1920;
+    unassigned.observed_height = 1080;
+    unassigned.video_stale = true;
+    if (!expect_reason("unassigned with latched stale stats is Ok", unassigned,
+                       {participant(1)}, true, ZoomOutputHealthReason::Ok))
+        return 1;
+    // Raw media inactive must also not flag an unassigned output.
+    unassigned.video_stale = false;
+    if (!expect_reason("unassigned ignores raw media inactive", unassigned,
+                       {participant(1)}, false, ZoomOutputHealthReason::Ok))
+        return 1;
+
     // Duplicate + participant missing combination (duplicate should win in current logic order)
     std::vector<ZoomOutputInfo> dup_missing = {output(88), output(88)};
     dup_missing[0].participant_id = 88;


### PR DESCRIPTION
Bug report: an Output Manager row with Assignment **None** showed a live 1920x1080@59.9 signal and negotiated SDK status, and the panel showed 6 phantom stale/recover warnings on 9 outputs.

**Root cause:** `ZoomSource::subscribe()` with a cleared assignment (Participant mode, id 0) skipped the engine call and set `m_subscribed = false` — but never unsubscribed the previous feed. The engine kept streaming the old participant into shared memory, and since `unsubscribe()` early-returns when `m_subscribed` is false, the leaked subscription was permanently uncleanable (bandwidth + SHM slot leak per occurrence). Secondary: `apply_output_health()` had no unassigned exemption, so None rows were graded WaitingForFirstFrame/StaleFrame and offered Recover.

**Fix:** assignment clears now call a new `clear_subscription_state()` (engine unsubscribe + latched-stat reset, not gated on the flag) with a log line; unassigned outputs are exempt from media health grading. Three regression tests cover the reported scenario (unassigned + no frames, unassigned + latched stale stats, unassigned + raw media inactive). Build clean, ctest 16/16.

Runtime verification for the reporter: assign a participant, watch frames, set Assignment to None — the Signal column should clear immediately and the OBS log shows "Assignment cleared; unsubscribing Zoom source".

🤖 Generated with [Claude Code](https://claude.com/claude-code)