### PR TITLE
Fix OBS 32.2 breakage: isolate FFmpeg runtime from OBS's own DLLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+### Fixed
+- **OBS 32.2 compatibility: OBS no longer breaks after installing CoreVideo.**
+  OBS Studio 32.2 upgraded its bundled FFmpeg to major version 8, which uses
+  the same DLL filenames (`avcodec-62.dll`, `avutil-60.dll`, …) as the FFmpeg
+  runtime CoreVideo shipped loose into `obs-plugins\64bit`. On OBS 32.2+ those
+  loose copies shadowed OBS's own DLLs, so OBS's built-in `obs-ffmpeg` module
+  (and CoreVideo itself) failed to load, taking down recording/streaming
+  encoders with it. The FFmpeg runtime now lives in a private
+  `obs-plugins\64bit\corevideo-ffmpeg\` directory and is delay-loaded through
+  a resolver that binds whatever FFmpeg the OBS process already has (OBS
+  32.2+) or CoreVideo's bundled copy (OBS ≤ 32.1) — never a mix. The
+  installer removes the legacy loose DLLs on upgrade; zip users should delete
+  `av*-*.dll` / `sw*-*.dll` from `obs-plugins\64bit` manually. If a usable
+  FFmpeg runtime cannot be bound, hardware-accelerated conversion falls back
+  to the CPU path with a clear log message instead of failing.
+
 ## [0.1.29] - 2026-07-30
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,48 @@ if(ENABLE_FFMPEG_HW_ACCEL)
         add_library(corevideo_ffmpeg INTERFACE)
         target_include_directories(corevideo_ffmpeg INTERFACE
             "${COREVIDEO_AVFILTER_INC}")
-        target_link_libraries(corevideo_ffmpeg INTERFACE
-            "${COREVIDEO_AVFILTER_LIB}" "${COREVIDEO_AVUTIL_LIB}")
-        set(COREVIDEO_FFMPEG_TARGET corevideo_ffmpeg)
         set(COREVIDEO_FFMPEG_BIN_DIR "${FFMPEG_ROOT}/bin")
+        if(WIN32 AND MSVC)
+            # The prebuilt import libs are dlltool-style long-format archives,
+            # which /DELAYLOAD cannot match (LNK4199 leaves the imports
+            # static). Regenerate short-format import libs from the DLLs'
+            # export tables so the delay-load resolver in
+            # cv-ffmpeg-loader.cpp actually receives the loads.
+            file(GLOB _cv_avfilter_bin "${COREVIDEO_FFMPEG_BIN_DIR}/avfilter-*.dll")
+            file(GLOB _cv_avutil_bin "${COREVIDEO_FFMPEG_BIN_DIR}/avutil-*.dll")
+            if(NOT _cv_avfilter_bin OR NOT _cv_avutil_bin)
+                message(FATAL_ERROR "ENABLE_FFMPEG_HW_ACCEL: avfilter/avutil "
+                    "DLL not found in ${COREVIDEO_FFMPEG_BIN_DIR}")
+            endif()
+            list(GET _cv_avfilter_bin 0 _cv_avfilter_bin)
+            list(GET _cv_avutil_bin 0 _cv_avutil_bin)
+            get_filename_component(_cv_msvc_bin "${CMAKE_LINKER}" DIRECTORY)
+            set(_cv_delaylib_dir "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg-delay-libs")
+            file(MAKE_DIRECTORY "${_cv_delaylib_dir}")
+            foreach(_cv_dll IN ITEMS "${_cv_avfilter_bin}" "${_cv_avutil_bin}")
+                get_filename_component(_cv_dll_we "${_cv_dll}" NAME_WE)
+                set(_cv_out_lib "${_cv_delaylib_dir}/${_cv_dll_we}.lib")
+                execute_process(
+                    COMMAND powershell -NoProfile -ExecutionPolicy Bypass
+                        -File "${CMAKE_CURRENT_SOURCE_DIR}/scripts/New-DelayImportLib.ps1"
+                        -DllPath "${_cv_dll}"
+                        -DumpbinExe "${_cv_msvc_bin}/dumpbin.exe"
+                        -LibExe "${_cv_msvc_bin}/lib.exe"
+                        -OutLib "${_cv_out_lib}"
+                    RESULT_VARIABLE _cv_gen_result
+                    OUTPUT_VARIABLE _cv_gen_output
+                    ERROR_VARIABLE _cv_gen_output)
+                if(NOT _cv_gen_result EQUAL 0)
+                    message(FATAL_ERROR "Import library regeneration failed "
+                        "for ${_cv_dll}:\n${_cv_gen_output}")
+                endif()
+                target_link_libraries(corevideo_ffmpeg INTERFACE "${_cv_out_lib}")
+            endforeach()
+        else()
+            target_link_libraries(corevideo_ffmpeg INTERFACE
+                "${COREVIDEO_AVFILTER_LIB}" "${COREVIDEO_AVUTIL_LIB}")
+        endif()
+        set(COREVIDEO_FFMPEG_TARGET corevideo_ffmpeg)
         message(STATUS "FFmpeg HW accel: using FFMPEG_ROOT=${FFMPEG_ROOT}")
     else()
         find_package(PkgConfig REQUIRED)
@@ -220,6 +258,7 @@ if(COREVIDEO_BUILD_PLUGIN)
         src/zoom-osc-server.cpp
         src/obs-utils.cpp
         src/hw-video-pipeline.cpp
+        src/cv-ffmpeg-loader.cpp
         src/cv-widgets.cpp
         src/cv-onboarding.cpp
         src/cv-update-check.cpp
@@ -268,21 +307,44 @@ if(COREVIDEO_BUILD_PLUGIN)
     if(ENABLE_FFMPEG_HW_ACCEL)
         target_link_libraries(obs-zoom-plugin PRIVATE ${COREVIDEO_FFMPEG_TARGET})
         target_compile_definitions(obs-zoom-plugin PRIVATE COREVIDEO_HW_ACCEL)
-        # Ship the FFmpeg runtime DLLs alongside the plugin on Windows so
-        # OBS's plugin loader can resolve avfilter / avutil / avcodec /
-        # swscale / swresample without polluting PATH.
+        # Ship the FFmpeg runtime in the private corevideo-ffmpeg/ subdirectory
+        # and delay-load it. OBS 32.2+ bundles FFmpeg 8 under the same DLL
+        # names; loose copies in obs-plugins/64bit made OBS's own obs-ffmpeg
+        # module bind our build and fail to load. cv-ffmpeg-loader.cpp resolves
+        # the delayed imports (in-process copies first, else the private dir).
         if(WIN32 AND COREVIDEO_FFMPEG_BIN_DIR AND EXISTS "${COREVIDEO_FFMPEG_BIN_DIR}")
             file(GLOB COREVIDEO_FFMPEG_DLLS "${COREVIDEO_FFMPEG_BIN_DIR}/*.dll")
             if(COREVIDEO_FFMPEG_DLLS)
                 add_custom_command(TARGET obs-zoom-plugin POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E make_directory
+                        "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
                         ${COREVIDEO_FFMPEG_DLLS}
-                        "$<TARGET_FILE_DIR:obs-zoom-plugin>"
+                        "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
                     COMMENT "Copying FFmpeg runtime DLLs for obs-zoom-plugin")
             endif()
             install(DIRECTORY "${COREVIDEO_FFMPEG_BIN_DIR}/"
-                DESTINATION "obs-plugins/64bit"
+                DESTINATION "obs-plugins/64bit/corevideo-ffmpeg"
                 FILES_MATCHING PATTERN "*.dll")
+
+            file(GLOB _cv_avfilter_dlls RELATIVE "${COREVIDEO_FFMPEG_BIN_DIR}"
+                "${COREVIDEO_FFMPEG_BIN_DIR}/avfilter-*.dll")
+            file(GLOB _cv_avutil_dlls RELATIVE "${COREVIDEO_FFMPEG_BIN_DIR}"
+                "${COREVIDEO_FFMPEG_BIN_DIR}/avutil-*.dll")
+            if(NOT _cv_avfilter_dlls OR NOT _cv_avutil_dlls)
+                message(FATAL_ERROR
+                    "ENABLE_FFMPEG_HW_ACCEL: avfilter/avutil DLL not found in "
+                    "${COREVIDEO_FFMPEG_BIN_DIR}; cannot set up delay-loading")
+            endif()
+            list(GET _cv_avfilter_dlls 0 _cv_avfilter_dll)
+            list(GET _cv_avutil_dlls 0 _cv_avutil_dll)
+            target_compile_definitions(obs-zoom-plugin PRIVATE
+                "COREVIDEO_AVFILTER_DLL=\"${_cv_avfilter_dll}\""
+                "COREVIDEO_AVUTIL_DLL=\"${_cv_avutil_dll}\"")
+            target_link_options(obs-zoom-plugin PRIVATE
+                "/DELAYLOAD:${_cv_avfilter_dll}"
+                "/DELAYLOAD:${_cv_avutil_dll}")
+            target_link_libraries(obs-zoom-plugin PRIVATE delayimp)
         endif()
     endif()
 

--- a/installer/corevideo.nsi
+++ b/installer/corevideo.nsi
@@ -161,6 +161,19 @@ FunctionEnd
 
 Section "CoreVideo for OBS" SecCoreVideo
   Call CheckObsClosed
+
+  ; v0.1.29 and earlier left the FFmpeg runtime loose in obs-plugins\64bit,
+  ; where it collides with the same-named FFmpeg 8 DLLs OBS 32.2+ keeps in
+  ; bin\64bit and stops OBS's own obs-ffmpeg module from loading. The runtime
+  ; now lives in obs-plugins\64bit\corevideo-ffmpeg\; sweep any leftovers.
+  Delete "$INSTDIR\obs-plugins\64bit\avcodec-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avdevice-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avfilter-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avformat-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avutil-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\swresample-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\swscale-*.dll"
+
   SetOutPath "$INSTDIR"
   File /r "${SOURCE_DIR}\*.*"
   Call VerifyInstalledRuntime

--- a/scripts/New-DelayImportLib.ps1
+++ b/scripts/New-DelayImportLib.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+Regenerates an MSVC short-format import library from a DLL's export table.
+
+The prebuilt FFmpeg import libraries (C:\ffmpeg\lib\*.lib) are dlltool-style
+long-format archives. MSVC's /DELAYLOAD cannot attribute imports from those
+to their DLL (LNK4199 "no imports found"), which silently leaves the imports
+static. Short-format libraries produced by lib.exe /def work with /DELAYLOAD.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$DllPath,
+    [Parameter(Mandatory = $true)][string]$DumpbinExe,
+    [Parameter(Mandatory = $true)][string]$LibExe,
+    [Parameter(Mandatory = $true)][string]$OutLib
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $DllPath)) { throw "DLL not found: $DllPath" }
+$dllName = Split-Path -Leaf $DllPath
+
+$exports = & $DumpbinExe /NOLOGO /EXPORTS $DllPath
+if ($LASTEXITCODE -ne 0) { throw "dumpbin failed on $DllPath (exit $LASTEXITCODE)" }
+
+# Export rows look like: "  ordinal  hint  RVA       name [= forwarder]"
+$names = @()
+$inTable = $false
+foreach ($line in $exports) {
+    if ($line -match '^\s+ordinal\s+hint\s+RVA\s+name') { $inTable = $true; continue }
+    if (-not $inTable) { continue }
+    if ($line -match '^\s*Summary') { break }
+    if ($line -match '^\s*\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]{8}\s+(\S+)') {
+        $names += $Matches[1]
+    }
+}
+if ($names.Count -eq 0) { throw "No exports parsed from $DllPath" }
+
+$defPath = [System.IO.Path]::ChangeExtension($OutLib, ".def")
+$defLines = @("LIBRARY $dllName", "EXPORTS") + $names
+Set-Content -LiteralPath $defPath -Value $defLines -Encoding ascii
+
+& $LibExe /NOLOGO "/DEF:$defPath" /MACHINE:X64 "/OUT:$OutLib"
+if ($LASTEXITCODE -ne 0) { throw "lib.exe failed for $OutLib (exit $LASTEXITCODE)" }
+
+Write-Host "Generated $OutLib ($($names.Count) exports from $dllName)"

--- a/scripts/Test-CoreVideoPackage.ps1
+++ b/scripts/Test-CoreVideoPackage.ps1
@@ -101,8 +101,18 @@ $ffmpegDlls = @(
     "swresample-6.dll",
     "swscale-9.dll"
 )
+
+# The FFmpeg runtime must never sit loose in obs-plugins\64bit: OBS 32.2+
+# bundles FFmpeg 8 under identical DLL names, and loose copies there stop
+# OBS's own obs-ffmpeg module from loading (breaks OBS outright).
+$looseFfmpeg = @(Get-ChildItem -LiteralPath (Join-Path $root "obs-plugins\64bit") -File -ErrorAction Stop |
+    Where-Object { $_.Name -match '^(avcodec|avdevice|avfilter|avformat|avutil|swresample|swscale)-\d+\.dll$' })
+if ($looseFfmpeg.Count -gt 0) {
+    throw "Release package validation failed. FFmpeg DLLs must live in obs-plugins\64bit\corevideo-ffmpeg, not loose in obs-plugins\64bit: $($looseFfmpeg.Name -join ', ')"
+}
+
 $ffmpegPresent = $ffmpegDlls | Where-Object {
-    Test-Path -LiteralPath (Join-Path $root "obs-plugins\64bit\$_")
+    Test-Path -LiteralPath (Join-Path $root "obs-plugins\64bit\corevideo-ffmpeg\$_")
 }
 if ($ffmpegPresent.Count -gt 0 -and $ffmpegPresent.Count -ne $ffmpegDlls.Count) {
     throw "Release package has a partial FFmpeg runtime. Present: $($ffmpegPresent -join ', ')"

--- a/scripts/release-local.ps1
+++ b/scripts/release-local.ps1
@@ -369,6 +369,15 @@ try {
         if (-not (Test-Path -LiteralPath $ObsInstallPath)) {
             throw "OBS install path does not exist: $ObsInstallPath"
         }
+        # Pre-v0.1.30 installs left the FFmpeg runtime loose in obs-plugins\64bit,
+        # which collides with OBS 32.2+'s same-named FFmpeg 8 DLLs and stops
+        # OBS's own obs-ffmpeg module from loading. Sweep before copying.
+        $legacyDir = Join-Path $ObsInstallPath "obs-plugins\64bit"
+        if (Test-Path -LiteralPath $legacyDir) {
+            Get-ChildItem -LiteralPath $legacyDir -File |
+                Where-Object { $_.Name -match '^(avcodec|avdevice|avfilter|avformat|avutil|swresample|swscale)-\d+\.dll$' } |
+                Remove-Item -Force
+        }
         Copy-Item -Path (Join-Path $installPath "*") -Destination $ObsInstallPath -Recurse -Force
         & (Join-Path $PSScriptRoot "Test-CoreVideoPackage.ps1") `
             -PackageRoot $ObsInstallPath `

--- a/src/cv-ffmpeg-loader.cpp
+++ b/src/cv-ffmpeg-loader.cpp
@@ -1,0 +1,219 @@
+#include "cv-ffmpeg-loader.h"
+
+#include <obs-module.h>
+
+#if defined(_WIN32) && defined(COREVIDEO_HW_ACCEL)
+
+#include <windows.h>
+#include <delayimp.h>
+
+#include <string>
+
+// OBS 32.2+ bundles FFmpeg 8 under the same DLL names we ship (avfilter-11,
+// avutil-60, ...). Loose copies of those names in obs-plugins/64bit made
+// OBS's own obs-ffmpeg module bind our build and fail to load, breaking OBS
+// outright (and our plugin with it). The runtime therefore lives in the
+// private corevideo-ffmpeg/ subdirectory and resolves through the delay-load
+// hook below:
+//   - if the process already holds avfilter/avutil (OBS 32.2+), bind those —
+//     the Windows loader dedups modules by base name, so a second same-named
+//     copy can never be kept isolated from the first;
+//   - otherwise (OBS <= 32.1 ships avcodec-61-era names, no overlap) load our
+//     bundled runtime by absolute path so nothing else resolves into it.
+
+#ifndef COREVIDEO_AVFILTER_DLL
+#define COREVIDEO_AVFILTER_DLL "avfilter-11.dll"
+#endif
+#ifndef COREVIDEO_AVUTIL_DLL
+#define COREVIDEO_AVUTIL_DLL "avutil-60.dll"
+#endif
+
+static CvFfmpegRuntime g_runtime = CvFfmpegRuntime::Unavailable;
+static std::wstring g_private_dir;
+
+static std::wstring widen(const char *narrow)
+{
+    std::wstring wide;
+    for (const char *p = narrow; *p; ++p)
+        wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+    return wide;
+}
+
+static std::wstring plugin_directory()
+{
+    HMODULE self = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            reinterpret_cast<LPCWSTR>(&plugin_directory),
+                            &self))
+        return {};
+    wchar_t path[MAX_PATH];
+    DWORD len = GetModuleFileNameW(self, path, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH)
+        return {};
+    std::wstring dir(path, len);
+    size_t slash = dir.find_last_of(L"\\/");
+    if (slash == std::wstring::npos)
+        return {};
+    return dir.substr(0, slash + 1);
+}
+
+static bool is_delayed_ffmpeg_dll(const char *name)
+{
+    return _strnicmp(name, "avfilter", 8) == 0 ||
+           _strnicmp(name, "avutil", 6) == 0;
+}
+
+static FARPROC WINAPI cv_delayload_hook(unsigned event, DelayLoadInfo *info)
+{
+    if (event != dliNotePreLoadLibrary || !info || !info->szDll)
+        return nullptr;
+    if (!is_delayed_ffmpeg_dll(info->szDll))
+        return nullptr;
+
+    // A same-named module already in the process always wins; the loader
+    // would dedup to it on any name-based load anyway.
+    if (HMODULE loaded = GetModuleHandleA(info->szDll))
+        return reinterpret_cast<FARPROC>(loaded);
+
+    if (g_runtime != CvFfmpegRuntime::PrivateCopies || g_private_dir.empty())
+        return nullptr; // fall through to default search; init() already warned
+
+    std::wstring path = g_private_dir + widen(info->szDll);
+    // DLL_LOAD_DIR makes avfilter's own imports (avcodec/swscale/...) resolve
+    // from corevideo-ffmpeg/ first instead of OBS's bin directory.
+    HMODULE mod = LoadLibraryExW(path.c_str(), nullptr,
+                                 LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+                                     LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    if (!mod) {
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Failed to load private FFmpeg runtime '%s' "
+             "(error %lu) — hardware acceleration will fail over to CPU",
+             info->szDll, GetLastError());
+        return nullptr;
+    }
+    blog(LOG_INFO, "[obs-zoom-plugin] Loaded private FFmpeg runtime '%s'",
+         info->szDll);
+    return reinterpret_cast<FARPROC>(mod);
+}
+
+extern "C" const PfnDliHook __pfnDliNotifyHook2 = cv_delayload_hook;
+
+static bool legacy_loose_dlls_present(const std::wstring &plugin_dir)
+{
+    static const wchar_t *families[] = {L"avcodec-*.dll",  L"avdevice-*.dll",
+                                        L"avfilter-*.dll", L"avformat-*.dll",
+                                        L"avutil-*.dll",   L"swresample-*.dll",
+                                        L"swscale-*.dll"};
+    for (const wchar_t *pattern : families) {
+        WIN32_FIND_DATAW fd;
+        HANDLE find = FindFirstFileW((plugin_dir + pattern).c_str(), &fd);
+        if (find != INVALID_HANDLE_VALUE) {
+            FindClose(find);
+            return true;
+        }
+    }
+    return false;
+}
+
+CvFfmpegRuntime cv_ffmpeg_loader_init()
+{
+    std::wstring plugin_dir = plugin_directory();
+    if (plugin_dir.empty()) {
+        blog(LOG_ERROR, "[obs-zoom-plugin] Could not locate plugin directory; "
+                        "hardware acceleration disabled");
+        g_runtime = CvFfmpegRuntime::Unavailable;
+        return g_runtime;
+    }
+
+    // Pre-v0.1.30 installs left the FFmpeg runtime loose in obs-plugins/64bit,
+    // which collides with OBS 32.2+'s own FFmpeg 8 and stops obs-ffmpeg.dll
+    // from loading. We cannot delete them from here (no elevation, possibly
+    // already mapped) — shout so support bundles show the cause.
+    if (legacy_loose_dlls_present(plugin_dir))
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Legacy FFmpeg DLLs found loose in the OBS "
+             "plugin directory. On OBS 32.2+ these prevent OBS's own "
+             "obs-ffmpeg module from loading. Run the CoreVideo v0.1.30+ "
+             "installer (or delete av*-*.dll / sw*-*.dll from "
+             "obs-plugins\\64bit) to fix this.");
+
+    bool filter_loaded = GetModuleHandleA(COREVIDEO_AVFILTER_DLL) != nullptr;
+    bool util_loaded = GetModuleHandleA(COREVIDEO_AVUTIL_DLL) != nullptr;
+
+    if (filter_loaded && util_loaded) {
+        g_runtime = CvFfmpegRuntime::ProcessCopies;
+    } else if (filter_loaded != util_loaded) {
+        // One half of the pair is mapped without the other (e.g. obs-ffmpeg
+        // failed mid-load). Binding across builds is how crashes start —
+        // refuse and stay on the CPU path.
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Inconsistent FFmpeg runtime in process "
+             "(%s loaded, %s not) — hardware acceleration disabled",
+             filter_loaded ? COREVIDEO_AVFILTER_DLL : COREVIDEO_AVUTIL_DLL,
+             filter_loaded ? COREVIDEO_AVUTIL_DLL : COREVIDEO_AVFILTER_DLL);
+        g_runtime = CvFfmpegRuntime::Unavailable;
+    } else {
+        g_private_dir = plugin_dir + L"corevideo-ffmpeg\\";
+        DWORD attrs =
+            GetFileAttributesW((g_private_dir + widen(COREVIDEO_AVFILTER_DLL))
+                                   .c_str());
+        if (attrs != INVALID_FILE_ATTRIBUTES) {
+            g_runtime = CvFfmpegRuntime::PrivateCopies;
+        } else {
+            blog(LOG_ERROR,
+                 "[obs-zoom-plugin] Bundled FFmpeg runtime missing at "
+                 "corevideo-ffmpeg\\%s — hardware acceleration disabled",
+                 COREVIDEO_AVFILTER_DLL);
+            g_runtime = CvFfmpegRuntime::Unavailable;
+        }
+    }
+    return g_runtime;
+}
+
+bool cv_ffmpeg_available()
+{
+    return g_runtime == CvFfmpegRuntime::ProcessCopies ||
+           g_runtime == CvFfmpegRuntime::PrivateCopies;
+}
+
+const char *cv_ffmpeg_runtime_describe()
+{
+    switch (g_runtime) {
+    case CvFfmpegRuntime::ProcessCopies:
+        return "using FFmpeg runtime already loaded by OBS (OBS 32.2+)";
+    case CvFfmpegRuntime::PrivateCopies:
+        return "using bundled FFmpeg runtime from corevideo-ffmpeg/";
+    case CvFfmpegRuntime::SystemLinked:
+        return "using system-linked FFmpeg";
+    default:
+        return "no usable FFmpeg runtime — hardware acceleration disabled";
+    }
+}
+
+#else // !_WIN32 || !COREVIDEO_HW_ACCEL
+
+#ifdef COREVIDEO_HW_ACCEL
+static CvFfmpegRuntime g_runtime = CvFfmpegRuntime::SystemLinked;
+#else
+static CvFfmpegRuntime g_runtime = CvFfmpegRuntime::Unavailable;
+#endif
+
+CvFfmpegRuntime cv_ffmpeg_loader_init()
+{
+    return g_runtime;
+}
+
+bool cv_ffmpeg_available()
+{
+    return g_runtime == CvFfmpegRuntime::SystemLinked;
+}
+
+const char *cv_ffmpeg_runtime_describe()
+{
+    return g_runtime == CvFfmpegRuntime::SystemLinked
+               ? "using system-linked FFmpeg"
+               : "built without FFmpeg hardware acceleration";
+}
+
+#endif

--- a/src/cv-ffmpeg-loader.h
+++ b/src/cv-ffmpeg-loader.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Decides where the plugin's FFmpeg runtime (avfilter/avutil) comes from and,
+// on Windows, installs the delay-load resolver that enforces the decision.
+// Must run before the first HwVideoPipeline use. See cv-ffmpeg-loader.cpp.
+enum class CvFfmpegRuntime {
+    SystemLinked,  // non-Windows: normal dynamic linking, nothing to resolve
+    ProcessCopies, // binding the avfilter/avutil OBS already loaded (OBS 32.2+)
+    PrivateCopies, // loading our bundled runtime from corevideo-ffmpeg/
+    Unavailable,   // no usable runtime: hardware acceleration must stay off
+};
+
+CvFfmpegRuntime cv_ffmpeg_loader_init();
+
+// True once init() found a usable runtime. HwVideoPipeline::init() checks this
+// before touching any FFmpeg symbol so a missing runtime degrades to the CPU
+// path instead of raising a delay-load exception.
+bool cv_ffmpeg_available();
+
+const char *cv_ffmpeg_runtime_describe();

--- a/src/hw-video-pipeline.cpp
+++ b/src/hw-video-pipeline.cpp
@@ -1,4 +1,5 @@
 #include "hw-video-pipeline.h"
+#include "cv-ffmpeg-loader.h"
 #ifdef COREVIDEO_HW_ACCEL
 
 extern "C" {
@@ -60,6 +61,14 @@ bool HwVideoPipeline::init(HwAccelMode mode)
     shutdown();
     if (mode == HwAccelMode::None)
         return false;
+
+    // Without a usable runtime the first avfilter call would raise a
+    // delay-load exception instead of failing over to the CPU path.
+    if (!cv_ffmpeg_available()) {
+        blog(LOG_WARNING, "[obs-zoom-plugin] HW accel: %s",
+             cv_ffmpeg_runtime_describe());
+        return false;
+    }
 
     if (mode == HwAccelMode::Auto) {
         const auto it = std::find_if(std::begin(kBackends), std::end(kBackends),

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -14,6 +14,7 @@
 #include "zoom-iso-panel.h"
 #include "zoom-control-server.h"
 #include "zoom-osc-server.h"
+#include "cv-ffmpeg-loader.h"
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
@@ -349,7 +350,9 @@ bool obs_module_load(void)
 {
     blog(LOG_INFO, "[obs-zoom-plugin] Loading plugin v%s", OBS_ZOOM_PLUGIN_VERSION);
 #ifdef COREVIDEO_HW_ACCEL
-    blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: enabled at build (FFmpeg)");
+    cv_ffmpeg_loader_init();
+    blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: %s",
+         cv_ffmpeg_runtime_describe());
 #else
     blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: disabled (built without ENABLE_FFMPEG_HW_ACCEL - CPU path only)");
 #endif


### PR DESCRIPTION
## Problem

Beta users on OBS Studio 32.2+ report OBS crashing/breaking after installing CoreVideo. Root cause (reproduced locally on a portable OBS 32.2.1 rig):

- OBS 32.2 (2026-07-21) upgraded its bundled FFmpeg to major version **8** — same DLL filenames (`avcodec-62.dll`, `avutil-60.dll`, `avfilter-11.dll`, …) as the FFmpeg runtime CoreVideo ships.
- We installed that runtime **loose into `obs-plugins/64bit`**, the directory OBS loads *all* plugins from. With OBS 32.2's new Windows DLL-loading behavior, OBS's own `obs-ffmpeg.dll` resolved our build instead of OBS's and **failed to load**, killing recording/streaming encoders and breaking OBS outright (`Plugin Load Error: obs-ffmpeg, obs-zoom-plugin`).
- On OBS ≤ 32.1 the names never overlapped (`avcodec-61`), which is why this only appeared with the OBS 32.2 auto-update.

## Fix

- FFmpeg runtime moves to a private **`obs-plugins/64bit/corevideo-ffmpeg/`** directory.
- `avfilter`/`avutil` imports are now **delay-loaded** through a resolver (`src/cv-ffmpeg-loader.cpp`) that binds the FFmpeg already loaded in the OBS process when present (OBS 32.2+), else our bundled copies by absolute path (OBS ≤ 32.1) — never a mix (the Windows loader dedups modules by base name, so mixing is exactly how the crash happened).
- If no usable runtime can be bound, hardware-accelerated conversion **falls back to the CPU path** with a clear log line instead of raising a delay-load exception.
- The prebuilt FFmpeg import libs are dlltool-style long-format, which `/DELAYLOAD` silently ignores (LNK4199) — `scripts/New-DelayImportLib.ps1` regenerates short-format import libs from the DLL export tables at configure time.
- **Installer sweeps the legacy loose DLLs on upgrade** (NSIS + `release-local.ps1 -Install`); plugin startup logs an error if leftovers remain; `Test-CoreVideoPackage` now fails any package with loose FFmpeg DLLs.

## Verification

- Portable OBS **32.2.1** rig: `obs-ffmpeg.dll` and `obs-zoom-plugin.dll` both load, `ffmpeg_aac` encoder present, resolver logs "using FFmpeg runtime already loaded by OBS (OBS 32.2+)".
- Portable OBS **32.1.2** rig: plugin loads, resolver logs "using bundled FFmpeg runtime from corevideo-ffmpeg/".
- `dumpbin /DEPENDENTS`: avfilter/avutil confirmed in the delay-load section.
- 16/16 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)