### PR TITLE
CHANGELOG: 0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-07-31
+
 ### Fixed
 - **OBS 32.2 compatibility: OBS no longer breaks after installing CoreVideo.**
   OBS Studio 32.2 upgraded its bundled FFmpeg to major version 8, which uses


### PR DESCRIPTION
Version stamp for the v0.1.30 release (OBS 32.2 FFmpeg-collision fix, PR #162).

🤖 Generated with [Claude Code](https://claude.com/claude-code)