### PR TITLE
macOS engine: working port — auth, join, roster, raw media, screen share

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,124 @@
+name: Bug Report
+description: Something in CoreVideo (the OBS plugin) isn't working as expected.
+title: "[Bug]: "
+labels: ["bug", "beta"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug during the CoreVideo public beta. The more of this
+        we can fill in, the faster we can reproduce it.
+
+        Before filing, it's worth skimming the
+        [Troubleshooting section](https://corevideo.io/documentation/#troubleshooting)
+        of the docs — SmartScreen warnings, "no video" checklists, sign-in loops,
+        and firewall prompts are all covered there.
+
+  - type: input
+    id: version
+    attributes:
+      label: CoreVideo version
+      description: >
+        CoreVideo does not currently show its version in the Zoom Plugin Settings
+        dialog. Find it one of these ways: the exported support bundle's
+        `summary.txt` ("Plugin version: ..."), the OBS log line
+        `[obs-zoom-plugin] Loading plugin v...` (Help → Log Files → View Current
+        Log in OBS), or the installer/ZIP filename you downloaded from
+        https://corevideo.io/download or the
+        [Releases page](https://github.com/iamfatness/CoreVideo/releases)
+        (e.g. `CoreVideo-Setup-1.4.0.exe`).
+      placeholder: e.g. 1.4.0
+    validations:
+      required: true
+
+  - type: input
+    id: obs-version
+    attributes:
+      label: OBS Studio version
+      description: Help → About in OBS Studio. CoreVideo requires OBS Studio 30+.
+      placeholder: e.g. 31.0.2
+    validations:
+      required: true
+
+  - type: input
+    id: windows-version
+    attributes:
+      label: Windows version
+      description: Settings → System → About, or run `winver`. Windows 10/11 x64 is the only supported platform.
+      placeholder: e.g. Windows 11 23H2 (build 22631.3737)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug. Screenshots or a short screen recording help a lot.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Sign in with Zoom
+        2. Join meeting ...
+        3. Add a Zoom Participant source assigned to ...
+        4. ...
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: support-bundle-checklist
+    attributes:
+      label: Support bundle
+      description: >
+        Please attach a redacted support bundle — it's the single most useful
+        thing you can attach and takes under a minute to create.
+
+
+        **How to export it:** In OBS, open the **Zoom Diagnostics** dock
+        (Docks → Zoom Diagnostics, or Tools → Zoom Diagnostics if you haven't
+        shown the dock yet) and click **Create Support Bundle**. This writes a
+        timestamped folder and a matching `.zip`
+        (`CoreVideo-support-<timestamp>.zip`) under
+        `%AppData%\obs-studio\plugin_config\obs-zoom-plugin\support-bundles\`.
+        The bundle already redacts SDK keys/secrets, OAuth tokens, and other
+        credentials before writing anything to disk — it's safe to attach in
+        full. Drag the `.zip` onto this issue text box to upload it.
+      options:
+        - label: I attached the redacted support bundle `.zip`, or explained below why I couldn't
+          required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Additional logs or context
+      description: >
+        Anything else worth including — a full OBS log
+        (Help → Log Files → Upload Current Log File, paste the link), the
+        Meeting SDK/OBS version combo, or anything unusual about your setup
+        (VPN, admin-managed Zoom account, multiple OBS profiles, etc).
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Installed platform
+      description: CoreVideo's only supported, packaged, and released target is Windows x64. Source builds on other platforms are unsupported/experimental.
+      options:
+        - Windows 10/11 x64 (installer or ZIP release)
+        - Windows arm64 (source build)
+        - macOS (source build)
+        - Linux (source build)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions
+    url: https://corevideo.io/support/
+    about: For "how do I..." questions, check the Support page and full documentation first.
+  - name: Security vulnerability
+    url: https://github.com/iamfatness/CoreVideo/blob/main/SECURITY.md
+    about: Do not open a public issue for security vulnerabilities — see the responsible disclosure process instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Suggest a new capability or improvement for CoreVideo.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please check the
+        [Roadmap](https://github.com/iamfatness/CoreVideo/blob/main/docs/ROADMAP.md)
+        first — your idea may already be planned under Now / Next / Later.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do today that CoreVideo doesn't support, or only supports awkwardly?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the feature look like? A new source type, dock control, TCP/OSC command, config option, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds you've tried
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area (best guess is fine)
+      options:
+        - Video / audio capture pipeline
+        - Assignment modes (Spotlight, Active Speaker, Screen Share)
+        - Zoom Control dock / Output Manager UI
+        - Sign-in / OAuth
+        - TCP / OSC control API
+        - ISO recording
+        - Diagnostics / support bundle
+        - Installer / packaging
+        - Documentation
+        - Something else
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, or links to similar features in other tools are welcome.
+    validations:
+      required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ jobs:
   build-windows:
     name: Windows x64
     runs-on: windows-2022
+    # contents: write so GITHUB_TOKEN can see the draft release that stores the
+    # license-restricted Zoom SDK (drafts are invisible to a read-only token).
+    permissions:
+      contents: write
     outputs:
       has_zoom_runtime: ${{ steps.zoom_sdk.outputs.has_zoom_runtime }}
     steps:
@@ -107,24 +111,33 @@ jobs:
           aqt install-qt windows desktop 6.7.3 win64_msvc2019_64 --outputdir C:\Qt
           "QT_ROOT_DIR=C:\Qt\6.7.3\msvc2019_64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Download Zoom Windows SDK
+      # The Zoom SDK is license-restricted: it lives as an asset on a DRAFT
+      # release in this repo (never publish that release). curl.exe strips the
+      # Authorization header on the S3 redirect hop for us and is binary-safe,
+      # unlike PowerShell 5.1 stdout redirection. Never commit the SDK.
+      - name: Download Zoom Windows SDK (private draft-release asset)
         id: zoom_sdk
         env:
-          ZOOM_SDK_DOWNLOAD_URL: ${{ secrets.ZOOM_SDK_WINDOWS_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: powershell
         run: |
-          if ($env:ZOOM_SDK_DOWNLOAD_URL) {
-              Invoke-WebRequest $env:ZOOM_SDK_DOWNLOAD_URL -OutFile zoom-sdk.zip
-              Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted
-              $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
-              Move-Item $inner.FullName third_party/zoom-sdk
-              "COREVIDEO_HAS_ZOOM_RUNTIME=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-              "has_zoom_runtime=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          } else {
+          $ErrorActionPreference = "Stop"
+          $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
+          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          if (-not $assetId) {
               "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
               "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-              Write-Warning "ZOOM_SDK_WINDOWS_URL is not configured. Building Windows validation artifact without ZoomObsEngine runtime."
+              Write-Warning "$assetName not found on any draft release (or token lacks access). Building Windows validation artifact without ZoomObsEngine runtime."
+              exit 0
           }
+          Write-Host "Fetching $assetName (asset id $assetId)"
+          curl.exe -sSfL -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/octet-stream" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$assetId" -o zoom-sdk.zip
+          if ((Get-Item zoom-sdk.zip).Length -lt 100MB) { throw "Downloaded SDK archive is implausibly small." }
+          Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted
+          $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
+          Move-Item $inner.FullName third_party/zoom-sdk
+          "COREVIDEO_HAS_ZOOM_RUNTIME=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "has_zoom_runtime=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Download FFmpeg (LGPL shared) for HW acceleration
         shell: powershell

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -101,20 +101,28 @@ jobs:
 
           "OBS_SDK_DIR=$sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Download Zoom Windows SDK
+      # The Zoom SDK is license-restricted: it lives as an asset on a DRAFT
+      # release in this repo (never publish that release). curl.exe strips the
+      # Authorization header on the S3 redirect hop and is binary-safe, unlike
+      # PowerShell 5.1 stdout redirection. Never commit the SDK.
+      - name: Download Zoom Windows SDK (private draft-release asset)
         id: zoom_sdk
         env:
-          ZOOM_SDK_DOWNLOAD_URL: ${{ secrets.ZOOM_SDK_WINDOWS_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          if ([string]::IsNullOrWhiteSpace($env:ZOOM_SDK_DOWNLOAD_URL)) {
+          $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
+          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          if (-not $assetId) {
             "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Warning "ZOOM_SDK_WINDOWS_URL is not configured. Building a validation-only package without ZoomObsEngine runtime."
+            Write-Warning "$assetName not found on any draft release (or token lacks access). Building a validation-only package without ZoomObsEngine runtime."
             exit 0
           }
-          Invoke-WebRequest $env:ZOOM_SDK_DOWNLOAD_URL -OutFile zoom-sdk.zip
+          Write-Host "Fetching $assetName (asset id $assetId)"
+          curl.exe -sSfL -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/octet-stream" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$assetId" -o zoom-sdk.zip
+          if ((Get-Item zoom-sdk.zip).Length -lt 100MB) { throw "Downloaded SDK archive is implausibly small." }
           Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted -Force
           $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
           if (-not $inner) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+## [0.1.29] - 2026-07-30
+
+### Fixed
+- Setting an output's assignment to "None" now actually stops the previous
+  feed: the engine subscription is torn down and the signal readout clears.
+  Previously the old participant kept streaming into shared memory (a live
+  signal on a "None" row) and could not be cleaned up without restarting
+  the engine.
+- Unassigned outputs are no longer graded as stale/waiting or offered
+  Recover actions in the Output Manager.
+- Sign-in and join now always present production Zoom credentials: the
+  production OAuth broker URL is baked into every build (locally-built
+  releases previously embedded a blank broker identity, which allowed
+  leftover developer credential overrides on tester machines), and the
+  broker's Meeting SDK token service was updated to production credentials
+  server-side.
+
 ## [0.1.28] - 2026-07-30
 
 First public beta release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,49 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-07-30
+
+First public beta release.
+
 ### Added
 - In-app update check: the Zoom Control dock shows a non-intrusive banner
   when a newer CoreVideo release is available, with a toggle in Settings to
   disable the startup check.
+- The plugin version is now shown in the Settings dialog.
+- Beta support surface: GitHub bug-report/feature-request templates (with
+  support-bundle instructions), a much larger Troubleshooting section in the
+  docs, and a documented flow for adding/removing CoreVideo on a Zoom account.
+- macOS groundwork: the real plugin and OAuth helper now build on Apple
+  Silicon CI and OAuth tokens use the macOS Keychain — no macOS packages are
+  published yet; Windows x64 remains the supported platform.
+
+### Fixed
+- Frozen-frame-forever after an engine crash/restart: shared-memory regions
+  now carry a generation stamp so sources re-attach automatically, shared
+  memory failures are surfaced as visible errors instead of dropped
+  silently, and region counts are capped with a clear "capacity" error.
+- Changing the OSC port no longer leaks the old poll timer and stack
+  duplicate handlers.
+- Leaving a meeting now clears the stored recovery session (including join
+  tokens) instead of keeping it in memory until the next join.
+- Bitfocus Companion module builds again against @companion-module/base 2.1.
+
+### Changed
+- Sign-in/join now runs through one centralized, unit-tested decision path:
+  every join attempt logs a single `[join-decision]` line and failures map
+  to distinct, actionable messages (expired token, wrong environment,
+  missing approval, and so on).
+- Zoom Meeting SDK updated from 7.0.2 to 7.1.5.
+- README documents the honest platform support matrix, and non-Windows
+  builds now log a prominent warning that OAuth tokens are stored without
+  OS-level encryption (Windows DPAPI is unchanged).
+- Documentation architecture diagrams rebuilt for readability (dark theme,
+  legible text, a hand-drawn system overview), fixing a content-security
+  policy issue that made production render them with Mermaid's light theme.
+- Test suite grew from 2 to 17 suites (IPC hardening, control/OSC parsing,
+  reconnect backoff and cancellation, join decisions, version comparison),
+  and the dock lifecycle smoke script now asserts reopen and shutdown
+  ordering.
 
 ## [0.1.27] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+### Fixed
+- **OBS 32.2 compatibility: OBS no longer breaks after installing CoreVideo.**
+  OBS Studio 32.2 upgraded its bundled FFmpeg to major version 8, which uses
+  the same DLL filenames (`avcodec-62.dll`, `avutil-60.dll`, …) as the FFmpeg
+  runtime CoreVideo shipped loose into `obs-plugins\64bit`. On OBS 32.2+ those
+  loose copies shadowed OBS's own DLLs, so OBS's built-in `obs-ffmpeg` module
+  (and CoreVideo itself) failed to load, taking down recording/streaming
+  encoders with it. The FFmpeg runtime now lives in a private
+  `obs-plugins\64bit\corevideo-ffmpeg\` directory and is delay-loaded through
+  a resolver that binds whatever FFmpeg the OBS process already has (OBS
+  32.2+) or CoreVideo's bundled copy (OBS ≤ 32.1) — never a mix. The
+  installer removes the legacy loose DLLs on upgrade; zip users should delete
+  `av*-*.dll` / `sw*-*.dll` from `obs-plugins\64bit` manually. If a usable
+  FFmpeg runtime cannot be bound, hardware-accelerated conversion falls back
+  to the CPU path with a clear log message instead of failing.
+
 ## [0.1.29] - 2026-07-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-07-31
+
 ### Fixed
 - **OBS 32.2 compatibility: OBS no longer breaks after installing CoreVideo.**
   OBS Studio 32.2 upgraded its bundled FFmpeg to major version 8, which uses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+### Fixed
+- **Hardware-accelerated video conversion works on OBS 32.2+ again.** v0.1.30
+  avoided the OBS 32.2 FFmpeg collision by binding the FFmpeg build OBS
+  already had in the process — but OBS's slim build has no `scale_cuda` or
+  `vpp_qsv`, so hardware conversion silently fell back to the CPU path. The
+  bundled runtime is now renamed to globally unique DLL names
+  (`cvfilter-11.dll`, `cvutil-60.dll`, …, patched in the PE name strings —
+  the same effect as an FFmpeg `--build-suffix` build), so CoreVideo always
+  loads its own full-featured FFmpeg on every OBS version with zero
+  possibility of colliding with OBS's. A new automated test loads the
+  renamed runtime, asserts `scale_cuda`/`vpp_qsv` are present, and asserts
+  no original-named FFmpeg module leaks into the process.
+
 ## [0.1.30] - 2026-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+## [0.1.31] - 2026-08-01
+
 ### Fixed
 - **Hardware-accelerated video conversion works on OBS 32.2+ again.** v0.1.30
   avoided the OBS 32.2 FFmpeg collision by binding the FFmpeg build OBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,19 +100,43 @@ if(ENABLE_FFMPEG_HW_ACCEL)
             "${COREVIDEO_AVFILTER_INC}")
         set(COREVIDEO_FFMPEG_BIN_DIR "${FFMPEG_ROOT}/bin")
         if(WIN32 AND MSVC)
-            # The prebuilt import libs are dlltool-style long-format archives,
-            # which /DELAYLOAD cannot match (LNK4199 leaves the imports
-            # static). Regenerate short-format import libs from the DLLs'
-            # export tables so the delay-load resolver in
-            # cv-ffmpeg-loader.cpp actually receives the loads.
-            file(GLOB _cv_avfilter_bin "${COREVIDEO_FFMPEG_BIN_DIR}/avfilter-*.dll")
-            file(GLOB _cv_avutil_bin "${COREVIDEO_FFMPEG_BIN_DIR}/avutil-*.dll")
+            # OBS bundles FFmpeg under the standard DLL names and the Windows
+            # loader dedups modules by base name, so a same-named private
+            # runtime can never be isolated from OBS's. Rename our runtime to
+            # cv-prefixed names (avfilter-11.dll -> cvfilter-11.dll, patched
+            # in the PE name strings — see scripts/New-PrivateFfmpeg.ps1) so
+            # the plugin always loads its own full-featured build.
+            set(COREVIDEO_FFMPEG_RUNTIME_DIR
+                "${CMAKE_CURRENT_BINARY_DIR}/cv-ffmpeg-runtime")
+            file(GLOB _cv_patched_check "${COREVIDEO_FFMPEG_RUNTIME_DIR}/cvfilter-*.dll")
+            if(NOT _cv_patched_check)
+                execute_process(
+                    COMMAND powershell -NoProfile -ExecutionPolicy Bypass
+                        -File "${CMAKE_CURRENT_SOURCE_DIR}/scripts/New-PrivateFfmpeg.ps1"
+                        -FfmpegBinDir "${COREVIDEO_FFMPEG_BIN_DIR}"
+                        -OutDir "${COREVIDEO_FFMPEG_RUNTIME_DIR}"
+                    RESULT_VARIABLE _cv_patch_result
+                    OUTPUT_VARIABLE _cv_patch_output
+                    ERROR_VARIABLE _cv_patch_output)
+                if(NOT _cv_patch_result EQUAL 0)
+                    message(FATAL_ERROR "Private FFmpeg runtime generation "
+                        "failed:\n${_cv_patch_output}")
+                endif()
+            endif()
+
+            file(GLOB _cv_avfilter_bin "${COREVIDEO_FFMPEG_RUNTIME_DIR}/cvfilter-*.dll")
+            file(GLOB _cv_avutil_bin "${COREVIDEO_FFMPEG_RUNTIME_DIR}/cvutil-*.dll")
             if(NOT _cv_avfilter_bin OR NOT _cv_avutil_bin)
-                message(FATAL_ERROR "ENABLE_FFMPEG_HW_ACCEL: avfilter/avutil "
-                    "DLL not found in ${COREVIDEO_FFMPEG_BIN_DIR}")
+                message(FATAL_ERROR "ENABLE_FFMPEG_HW_ACCEL: cvfilter/cvutil "
+                    "DLL not found in ${COREVIDEO_FFMPEG_RUNTIME_DIR}")
             endif()
             list(GET _cv_avfilter_bin 0 _cv_avfilter_bin)
             list(GET _cv_avutil_bin 0 _cv_avutil_bin)
+            # The prebuilt import libs are dlltool-style long-format archives,
+            # which /DELAYLOAD cannot match (LNK4199 leaves the imports
+            # static) — and they reference the original DLL names anyway.
+            # Generate short-format import libs from the renamed DLLs'
+            # export tables so the delayed imports resolve to cv* names.
             get_filename_component(_cv_msvc_bin "${CMAKE_LINKER}" DIRECTORY)
             set(_cv_delaylib_dir "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg-delay-libs")
             file(MAKE_DIRECTORY "${_cv_delaylib_dir}")
@@ -312,32 +336,20 @@ if(COREVIDEO_BUILD_PLUGIN)
         # names; loose copies in obs-plugins/64bit made OBS's own obs-ffmpeg
         # module bind our build and fail to load. cv-ffmpeg-loader.cpp resolves
         # the delayed imports (in-process copies first, else the private dir).
-        if(WIN32 AND COREVIDEO_FFMPEG_BIN_DIR AND EXISTS "${COREVIDEO_FFMPEG_BIN_DIR}")
-            file(GLOB COREVIDEO_FFMPEG_DLLS "${COREVIDEO_FFMPEG_BIN_DIR}/*.dll")
-            if(COREVIDEO_FFMPEG_DLLS)
-                add_custom_command(TARGET obs-zoom-plugin POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E make_directory
-                        "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                        ${COREVIDEO_FFMPEG_DLLS}
-                        "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
-                    COMMENT "Copying FFmpeg runtime DLLs for obs-zoom-plugin")
-            endif()
-            install(DIRECTORY "${COREVIDEO_FFMPEG_BIN_DIR}/"
-                DESTINATION "obs-plugins/64bit/corevideo-ffmpeg"
-                FILES_MATCHING PATTERN "*.dll")
+        if(WIN32 AND MSVC AND COREVIDEO_FFMPEG_RUNTIME_DIR)
+            file(GLOB COREVIDEO_FFMPEG_DLLS "${COREVIDEO_FFMPEG_RUNTIME_DIR}/*")
+            add_custom_command(TARGET obs-zoom-plugin POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${COREVIDEO_FFMPEG_DLLS}
+                    "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
+                COMMENT "Copying private FFmpeg runtime for obs-zoom-plugin")
+            install(DIRECTORY "${COREVIDEO_FFMPEG_RUNTIME_DIR}/"
+                DESTINATION "obs-plugins/64bit/corevideo-ffmpeg")
 
-            file(GLOB _cv_avfilter_dlls RELATIVE "${COREVIDEO_FFMPEG_BIN_DIR}"
-                "${COREVIDEO_FFMPEG_BIN_DIR}/avfilter-*.dll")
-            file(GLOB _cv_avutil_dlls RELATIVE "${COREVIDEO_FFMPEG_BIN_DIR}"
-                "${COREVIDEO_FFMPEG_BIN_DIR}/avutil-*.dll")
-            if(NOT _cv_avfilter_dlls OR NOT _cv_avutil_dlls)
-                message(FATAL_ERROR
-                    "ENABLE_FFMPEG_HW_ACCEL: avfilter/avutil DLL not found in "
-                    "${COREVIDEO_FFMPEG_BIN_DIR}; cannot set up delay-loading")
-            endif()
-            list(GET _cv_avfilter_dlls 0 _cv_avfilter_dll)
-            list(GET _cv_avutil_dlls 0 _cv_avutil_dll)
+            get_filename_component(_cv_avfilter_dll "${_cv_avfilter_bin}" NAME)
+            get_filename_component(_cv_avutil_dll "${_cv_avutil_bin}" NAME)
             target_compile_definitions(obs-zoom-plugin PRIVATE
                 "COREVIDEO_AVFILTER_DLL=\"${_cv_avfilter_dll}\""
                 "COREVIDEO_AVUTIL_DLL=\"${_cv_avutil_dll}\"")
@@ -520,6 +532,15 @@ if(BUILD_TESTING)
     )
     add_test(NAME CoreVideoOutputHealth
              COMMAND CoreVideoOutputHealthTest)
+
+    if(WIN32 AND MSVC AND COREVIDEO_FFMPEG_RUNTIME_DIR AND COREVIDEO_BUILD_PLUGIN)
+        add_executable(CoreVideoFfmpegRuntimeTest
+            tests/ffmpeg-runtime-test.cpp
+        )
+        add_dependencies(CoreVideoFfmpegRuntimeTest obs-zoom-plugin)
+        add_test(NAME CoreVideoFfmpegRuntime
+                 COMMAND CoreVideoFfmpegRuntimeTest)
+    endif()
 
     add_executable(CoreVideoSpeakerDirectorTest
         tests/speaker-director-test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ set(ZOOM_EMBED_SDK_KEY          "" CACHE STRING "Pre-embedded Zoom SDK key")
 set(ZOOM_EMBED_SDK_SECRET       "" CACHE STRING "Pre-embedded Zoom SDK secret")
 set(ZOOM_EMBED_JWT_TOKEN        "" CACHE STRING "Pre-embedded Zoom JWT token")
 set(ZOOM_EMBED_OAUTH_CLIENT_ID  "y6sIWSwiTZe1JygMx4C9EQ" CACHE STRING "Pre-embedded Zoom OAuth public client ID")
-set(ZOOM_EMBED_OAUTH_AUTHORIZATION_URL "" CACHE STRING "Pre-embedded Zoom OAuth authorization URL")
+# Default to the production broker start URL so every build — including local
+# release builds — carries the full production OAuth identity. A blank broker
+# URL makes the plugin honor developer credential overrides from local OBS
+# config, which is how dev credentials leaked into tester sessions.
+set(ZOOM_EMBED_OAUTH_AUTHORIZATION_URL "https://corevideo.iamfatness.us/oauth/start" CACHE STRING "Pre-embedded Zoom OAuth authorization URL")
 set(ZOOM_EMBED_MEETING_SDK_PUBLIC_APP_KEY "y6sIWSwiTZe1JygMx4C9EQ" CACHE STRING "Pre-embedded Zoom Meeting SDK public app key")
 configure_file(src/zoom-credentials.h.in
                "${CMAKE_CURRENT_BINARY_DIR}/zoom-credentials.h" @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,10 +456,18 @@ if(BUILD_ZOOM_ENGINE)
         # own. Without this the binary is emitted with ZERO LC_RPATH entries and
         # dyld aborts at launch with "no LC_RPATH's found" -- a link-clean build
         # that cannot run. CI never caught it because it only compiles and links.
+        #
+        # INSTALL_RPATH targets the shipped layout: the engine runs as
+        # ZoomObsEngine.app/Contents/MacOS/ZoomObsEngine with the Zoom SDK
+        # runtime in Contents/Frameworks, so "@executable_path/../Frameworks"
+        # resolves it. That layout is not a packaging preference -- the SDK
+        # loads its runtime bundles through the main bundle's Frameworks dir,
+        # and without them sdkAuth fails synchronously with no callback. See the
+        # header note in engine/src/main-macos.mm.
         set_target_properties(ZoomObsEngine PROPERTIES
             BUILD_WITH_INSTALL_RPATH OFF
             BUILD_RPATH "${ZOOM_SDK_ACTIVE_DIR}"
-            INSTALL_RPATH "@loader_path/zoom-runtime"
+            INSTALL_RPATH "@executable_path/../Frameworks"
         )
         # Relative DESTINATION (resolved against the install prefix). An
         # absolute "${CMAKE_INSTALL_PREFIX}/..." expands to the configure-time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,8 +367,16 @@ if(BUILD_ZOOM_ENGINE)
         )
         # rpath so the linker/loader can resolve ZoomSDK.framework from where the
         # SDK was fetched (CI compile/link validation only; not a shippable rpath).
+        #
+        # BUILD_RPATH is required, not optional: the framework is linked through
+        # raw "-F<dir>"/"-framework ZoomSDK" flags rather than an imported target
+        # with a known location, so CMake cannot infer any build-tree rpath on its
+        # own. Without this the binary is emitted with ZERO LC_RPATH entries and
+        # dyld aborts at launch with "no LC_RPATH's found" -- a link-clean build
+        # that cannot run. CI never caught it because it only compiles and links.
         set_target_properties(ZoomObsEngine PROPERTIES
             BUILD_WITH_INSTALL_RPATH OFF
+            BUILD_RPATH "${ZOOM_SDK_ACTIVE_DIR}"
             INSTALL_RPATH "@loader_path/zoom-runtime"
         )
         # Relative DESTINATION (resolved against the install prefix). An

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,48 @@ if(ENABLE_FFMPEG_HW_ACCEL)
         add_library(corevideo_ffmpeg INTERFACE)
         target_include_directories(corevideo_ffmpeg INTERFACE
             "${COREVIDEO_AVFILTER_INC}")
-        target_link_libraries(corevideo_ffmpeg INTERFACE
-            "${COREVIDEO_AVFILTER_LIB}" "${COREVIDEO_AVUTIL_LIB}")
-        set(COREVIDEO_FFMPEG_TARGET corevideo_ffmpeg)
         set(COREVIDEO_FFMPEG_BIN_DIR "${FFMPEG_ROOT}/bin")
+        if(WIN32 AND MSVC)
+            # The prebuilt import libs are dlltool-style long-format archives,
+            # which /DELAYLOAD cannot match (LNK4199 leaves the imports
+            # static). Regenerate short-format import libs from the DLLs'
+            # export tables so the delay-load resolver in
+            # cv-ffmpeg-loader.cpp actually receives the loads.
+            file(GLOB _cv_avfilter_bin "${COREVIDEO_FFMPEG_BIN_DIR}/avfilter-*.dll")
+            file(GLOB _cv_avutil_bin "${COREVIDEO_FFMPEG_BIN_DIR}/avutil-*.dll")
+            if(NOT _cv_avfilter_bin OR NOT _cv_avutil_bin)
+                message(FATAL_ERROR "ENABLE_FFMPEG_HW_ACCEL: avfilter/avutil "
+                    "DLL not found in ${COREVIDEO_FFMPEG_BIN_DIR}")
+            endif()
+            list(GET _cv_avfilter_bin 0 _cv_avfilter_bin)
+            list(GET _cv_avutil_bin 0 _cv_avutil_bin)
+            get_filename_component(_cv_msvc_bin "${CMAKE_LINKER}" DIRECTORY)
+            set(_cv_delaylib_dir "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg-delay-libs")
+            file(MAKE_DIRECTORY "${_cv_delaylib_dir}")
+            foreach(_cv_dll IN ITEMS "${_cv_avfilter_bin}" "${_cv_avutil_bin}")
+                get_filename_component(_cv_dll_we "${_cv_dll}" NAME_WE)
+                set(_cv_out_lib "${_cv_delaylib_dir}/${_cv_dll_we}.lib")
+                execute_process(
+                    COMMAND powershell -NoProfile -ExecutionPolicy Bypass
+                        -File "${CMAKE_CURRENT_SOURCE_DIR}/scripts/New-DelayImportLib.ps1"
+                        -DllPath "${_cv_dll}"
+                        -DumpbinExe "${_cv_msvc_bin}/dumpbin.exe"
+                        -LibExe "${_cv_msvc_bin}/lib.exe"
+                        -OutLib "${_cv_out_lib}"
+                    RESULT_VARIABLE _cv_gen_result
+                    OUTPUT_VARIABLE _cv_gen_output
+                    ERROR_VARIABLE _cv_gen_output)
+                if(NOT _cv_gen_result EQUAL 0)
+                    message(FATAL_ERROR "Import library regeneration failed "
+                        "for ${_cv_dll}:\n${_cv_gen_output}")
+                endif()
+                target_link_libraries(corevideo_ffmpeg INTERFACE "${_cv_out_lib}")
+            endforeach()
+        else()
+            target_link_libraries(corevideo_ffmpeg INTERFACE
+                "${COREVIDEO_AVFILTER_LIB}" "${COREVIDEO_AVUTIL_LIB}")
+        endif()
+        set(COREVIDEO_FFMPEG_TARGET corevideo_ffmpeg)
         message(STATUS "FFmpeg HW accel: using FFMPEG_ROOT=${FFMPEG_ROOT}")
     else()
         find_package(PkgConfig REQUIRED)
@@ -220,6 +258,7 @@ if(COREVIDEO_BUILD_PLUGIN)
         src/zoom-osc-server.cpp
         src/obs-utils.cpp
         src/hw-video-pipeline.cpp
+        src/cv-ffmpeg-loader.cpp
         src/cv-widgets.cpp
         src/cv-onboarding.cpp
         src/cv-update-check.cpp
@@ -268,21 +307,44 @@ if(COREVIDEO_BUILD_PLUGIN)
     if(ENABLE_FFMPEG_HW_ACCEL)
         target_link_libraries(obs-zoom-plugin PRIVATE ${COREVIDEO_FFMPEG_TARGET})
         target_compile_definitions(obs-zoom-plugin PRIVATE COREVIDEO_HW_ACCEL)
-        # Ship the FFmpeg runtime DLLs alongside the plugin on Windows so
-        # OBS's plugin loader can resolve avfilter / avutil / avcodec /
-        # swscale / swresample without polluting PATH.
+        # Ship the FFmpeg runtime in the private corevideo-ffmpeg/ subdirectory
+        # and delay-load it. OBS 32.2+ bundles FFmpeg 8 under the same DLL
+        # names; loose copies in obs-plugins/64bit made OBS's own obs-ffmpeg
+        # module bind our build and fail to load. cv-ffmpeg-loader.cpp resolves
+        # the delayed imports (in-process copies first, else the private dir).
         if(WIN32 AND COREVIDEO_FFMPEG_BIN_DIR AND EXISTS "${COREVIDEO_FFMPEG_BIN_DIR}")
             file(GLOB COREVIDEO_FFMPEG_DLLS "${COREVIDEO_FFMPEG_BIN_DIR}/*.dll")
             if(COREVIDEO_FFMPEG_DLLS)
                 add_custom_command(TARGET obs-zoom-plugin POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E make_directory
+                        "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
                         ${COREVIDEO_FFMPEG_DLLS}
-                        "$<TARGET_FILE_DIR:obs-zoom-plugin>"
+                        "$<TARGET_FILE_DIR:obs-zoom-plugin>/corevideo-ffmpeg"
                     COMMENT "Copying FFmpeg runtime DLLs for obs-zoom-plugin")
             endif()
             install(DIRECTORY "${COREVIDEO_FFMPEG_BIN_DIR}/"
-                DESTINATION "obs-plugins/64bit"
+                DESTINATION "obs-plugins/64bit/corevideo-ffmpeg"
                 FILES_MATCHING PATTERN "*.dll")
+
+            file(GLOB _cv_avfilter_dlls RELATIVE "${COREVIDEO_FFMPEG_BIN_DIR}"
+                "${COREVIDEO_FFMPEG_BIN_DIR}/avfilter-*.dll")
+            file(GLOB _cv_avutil_dlls RELATIVE "${COREVIDEO_FFMPEG_BIN_DIR}"
+                "${COREVIDEO_FFMPEG_BIN_DIR}/avutil-*.dll")
+            if(NOT _cv_avfilter_dlls OR NOT _cv_avutil_dlls)
+                message(FATAL_ERROR
+                    "ENABLE_FFMPEG_HW_ACCEL: avfilter/avutil DLL not found in "
+                    "${COREVIDEO_FFMPEG_BIN_DIR}; cannot set up delay-loading")
+            endif()
+            list(GET _cv_avfilter_dlls 0 _cv_avfilter_dll)
+            list(GET _cv_avutil_dlls 0 _cv_avutil_dll)
+            target_compile_definitions(obs-zoom-plugin PRIVATE
+                "COREVIDEO_AVFILTER_DLL=\"${_cv_avfilter_dll}\""
+                "COREVIDEO_AVUTIL_DLL=\"${_cv_avutil_dll}\"")
+            target_link_options(obs-zoom-plugin PRIVATE
+                "/DELAYLOAD:${_cv_avfilter_dll}"
+                "/DELAYLOAD:${_cv_avutil_dll}")
+            target_link_libraries(obs-zoom-plugin PRIVATE delayimp)
         endif()
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,10 @@ if(BUILD_ZOOM_ENGINE)
             "-F${ZOOM_SDK_ACTIVE_DIR}"
             "-framework ZoomSDK"
             "-framework Foundation"
+            # The engine hosts an NSApplication: the Zoom macOS SDK is an AppKit
+            # client (its own sample is built on NSApplicationMain), so a bare
+            # NSRunLoop is not enough to service its delegate callbacks.
+            "-framework AppKit"
         )
         # rpath so the linker/loader can resolve ZoomSDK.framework from where the
         # SDK was fetched (CI compile/link validation only; not a shippable rpath).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,6 +508,33 @@ if(COREVIDEO_BUILD_PLUGIN)
             DESTINATION "obs-plugins/64bit/plugins/tls"
         )
     endif()
+    # macOS counterpart of the Windows TLS-backend install above. OBS.app bundles
+    # Qt but ships NO Qt TLS backend plugin (there is no PlugIns/tls directory),
+    # so QtNetwork in the OBS process has no TLS provider and every https request
+    # fails with "TLS initialization failed" -- which broke the OAuth broker
+    # redeem. securetransport is the native backend and needs no OpenSSL dylib;
+    # certonly is Qt's no-TLS fallback and is what it loads when nothing else is
+    # present. plugin-main.cpp adds this directory to the Qt library paths.
+    if(APPLE AND COREVIDEO_QT_PLUGIN_DIR AND EXISTS "${COREVIDEO_QT_PLUGIN_DIR}/tls")
+        set(_cv_macos_tls_backends "")
+        foreach(_cv_tls_lib
+            "libqsecuretransportbackend.dylib"
+            "libqcertonlybackend.dylib")
+            if(EXISTS "${COREVIDEO_QT_PLUGIN_DIR}/tls/${_cv_tls_lib}")
+                list(APPEND _cv_macos_tls_backends
+                    "${COREVIDEO_QT_PLUGIN_DIR}/tls/${_cv_tls_lib}")
+            else()
+                message(WARNING
+                    "Qt TLS backend not found: ${COREVIDEO_QT_PLUGIN_DIR}/tls/${_cv_tls_lib}. "
+                    "https requests (OAuth broker redeem, update check) will fail at runtime.")
+            endif()
+        endforeach()
+        if(_cv_macos_tls_backends)
+            install(FILES ${_cv_macos_tls_backends}
+                DESTINATION "obs-plugins/64bit/plugins/tls"
+            )
+        endif()
+    endif()
     if(WIN32 AND COREVIDEO_QT_PLUGIN_DIR AND EXISTS "${COREVIDEO_QT_PLUGIN_DIR}/platforms/qwindows.dll")
         install(FILES
             "${COREVIDEO_QT_PLUGIN_DIR}/platforms/qwindows.dll"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ Changelog: **[Release notes & version history ->](CHANGELOG.md)**
 
 The CMake project genuinely supports configuring on all of the above (see `buildspec/macos.cmake`, the Unix-socket IPC path in `engine-ipc.h`, and `oauth-callback-helper-macos.mm`), so a source build is *possible* on macOS/Linux/Windows-arm64 - it is just not something the project packages, tests, or supports today. If you get one working, bug reports and PRs are welcome, but expect to do your own SDK/Qt/OBS wiring.
 
+## Beta Status
+
+CoreVideo is in **public beta**. The only supported, packaged release target is
+**Windows x64** (installer or ZIP - see [Platform Support](#platform-support)
+above); the beta installer is not yet code-signed, so Windows SmartScreen will
+flag it on first run (see [Troubleshooting](https://corevideo.io/documentation/#troubleshooting)).
+Known limitations and what's planned next are tracked in the
+**[Roadmap](docs/ROADMAP.md)**. To report a bug or request a feature, open a
+[GitHub issue](https://github.com/iamfatness/CoreVideo/issues/new/choose) -
+the bug report template walks you through attaching a redacted support bundle
+from the Zoom Diagnostics dock. New releases are announced through a
+dismissible in-app update banner in the Zoom Control dock (a plain,
+unauthenticated check against the public GitHub Releases API, once per OBS
+session) and on the [Releases page](https://github.com/iamfatness/CoreVideo/releases).
+
 ## Quick Start
 
 1. **For source builds, get the Zoom SDK** - download from the [Zoom Developer Portal](https://developers.zoom.us/docs/meeting-sdk/releases/) and place it at `third_party/zoom-sdk/`. CMake auto-detects x64/arm64/x86 sub-layouts on Windows. End users installing an official Windows release do not need to download or provide SDK files.

--- a/README.md
+++ b/README.md
@@ -147,9 +147,12 @@ The CMake project genuinely supports configuring on all of the above (see `build
 
 GitHub Actions can validate the Windows build without the restricted Zoom
 runtime, but public client releases must include `ZoomObsEngine.exe`,
-`zoom-runtime\sdk.dll`, Qt TLS plugins, and the other bundled runtime files. If
-`ZOOM_SDK_WINDOWS_URL` is not configured as a GitHub repository secret, CI skips
-publishing a GitHub Release instead of shipping an incomplete package.
+`zoom-runtime\sdk.dll`, Qt TLS plugins, and the other bundled runtime files.
+CI fetches the license-restricted Zoom SDK from an asset on a **draft** GitHub
+release in this repository (draft releases are not publicly visible; the
+workflow token downloads the asset at build time). If the asset is missing, CI
+skips publishing a GitHub Release instead of shipping an incomplete package.
+Keep that release a draft — publishing it would make the SDK public.
 
 For fast local releases from a machine that already has the Zoom runtime, use:
 

--- a/docs/HANDOFF-macos-engine.md
+++ b/docs/HANDOFF-macos-engine.md
@@ -53,9 +53,18 @@ Keep the loud-fail discipline: any path you haven't implemented emits a clear er
 and never silently pretends. **Do not fake frames.**
 
 ## Runtime verification (this is why you're on a Mac — do all of it)
-- Build locally against OBS.app + `brew qt@6` (mirror the CI Configure step in
-  `.github/workflows/build.yml` build-macos job). Install the plugin bundle + `ZoomObsEngine`
-  + `CoreVideoOAuthCallback.app` into your OBS plugins dir.
+- Build locally against OBS.app. Do **not** follow CI's `brew install cmake qt@6`: the dev Mac
+  has no Homebrew and cannot get one (`/opt` is root-owned, no sudo). The working toolchain is
+  cmake/ninja/ctest via `pip --user`, `gh` from a release tarball, and Qt **6.8.3** via
+  `aqtinstall` — 6.8 because OBS.app bundles Qt 6.8 (its Info.plist says 6.8 even though the
+  shipped Qt is newer, so match at load time, not by reading the plist). macOS 26's SDK also
+  dropped `AGL.framework` while Qt's `FindWrapOpenGL` still links it unconditionally; pass
+  `-DWrapOpenGL_AGL=$(xcrun --show-sdk-path)/System/Library/Frameworks/OpenGL.framework`.
+  That is an environment issue, so keep it a configure flag and never commit it.
+- Assemble and install with `scripts/make-macos-bundle.sh --build-dir build --install`.
+  Never hand-assemble the bundle — that is how the Qt double-load and missing-TLS-backend
+  bugs kept coming back. Add `--link-sdk` for fast local iteration (symlinks the 612 MB Zoom
+  SDK instead of copying it; not distributable).
 - Load in OBS.app: confirm the source/dock/dialogs appear and the plugin logs cleanly.
 - **Real join**: join an actual Zoom meeting; verify the roster populates, live video renders
   in the OBS source, audio works, and active-speaker + spotlight + screenshare work. This is
@@ -74,9 +83,23 @@ and never silently pretends. **Do not fake frames.**
   compile-only zip.
 
 ## Gotchas (already known)
-- macOS POSIX shm names are limited to ~31 chars (`PSHMNAMLEN`); `IPC_SHM_PREFIX` + a 64-char
-  source UUID overflows. Fix the shm naming (hash/shorten the UUID) on **both** sides of
-  `engine-ipc.h` — this only bites once real frames flow, which is exactly now.
+- **The Zoom SDK runtime must be inside the engine's app bundle.** `ZoomSDK.framework` is not
+  self-contained: at auth time it loads sibling *bundles* (`ssb_sdk`, `zNet`, `zPTUIEx`, …)
+  which it locates through the **main bundle's `Contents/Frameworks`** — not through rpath and
+  not relative to the framework itself. Miss them and the failure lies to you: `initSDK`
+  returns Success, `getAuthService` returns a live object, then `sdkAuth` returns
+  `ZoomSDKError_Failed(1)` *synchronously* and no delegate ever fires. The engine therefore
+  ships as `ZoomObsEngine.app` with the SDK in `Contents/Frameworks`;
+  `preflight_sdk_runtime()` in `main-macos.mm` now reports this as `sdk_runtime_missing`
+  instead of leaving it to be re-diagnosed. **Verified 2026-08-01**: with the bundle correct,
+  a well-formed bogus-signature JWT returns `auth_fail code 7 AUTHRET_JWTTOKENWRONG` — a real
+  server verdict, so the ObjC++ auth path and the `AUTHRET_*` mapping both work end to end.
+- macOS POSIX shm names are limited to 31 chars including the leading `/` (`PSHMNAMLEN`),
+  verified empirically. The cause is **not** a "64-char source UUID" as earlier drafts of this
+  doc claimed: `make_source_uuid()` emits only ~22 chars, and the `ZoomObsPlugin_` prefix eats
+  14 of the 31 by itself, so shortening the UUID could never have fixed it. Fixed in `c009250`
+  by hashing the whole name inside `shm_region_create`/`shm_region_open_read` on the Apple
+  branch only, so both sides agree and Windows/Linux wire behavior is untouched.
 - `-undefined dynamic_lookup` must be passed via CMake `SHELL:` (already fixed) — don't
   regress it.
 - The mac engine links `-F<sdk_dir> -framework ZoomSDK`; `-F` must be on both compile and

--- a/docs/index.html
+++ b/docs/index.html
@@ -381,6 +381,45 @@
         (details in <a href="#signin">Sign in with Zoom</a> below). That's it — you're ready to use it.</p>
       </div></div>
     </div>
+
+    <h3>Adding CoreVideo to your Zoom account</h3>
+    <p>
+      In Zoom's terms, an app is <strong>added</strong> to your Zoom account the first time you
+      authorize it. There are two equivalent ways to do that:
+    </p>
+    <ul>
+      <li><strong>From OBS (recommended):</strong> click <strong>Sign in with Zoom</strong> in the
+      Zoom Control dock or Tools&nbsp;→&nbsp;Zoom Plugin Settings. Your browser opens Zoom's
+      authorization page; review the requested permissions and click <strong>Allow</strong>.
+      CoreVideo is added to your account automatically and the sign-in completes back in OBS.</li>
+      <li><strong>From the Zoom App Marketplace:</strong> open the
+      <a href="https://marketplace.zoom.us/" target="_blank" rel="noopener">Zoom App Marketplace</a>,
+      search for <strong>CoreVideo</strong>, open the listing, and click <strong>Add</strong>.
+      After you click <strong>Allow</strong> on the permissions screen, install the Windows app
+      (steps above) and sign in — the account authorization is already in place.</li>
+    </ul>
+    <p>
+      Either way, CoreVideo then appears under
+      <a href="https://marketplace.zoom.us/user/installed" target="_blank" rel="noopener">Zoom App Marketplace&nbsp;→&nbsp;Manage&nbsp;→&nbsp;Added Apps</a>,
+      where you can review or <a href="#removing">remove</a> it at any time.
+    </p>
+    <div class="callout info">
+      <div class="callout-title">ℹ️ What you are granting</div>
+      CoreVideo requests only two read-only scopes: <code>user:read:user</code> (your profile /
+      display name) and <code>user:read:token</code> (a short-lived Zoom Access Key used to join
+      meetings as you). It requests no write access, no recording access, and no access to other
+      users' data. Tokens are stored encrypted on your machine — see
+      <a href="#signin">Sign in with Zoom</a>.
+    </div>
+    <div class="callout warning">
+      <div class="callout-title">⚠️ Admin-managed accounts</div>
+      If your organization restricts Marketplace apps, the authorization page may show
+      <strong>Request pre-approval</strong> instead of <strong>Allow</strong>. Send the request (or
+      ask your Zoom admin to approve CoreVideo under
+      <strong>Admin&nbsp;→&nbsp;Advanced&nbsp;→&nbsp;App&nbsp;Marketplace</strong>), then sign in
+      again once it's approved.
+    </div>
+
     <div class="callout info">
       <div class="callout-title">ℹ️ Having trouble?</div>
       See <a href="#troubleshooting">Troubleshooting</a> for installer, dock-not-showing, and sign-in

--- a/docs/index.html
+++ b/docs/index.html
@@ -1983,53 +1983,6 @@ sequenceDiagram
   </footer>
 </main>
 
-<script>
-  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
-  // v10 — with theme:'dark' they are silently ignored (that was the source of
-  // the unreadable khaki clusters).
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      darkMode: true,
-      fontSize: '16px',
-      background: '#16191b',
-      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
-      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
-      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
-      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
-      edgeLabelBackground: '#0a0b0c',
-      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
-      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
-      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
-      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
-      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
-      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
-      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
-      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    },
-    // useMaxWidth:false renders every diagram at its natural size — text stays
-    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
-    // instead of shrinking to fit the column.
-    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
-    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
-      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
-    state: { useMaxWidth: false },
-    class: { useMaxWidth: false },
-  });
-
-  const sections = document.querySelectorAll('section[id]');
-  const navLinks = document.querySelectorAll('#sidebar a');
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting) {
-        navLinks.forEach(a => a.classList.remove('active'));
-        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
-        if (active) active.classList.add('active');
-      }
-    });
-  }, { rootMargin: '-20% 0px -70% 0px' });
-  sections.forEach(s => observer.observe(s));
-</script>
+<script src="/assets/docs-init.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,18 +41,17 @@
 
     #sidebar {
       position: fixed; top: 52px; left: 0; bottom: 0; width: 260px;
-      background: var(--surface); border-right: 1px solid var(--border);
-      padding: 24px 0; overflow-y: auto; z-index: 100;
+      background: var(--bg); border-right: 1px solid var(--border);
+      padding: 18px 0 32px; overflow-y: auto; z-index: 100;
     }
-    .nav-logo { padding: 0 20px 20px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-    .nav-logo h1 { font-size: 1.1rem; color: var(--accent); font-weight: 700; }
-    .nav-logo p  { font-size: 0.75rem; color: var(--muted); margin-top: 2px; }
     #sidebar a {
-      display: block; padding: 7px 20px; color: var(--muted); text-decoration: none;
-      font-size: 0.95rem; border-left: 2px solid transparent; transition: all 0.15s;
+      display: block; padding: 6px 20px; color: var(--muted); text-decoration: none;
+      font-size: 0.88rem; border-left: 2px solid transparent; transition: color .15s, background .15s, border-color .15s;
     }
-    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.1); }
-    .nav-section { padding: 14px 20px 4px; font-size: 0.78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); }
+    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.08); }
+    .nav-section { padding: 18px 20px 6px; font-family: "IBM Plex Mono", ui-monospace, monospace;
+      font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: .14em; color: #77828a; }
+    .nav-section-first { padding-top: 4px; }
     main { margin-left: 260px; max-width: 960px; padding: 48px 56px; }
     section[id] { scroll-margin-top: 72px; }
 
@@ -116,12 +115,16 @@
     .card h4 { margin: 0 0 6px; font-size: 0.9rem; }
     .card p { font-size: 0.8rem; color: var(--muted); margin: 0; }
 
+    .diagram-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     .diagram-wrap {
       background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
-      padding: 28px; margin: 20px 0; overflow-x: auto;
+      padding: 24px; margin: 20px 0; overflow-x: auto;
     }
-    .diagram-wrap .mermaid { display: flex; justify-content: center; }
-    .diagram-caption { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 12px; font-style: italic; }
+    .diagram-wrap .mermaid { display: flex; justify-content: safe center; min-width: min-content; }
+    .diagram-wrap .mermaid svg { max-width: none; }
+    .diagram-wrap > svg.arch { display: block; width: 100%; height: auto; min-width: 720px; }
+    .diagram-caption { font-size: 0.85rem; color: var(--muted); text-align: center; margin-top: 14px;
+      font-family: "IBM Plex Mono", ui-monospace, monospace; }
 
     table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.875rem; }
     th { background: #16191b; border: 1px solid var(--border); padding: 10px 14px; text-align: left; font-weight: 600; color: var(--muted); }
@@ -146,9 +149,16 @@
 
     section { scroll-margin-top: 24px; }
 
-    @media (max-width: 768px) {
-      #sidebar { display: none; }
-      main { margin-left: 0; padding: 24px 20px; }
+    @media (max-width: 960px) {
+      /* Sidebar becomes a horizontal on-page index instead of disappearing. */
+      #sidebar { position: static; width: auto; bottom: auto; display: flex; align-items: center;
+        overflow-x: auto; white-space: nowrap; padding: 10px 12px; gap: 2px;
+        border-right: none; border-bottom: 1px solid var(--border); }
+      .nav-section { padding: 0 6px 0 14px; }
+      .nav-section-first { padding-left: 6px; }
+      #sidebar a { padding: 6px 10px; border-left: none; border-radius: 6px; font-size: 0.82rem; }
+      #sidebar a:hover, #sidebar a.active { background: rgba(34,200,110,.12); }
+      main { margin-left: 0; padding: 28px 20px; }
       .site-topbar { flex-direction: column; align-items: flex-start; gap: 10px; }
       .site-topbar .topnav { justify-content: flex-start; }
       main > footer { margin-left: 0 !important; }
@@ -172,12 +182,8 @@
   </nav>
 </header>
 
-<nav id="sidebar">
-  <div class="nav-logo">
-    <h1>📹 CoreVideo</h1>
-    <p>OBS Plugin for Live Zoom Video</p>
-  </div>
-  <div class="nav-section">Overview</div>
+<nav id="sidebar" aria-label="On this page">
+  <div class="nav-section nav-section-first">Overview</div>
   <a href="#overview">Introduction</a>
   <a href="#features">Features</a>
   <div class="nav-section">Get Started</div>
@@ -556,65 +562,89 @@
       which feed they subscribe to: a fixed participant, the active speaker, a
       spotlight slot, or the active screen share.
     </p>
-    <div class="diagram-wrap">
-      <div class="mermaid">
-graph TB
-    subgraph Machine["User's Machine"]
-      subgraph OBS["OBS Studio"]
-        Canvas["Canvas / Output"]
-        VSrc["Zoom Participant\nSource"]
-        Canvas --> VSrc
-      end
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
+      <svg class="arch" viewBox="0 0 1140 600" role="img" aria-labelledby="fig1-t fig1-d" xmlns="http://www.w3.org/2000/svg">
+  <title id="fig1-t">CoreVideo system overview</title>
+  <desc id="fig1-d">Zoom Cloud feeds the ZoomObsEngine child process over HTTPS/WSS. The engine owns all Zoom SDK access and writes I420 video and PCM audio into shared memory, which the obs-zoom-plugin reads and hands to OBS Studio sources. Plugin and engine exchange JSON IPC over a named pipe or Unix socket. External controllers reach the plugin over TCP 19870 and OSC 19871.</desc>
+  <defs>
+    <marker id="ar-g" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#22c86e"/></marker>
+    <marker id="ar-n" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#8b949b"/></marker>
+    <marker id="ar-nr" markerWidth="9" markerHeight="8" refX="0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M8,0 L8,6 L0,3 z" fill="#8b949b"/></marker>
+  </defs>
+  <style>
+    .p-title { font: 700 13px "Space Grotesk", sans-serif; letter-spacing: .1em; fill: #e9edef; }
+    .p-tag   { font: 400 9.5px "IBM Plex Mono", monospace; letter-spacing: .06em; fill: #77828a; }
+    .chip    { fill: #1a2025; stroke: #2c343b; }
+    .c-txt   { font: 400 12px "IBM Plex Mono", monospace; fill: #dbe3e8; }
+    .e-lab   { font: 600 11px "IBM Plex Mono", monospace; letter-spacing: .08em; fill: #8b949b; }
+    .e-lab.g { fill: #4fd88f; }
+    .e-sub   { font: 400 10px "IBM Plex Mono", monospace; fill: #6d777d; }
+  </style>
 
-      subgraph Plugin["obs-zoom-plugin  (no SDK dependency)"]
-        ZDock["ZoomDock\n(Control UI · CvStatusDot · CvBanner)"]
-        ZEC["ZoomEngineClient\n★ central singleton"]
-        ZRM["ZoomReconnectManager\n(auto-reconnect)"]
-        ZOAuth["ZoomOAuthManager\n(OAuth broker · ZAK fetch · DPAPI)"]
-        ZS["ZoomSource\n(ShmRegion · AssignmentMode)"]
-        ZOM["ZoomOutputManager"]
-        ZCS["ZoomControlServer :19870"]
-        ZOSC["ZoomOscServer :19871"]
+  <!-- Zoom Cloud -->
+  <rect x="16" y="210" width="160" height="128" rx="12" fill="#10151a" stroke="rgba(188,140,255,.38)" stroke-width="1.5"/>
+  <circle cx="34" cy="234" r="4" fill="#bc8cff"/>
+  <text class="p-title" x="46" y="238">ZOOM CLOUD</text>
+  <text class="p-tag" x="30" y="258">RAW A/V SOURCE</text>
+  <rect class="chip" x="30" y="274" width="132" height="30" rx="7"/>
+  <text class="c-txt" x="42" y="293">Live meeting</text>
 
-        ZDock --> ZEC
-        ZDock --> ZOAuth
-        ZRM --> ZEC
-        ZEC --> ZS
-        ZCS & ZOSC --> ZOM & ZEC
-        ZEC --> ZRM
-        ZOAuth -->|"ZAK + publicAppKey"| ZEC
-      end
+  <!-- Engine -->
+  <rect x="252" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(34,200,110,.5)" stroke-width="1.5"/>
+  <circle cx="270" cy="94" r="4" fill="#22c86e"/>
+  <text class="p-title" x="282" y="98">ZOOMOBSENGINE</text>
+  <text class="p-tag" x="266" y="118">ALL ZOOM SDK ACCESS &#183; CHILD PROCESS</text>
+  <rect class="chip" x="266" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="155">Zoom SDK &#183; auth / meeting / raw</text>
+  <rect class="chip" x="266" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="197">Participant + spotlight tracking</text>
+  <rect class="chip" x="266" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="239">EngineVideo &#8212; I420 &#8594; SHM</text>
+  <rect class="chip" x="266" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="281">EngineAudio &#8212; PCM &#8594; SHM</text>
+  <rect class="chip" x="266" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="323">ISO recorder &#8212; FFmpeg</text>
+  <rect class="chip" x="266" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="365">IPC loop</text>
 
-      subgraph Engine["ZoomObsEngine  (ALL SDK access)"]
-        ELoop["IPC Loop"]
-        EVid["EngineVideo\n(SHM write)"]
-        EAud["EngineAudio\n(SHM write)"]
-        EPart["Participant &amp; Spotlight\ntracking"]
-        SDK["Zoom SDK\nAuth · Meeting · Webinar · Raw data"]
-        ELoop --> EVid & EAud & EPart --> SDK
-      end
+  <!-- Plugin -->
+  <rect x="632" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="650" cy="94" r="4" fill="#e9edef"/>
+  <text class="p-title" x="662" y="98">OBS-ZOOM-PLUGIN</text>
+  <text class="p-tag" x="646" y="118">OBS MODULE &#183; NO SDK DEPENDENCY</text>
+  <rect class="chip" x="646" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="155">ZoomEngineClient &#183; singleton</text>
+  <rect class="chip" x="646" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="197">ZoomSource &#215;N &#8212; SHM read</text>
+  <rect class="chip" x="646" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="239">ZoomDock &#8212; control UI</text>
+  <rect class="chip" x="646" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="281">OAuth manager &#8212; PKCE &#183; ZAK</text>
+  <rect class="chip" x="646" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="323">Output manager &#183; reconnect</text>
+  <rect class="chip" x="646" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="365">Control APIs &#8212; TCP &#183; OSC</text>
 
-      subgraph ZoomCloud["Zoom Cloud"]
-        Mtg["Live Meeting / Webinar"]
-      end
+  <!-- OBS Studio -->
+  <rect x="972" y="199" width="152" height="150" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="990" cy="223" r="4" fill="#e9edef"/>
+  <text class="p-title" x="1002" y="227">OBS STUDIO</text>
+  <rect class="chip" x="986" y="244" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="263">Zoom sources</text>
+  <rect class="chip" x="986" y="286" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="305">Program out</text>
 
-      subgraph External["External Control"]
-        Ctrl["Script / Dashboard"]
-      end
-    end
+  <!-- External control -->
+  <rect x="632" y="506" width="280" height="64" rx="12" fill="#10151a" stroke="rgba(232,164,31,.4)" stroke-width="1.5"/>
+  <circle cx="650" cy="530" r="4" fill="#e8a41f"/>
+  <text class="p-title" x="662" y="534">EXTERNAL CONTROL</text>
+  <text class="p-tag" x="646" y="554">COMPANION &#183; SCRIPTS &#183; CONSOLES</text>
 
-    OBS -->|loads| Plugin
-    VSrc <--> ZS
-    Plugin <-->|"JSON IPC\n(named pipe / Unix socket)"| ELoop
-    EVid & EAud -->|"Named Shared Memory\nI420 frames · PCM audio"| ZS
-    SDK <-->|HTTPS/WSS| Mtg
-    Ctrl <-->|"TCP :19870\nUDP OSC :19871"| ZCS & ZOSC
-    style OBS fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Plugin fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style ZoomCloud fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style External fill:#2d2000,stroke:#d29922,color:#e6edf3
-      </div>
+  <!-- Edges -->
+  <path d="M176,274 L244,274" stroke="#8b949b" stroke-width="2" fill="none" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="210" y="252" text-anchor="middle">HTTPS</text>
+  <text class="e-sub" x="210" y="264" text-anchor="middle">/ WSS</text>
+
+  <path d="M532,250 L624,250" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="582" y="226" text-anchor="middle">SHARED MEMORY</text>
+  <text class="e-sub" x="582" y="240" text-anchor="middle">I420 &#183; PCM</text>
+
+  <path d="M540,340 L624,340" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="582" y="316" text-anchor="middle">JSON IPC</text>
+  <text class="e-sub" x="582" y="330" text-anchor="middle">pipe / socket</text>
+
+  <path d="M912,274 L964,274" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="938" y="258" text-anchor="middle">FRAMES</text>
+
+  <path d="M772,498 L772,478" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-sub" x="786" y="492" text-anchor="start">TCP :19870 &#183; UDP OSC :19871</text>
+</svg>
       <div class="diagram-caption">Fig 1 - All SDK access is in ZoomObsEngine. ZoomOAuthManager handles broker-backed OAuth PKCE, token storage, and ZAK fetches. TCP and OSC provide external control without linking the Zoom SDK into OBS.</div>
     </div>
   </section>
@@ -628,39 +658,26 @@ graph TB
       New additions: <code>ZoomDock</code> (join UI), <code>ZoomReconnectManager</code>
       (auto-reconnect), and <code>HwVideoPipeline</code> (hardware I420→NV12).
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 classDiagram
     class ZoomEngineClient {
         &lt;&lt;Singleton&gt;&gt;
-        +start(auth_token, public_app_key) / stop() / stop_for_reconnect()
-        +join(id, pass, name, kind: MeetingKind)
-        +leave()
-        +subscribe(uuid, pid, isolate_audio)
+        +start() / stop()
+        +join() / leave()
+        +subscribe(uuid, pid)
         +subscribe_spotlight(uuid, slot)
         +subscribe_screenshare(uuid)
-        +unsubscribe(uuid)
-        +state() MeetingState
-        +is_authenticated() bool
-        +active_speaker_id() uint32_t
-        +roster() vector~ParticipantInfo~
+        +state() / roster()
         +register_source(uuid, callbacks)
-        +add_roster_callback(key, cb)
     }
     class ZoomSource {
         +assignment : AssignmentMode
-        +participant_id : atomic~uint32_t~
-        +spotlight_slot : atomic~uint32_t~
-        +failover_participant_id : atomic~uint32_t~
         +resolution : VideoResolution
         +video_loss_mode : VideoLossMode
-        +hw_accel_override : int
-        +speaker_sensitivity_ms, speaker_hold_ms
-        +configure_output_ex(mode, pid, slot, failover, …)
+        +configure_output_ex(...)
         +on_engine_frame(w, h)
-        +on_engine_audio(byte_len)
-        +m_hk_active_on_id, m_hk_active_off_id
-        +m_hw_pipeline : HwVideoPipeline
+        +on_engine_audio(bytes)
     }
     class ZoomOAuthManager {
         &lt;&lt;Singleton&gt;&gt;
@@ -669,29 +686,19 @@ classDiagram
         +register_url_scheme() bool
         +refresh_access_token_blocking() bool
         +fetch_user_zak_blocking(zak) bool
-        -m_pending_state : QString
-        -m_pending_verifier : QString
     }
     class ZoomDock {
         +on_join_clicked()
         +on_leave_clicked()
         +on_cancel_recovery_clicked()
         +update_state_indicator()
-        +update_recovery_panel()
-        +update_credentials_banner()
-        -m_state_dot : CvStatusDot
-        -m_credentials_banner : CvBanner
-        -m_join_token_type : QComboBox
-        -m_output_table : QTableWidget
     }
     class ZoomReconnectManager {
         &lt;&lt;Singleton&gt;&gt;
         +set_policy(policy)
-        +store_session(auth_token, id, pass, name)
-        +trigger(reason: RecoveryReason)
-        +cancel()
-        +on_join_success() / on_join_failed(permanent)
-        +is_recovering() bool
+        +store_session(...)
+        +trigger(reason) / cancel()
+        +on_join_success() / on_join_failed()
         +next_retry_ms() int
     }
     class HwVideoPipeline {
@@ -742,23 +749,17 @@ classDiagram
       All Zoom SDK state (auth, meeting, roster, active speaker) is owned by the
       engine; the client tracks it locally by processing the event stream.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 graph TB
     subgraph Plugin["obs-zoom-plugin process"]
         ZEC["ZoomEngineClient\n★ singleton"]
         Reader["reader_loop()\n(dedicated thread)"]
-        S1["ZoomSource A\n(ShmRegion video+audio)"]
-        S2["ZoomSource B\n(ShmRegion video+audio)"]
+        S1["ZoomSource A"]
+        S2["ZoomSource B"]
         ZEC --> Reader
-        ZEC -->|"on_frame / on_audio callbacks"| S1
-        ZEC -->|"on_frame / on_audio callbacks"| S2
-    end
-
-    subgraph IPC["IPC"]
-        P2E["Plugin → Engine\njson cmds"]
-        E2P["Engine → Plugin\njson events"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        ZEC -->|"frame / audio callbacks"| S1
+        ZEC -->|"frame / audio callbacks"| S2
     end
 
     subgraph Engine["ZoomObsEngine process"]
@@ -767,14 +768,11 @@ graph TB
         SDK3 --- ETrack
     end
 
-    ZEC -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> Engine
-    Engine -- "ready · auth_ok · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> Reader
-    Engine -- "write frames" --> SHM
+    ZEC -- "commands · JSON" --> SDK3
+    SDK3 -- "events · JSON" --> Reader
+    SDK3 -- "frame write" --> SHM["Named shared memory"]
     S1 & S2 -- "mmap read" --> SHM
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 3 — ZoomEngineClient launches the engine, owns IPC channels, and dispatches callbacks to each ZoomSource.</div>
     </div>
@@ -826,35 +824,23 @@ graph TB
       Frame data flows through named shared memory to avoid copying large buffers.
       <code>ZoomEngineClient</code> in the plugin abstracts all IPC details.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-graph LR
+flowchart LR
     subgraph Plugin["obs-zoom-plugin"]
         ZEC2["ZoomEngineClient"]
-        SHM_R["ZoomSource\nShmRegion (mmap read)"]
-    end
-
-    subgraph IPC["IPC Channels"]
-        P2E["Plugin → Engine\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        E2P["Engine → Plugin\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        SHM_R["ZoomSource\nSHM read (mmap)"]
     end
 
     subgraph Engine["ZoomObsEngine"]
-        ELoop["IPC Loop\n+ reader_loop"]
-        EVid["EngineVideo"]
-        EAud["EngineAudio"]
-        SDK2["Zoom SDK\n(all SDK access)"]
-        ELoop --> EVid & EAud --> SDK2
+        ELoop["IPC loop"]
+        EMed["EngineVideo · EngineAudio"]
     end
 
-    ZEC2 -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> ELoop
-    ELoop -- "ready · auth_ok · auth_fail · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> ZEC2
-    EVid & EAud -- "write I420 + PCM" --> SHM --> SHM_R
+    ZEC2 -- "commands · JSON" --> ELoop
+    ELoop -- "events · JSON" --> ZEC2
+    EMed -- "I420 + PCM" --> SHM["Named shared memory"] --> SHM_R
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 4 — Cross-platform IPC: JSON over named pipes (Windows) or Unix sockets (macOS/Linux); frames through shared memory.</div>
     </div>
@@ -867,9 +853,9 @@ graph LR
 
   <section id="arch-video">
     <h2>Architecture: Video Pipeline</h2>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     CAM["Participant\nCamera"] --> ZC["Zoom Cloud"]
     ZC -->|decoded I420| EV["Engine EngineVideo\n(IZoomSDKRenderer)"]
     EV -->|"write I420 to\nShmRegion"| SHM2["Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
@@ -878,14 +864,6 @@ flowchart LR
     ZS5 -->|"VideoLossMode:\nLastFrame / Black"| LOSS["Loss handling"]
     LOSS -->|"I420 planar\nPreviewCallback ≤5fps"| OBS_V["OBS Video\nobs_source_output_video()"]
 
-    style CAM fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EV fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM2 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC3 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZS5 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style LOSS fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style OBS_V fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 5 — Video path: engine writes I420 to shared memory; ZoomSource reads via ShmRegion and forwards to OBS.</div>
     </div>
@@ -909,7 +887,7 @@ flowchart LR
       pushes it to OBS. Stereo sources use an internal <code>m_stereo_buf</code> to
       interleave channels before output.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart TB
     SDK4["Zoom SDK\n(inside engine)"]
@@ -922,10 +900,6 @@ flowchart TB
 
     ZS6 -->|"Mono: direct S16\nStereo: interleaved"| OBS_A["OBS Audio\nobs_source_output_audio()"]
 
-    style SDK4 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EAud2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM3 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZS6 fill:#0d2137,stroke:#22c86e,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 6 — Audio pipeline: engine mixes/isolates audio in-process and delivers chunks through shared memory.</div>
     </div>
@@ -949,9 +923,9 @@ flowchart TB
       <code>frame</code> events on the share source UUID and forwards them to OBS
       exactly like participant video.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     SC2["Screen Share\nIn Meeting"] --> ZC3["Zoom Cloud"]
     ZC3 -->|onSharingStatus| EShare["Engine\nShareDelegate\n(inside ZoomObsEngine)"]
     EShare -->|subscribe share renderer| Rnd["IZoomSDKRenderer"]
@@ -959,12 +933,6 @@ flowchart LR
     SHM4 -->|"frame event"| ZEC4["ZoomEngineClient\n→ ZoomSource (share)"]
     ZEC4 -->|obs_source_output_video| OBS_SS["OBS Zoom\nShare Source"]
 
-    style SC2 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC3 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EShare fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM4 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC4 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style OBS_SS fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 7 — Screen share: engine-side delegate writes I420 to shared memory; plugin receives via ZoomEngineClient frame callback.</div>
     </div>
@@ -981,7 +949,7 @@ flowchart LR
       the helper with <code>AuthContext.publicAppKey</code>. The engine is not
       started on module load; it is launched the first time a join is requested.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant OBS as OBS Studio
@@ -997,7 +965,7 @@ sequenceDiagram
     PM->>ZOA2: load OAuth tokens and broker URL
     PM->>ZoomControlServer: start(control_server_port)
     PM->>ZoomOscServer: start(osc_server_port)
-    PM->>ZDock: ensure_zoom_dock() [after OBS_FRONTEND_EVENT_FINISHED_LOADING]
+    PM->>ZDock: ensure_zoom_dock() after frontend loaded
 
     Note over ZDock: User clicks Join or API sends join cmd
 
@@ -1067,7 +1035,7 @@ sequenceDiagram
     </div>
 
     <h3>Authorization Flow</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant User
@@ -1085,17 +1053,17 @@ sequenceDiagram
     ZOA->>Browser: QDesktopServices::openUrl(/oauth/start?state=…)
     Browser->>Broker2: GET /oauth/start
     Broker2->>Broker2: generate PKCE verifier/challenge
-    Broker2->>ZoomCloud2: redirect to /v2/authorize?client_id=…&code_challenge=…
+    Broker2->>ZoomCloud2: redirect → /v2/authorize (PKCE)
     ZoomCloud2-->>Browser: consent screen
     User->>Browser: approve
     ZoomCloud2-->>Broker2: redirect to /oauth/callback?code=…&state=…
-    Broker2-->>Browser: redirect to corevideo://oauth/callback?broker_token=…&state=…
-    Browser->>Helper: launch CoreVideoOAuthCallback (Windows: .exe / macOS: .app)
-    Helper->>ZCS2: POST {"cmd":"oauth_callback","url":"corevideo://oauth/callback?broker_token=…&state=…"}
+    Broker2-->>Browser: redirect → corevideo://oauth/callback
+    Browser->>Helper: launch CoreVideoOAuthCallback helper
+    Helper->>ZCS2: POST {"cmd":"oauth_callback", url}
     ZCS2->>ZOA: handle_redirect_url(url)
     ZOA->>ZOA: verify state matches m_pending_state
     ZOA->>Broker2: POST /oauth/redeem broker_token=…
-    Broker2->>ZoomCloud2: POST /oauth/token client_id + code_verifier, no secret
+    Broker2->>ZoomCloud2: POST /oauth/token (PKCE, no secret)
     Broker2-->>ZOA: {access_token, refresh_token, expires_in}
     ZOA->>ZOA: store tokens (DPAPI on Windows)
     Note over ZOA: Ready to fetch ZAK on next join
@@ -1104,7 +1072,7 @@ sequenceDiagram
     </div>
 
     <h3>ZAK Fetch and publicAppKey SDK Auth (before each join)</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZDock4 as ZoomDock
@@ -1114,12 +1082,12 @@ sequenceDiagram
     participant ZEC8 as ZoomEngineClient
 
     ZDock4->>ZOA2: fetch_user_zak_blocking(zak)
-    ZOA2->>ZOA2: check token expiry\nrefresh_access_token_blocking() if expired
-    ZOA2->>ZoomAPI: GET /v2/users/me/token?type=zak\nAuthorization: Bearer {access_token}
+    ZOA2->>ZOA2: refresh access token if expired
+    ZOA2->>ZoomAPI: GET /users/me/token?type=zak
     ZoomAPI-->>ZOA2: signed-in user ZAK
     ZOA2-->>ZDock4: zak string
-    ZDock4->>ZEC8: start(public_app_key), then join(id, pass, name, kind, zak)
-    ZEC8->>Engine: {"cmd":"init","public_app_key":"…"} then {"cmd":"join","meeting_id":"…","user_zak":"…"}
+    ZDock4->>ZEC8: start(publicAppKey) → join(…, zak)
+    ZEC8->>Engine: {"cmd":"init"} then {"cmd":"join"}
       </div>
       <div class="diagram-caption">Fig 8c - A user ZAK is fetched before each join using the stored OAuth access token; token refresh is automatic when expired.</div>
     </div>
@@ -1149,7 +1117,7 @@ sequenceDiagram
       Joining is centralized in <code>ZoomDock</code> (or the TCP/OSC control APIs) —
       not in individual sources. Sources subscribe to the already-joined meeting.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant U as User / Control API
@@ -1159,23 +1127,23 @@ sequenceDiagram
     participant ZS3 as ZoomSource
     participant Engine as ZoomObsEngine
 
-    U->>ZDock2: click Join (meeting_id, passcode, display_name, [webinar])
+    U->>ZDock2: click Join
     ZDock2->>ZRM2: store_session(auth_token, id, pass, name)
-    ZDock2->>ZEC6: start(public_app_key) [launches engine if not running]
+    ZDock2->>ZEC6: start() — launch engine if needed
     ZDock2->>ZEC6: join(id, pass, name, kind=Meeting|Webinar)
-    ZEC6->>Engine: {"cmd":"join","meeting_id":"…","kind":"meeting|webinar"}
+    ZEC6->>Engine: {"cmd":"join", kind}
     Engine-->>ZEC6: {"cmd":"joined"}
     ZEC6-->>ZRM2: on_join_success()
 
     Note over ZS3: ZoomSource.activate() when OBS activates source
 
-    ZS3->>ZEC6: subscribe(uuid, pid, isolate) OR subscribe_spotlight(uuid, slot)
-    ZEC6->>Engine: {"cmd":"subscribe","source_uuid":"…","participant_id":N}
+    ZS3->>ZEC6: subscribe() / subscribe_spotlight()
+    ZEC6->>Engine: {"cmd":"subscribe", uuid, pid}
 
     loop Live capture
         Engine-->>ZEC6: {"cmd":"frame","uuid":"…","w":W,"h":H}
         ZEC6-->>ZS3: on_engine_frame(w, h)
-        ZS3->>ZS3: read I420 from video shm, process with HwVideoPipeline if enabled
+        ZS3->>ZS3: read I420 from SHM (+HW pipeline)
         ZS3->>OBS: obs_source_output_video()
         Engine-->>ZEC6: {"cmd":"audio","uuid":"…","byte_len":B}
         ZEC6-->>ZS3: on_engine_audio(byte_len)
@@ -1259,7 +1227,7 @@ sequenceDiagram
       This mirrors the ZoomISO "Spotlight 1/2/3" output model.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart LR
     subgraph Source["ZoomSource (AssignmentMode)"]
@@ -1276,9 +1244,6 @@ flowchart LR
 
     ZEC7 -->|JSON IPC| Engine2["ZoomObsEngine\n(resolves → SDK renderer)"]
 
-    style Source fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZEC7 fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
       </div>
       <div class="diagram-caption">Assignment modes map to different ZoomEngineClient subscribe calls; the engine resolves each to the correct SDK renderer.</div>
     </div>
@@ -1328,7 +1293,7 @@ flowchart LR
       <code>obs_queue_task(OBS_TASK_UI, …)</code> to re-evaluate on the OBS UI thread.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 stateDiagram-v2
     [*] --> Idle : active_speaker_mode = off
@@ -1360,7 +1325,7 @@ stateDiagram-v2
     </div>
 
     <h3>Switch Sequence</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZP as ZoomEngineClient\n(roster_callback)
@@ -1369,8 +1334,8 @@ sequenceDiagram
     participant UI as OBS UI Thread
     participant VD as VideoDelegate
 
-    ZP-->>ZS4: roster callback\n(active_speaker_id from engine event = X)
-    ZS4->>ZS4: on_active_speaker_changed()\npending = X, candidate_since = now
+    ZP-->>ZS4: roster callback: active_speaker = X
+    ZS4->>ZS4: pending = X, start hold timer
 
     alt delay == 0
         ZS4->>ZS4: do_speaker_switch(X)
@@ -1529,7 +1494,7 @@ sequenceDiagram
       position in OBS. It is the primary UI for meeting management.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-obs-workspace.svg" alt="CoreVideo OBS workspace with Zoom Control dock" style="max-width:100%;height:auto;">
       <div class="diagram-caption">CoreVideo runs as normal OBS UI: the Zoom Control dock manages meeting state and raw media while Zoom Participant sources render inside OBS scenes.</div>
     </div>
@@ -1731,7 +1696,7 @@ sequenceDiagram
       <tr><td><code>ZoomOutputProfile::remove(name)</code></td><td>Deletes profile JSON file</td></tr>
     </table>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-output-manager.svg" alt="CoreVideo Output Manager with participant and output mapping" style="max-width:100%;height:auto;">
       <div class="diagram-caption">The Output Manager mirrors the dock assignment controls and remains useful for named profile save/load workflows.</div>
     </div>
@@ -1820,7 +1785,7 @@ sequenceDiagram
     </table>
 
     <h3>Zoom Participant Source Properties</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-source-properties.svg" alt="CoreVideo Zoom Participant source properties" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Each Zoom Participant source keeps its own assignment mode, audio routing, requested resolution, and failover behavior.</div>
     </div>
@@ -1887,7 +1852,7 @@ sequenceDiagram
       state in the panel and TCP status payload.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/iso-recording-flow.svg" alt="CoreVideo ISO recording flow" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Assignments resolve the participant IDs. Each assigned Zoom source can feed an FFmpeg writer for video/audio ISO files while OBS continues to own the program output.</div>
     </div>
@@ -1980,27 +1945,38 @@ sequenceDiagram
 </main>
 
 <script>
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
   mermaid.initialize({
     startOnLoad: true,
-    theme: 'dark',
+    theme: 'base',
     themeVariables: {
       darkMode: true,
-      background: '#0d1117',
-      mainBkg: '#1e2a35', primaryColor: '#1e2a35', primaryTextColor: '#eaf2f6',
-      primaryBorderColor: '#2fd07f', nodeBorder: '#2fd07f',
-      secondaryColor: '#26313c', tertiaryColor: '#1a222b',
-      lineColor: '#aeb7bf', textColor: '#eaf2f6', nodeTextColor: '#eaf2f6',
-      edgeLabelBackground: '#0d1117', clusterBkg: '#161d25', clusterBorder: '#3a4650', titleColor: '#eaf2f6',
-      actorBkg: '#1e2a35', actorBorder: '#2fd07f', actorTextColor: '#ffffff',
-      actorLineColor: '#aeb7bf', signalColor: '#aeb7bf', signalTextColor: '#eaf2f6',
-      noteBkgColor: '#2a3742', noteTextColor: '#eaf2f6', noteBorderColor: '#4a5762',
-      activationBorderColor: '#2fd07f', activationBkgColor: '#183a2a',
-      sequenceNumberColor: '#0d1117', labelBoxBkgColor: '#1e2a35',
-      labelBoxBorderColor: '#4a5762', labelTextColor: '#eaf2f6', loopTextColor: '#eaf2f6',
-      fontFamily: 'Space Grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     },
-    flowchart: { curve: 'basis', htmlLabels: true },
-    sequence: { actorMargin: 60, messageMargin: 30 },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
   });
 
   const sections = document.querySelectorAll('section[id]');

--- a/docs/index.html
+++ b/docs/index.html
@@ -232,6 +232,18 @@
       and TCP/OSC control APIs for full broadcast automation.
     </p>
     <div class="callout warning" style="margin-top:18px;">
+      <div class="callout-title">🧪 Beta status</div>
+      CoreVideo is in <strong>public beta</strong>. The supported platform is
+      <strong>Windows x64</strong> (installer or ZIP) — see
+      <a href="ROADMAP.md">the Roadmap</a> for known limitations and what's
+      planned next. To report a problem, use
+      <a href="https://github.com/iamfatness/CoreVideo/issues/new/choose">GitHub Issues</a>
+      (the bug report template walks you through attaching a redacted
+      <a href="#troubleshooting">support bundle</a>). New releases are announced
+      through a dismissible in-app update banner in the Zoom Control dock and on the
+      <a href="https://github.com/iamfatness/CoreVideo/releases">GitHub Releases</a> page.
+    </div>
+    <div class="callout warning" style="margin-top:18px;">
       <div class="callout-title">Zoom Raw Data Bandwidth Planning</div>
       CoreVideo uses Zoom Meeting SDK raw data APIs. Raw data access does not require Enhanced Media by itself,
       but quality and stream count follow Zoom account and app entitlements. Standard accounts are commonly
@@ -239,6 +251,7 @@
       100 Mbps. Plan around 4-6 Mbps per standard 1080p feed.
     </div>
     <div class="hero-badges" style="margin-top:16px;">
+      <span class="badge orange">Public beta</span>
       <span class="badge green">Free</span>
       <span class="badge green">OBS Studio 30+</span>
       <span class="badge orange">Windows installer</span>
@@ -569,16 +582,183 @@
   <!-- ── Troubleshooting ────────────────────────────────────────── -->
   <section id="troubleshooting">
     <h2>Troubleshooting</h2>
+    <div class="callout warning">
+      <div class="callout-title">⚠️ Public beta</div>
+      CoreVideo is in public beta. The Windows installer is not yet code-signed, and
+      the issues below are the ones we expect to see most from new installs. If
+      something isn't covered here, see <a href="#filing-a-bug">Filing a bug</a> below.
+    </div>
     <table>
       <tr><th>Symptom</th><th>Fix</th></tr>
-      <tr><td>Zoom Control dock not visible after install</td><td>Enable it from OBS <strong>Docks&nbsp;→&nbsp;Zoom Control</strong>. Confirm OBS is version 30+ and was fully closed during install.</td></tr>
-      <tr><td>"Sign in with Zoom" doesn't complete</td><td>Finish the browser consent and allow the <code>corevideo://</code> link to open CoreVideo. Re-run sign-in from Tools&nbsp;→&nbsp;Zoom Plugin Settings.</td></tr>
-      <tr><td>Joined, but no video</td><td>Confirm the host admitted "OBS" from the waiting room, the participant has their camera on, and your Zoom account/app entitlements allow raw video (see Requirements).</td></tr>
+      <tr><td>Zoom Control dock not visible after install</td><td>Enable it from OBS <strong>Docks&nbsp;→&nbsp;Zoom Control</strong> (or <strong>Tools&nbsp;→&nbsp;Zoom Control</strong>, which creates and shows it even if you've never opened it before). Confirm OBS is version 30+ and was fully closed during install.</td></tr>
+      <tr><td>"Sign in with Zoom" doesn't complete</td><td>Finish the browser consent and allow the <code>corevideo://</code> link to open CoreVideo. Re-run sign-in from Tools&nbsp;→&nbsp;Zoom Plugin Settings. See <a href="#signin-loop">Sign-in loop</a> below for more.</td></tr>
+      <tr><td>Joined, but no video</td><td>Work through the <a href="#no-video-frames">No video frames</a> checklist below.</td></tr>
       <tr><td>Source shows color bars</td><td>The source isn't subscribed yet — assign a participant or slot in the source properties or the Output Manager.</td></tr>
       <tr><td>Choppy or low-resolution feeds</td><td>Reduce the number of concurrent 1080p feeds or the requested resolution, and check available bandwidth (~4-6 Mbps per 1080p feed).</td></tr>
+      <tr><td>Windows warns "Windows protected your PC" during install</td><td>Expected for the unsigned beta installer — see <a href="#smartscreen">SmartScreen</a> below.</td></tr>
+      <tr><td>Windows Firewall prompts for CoreVideo or ZoomObsEngine</td><td>Both control ports are loopback-only — see <a href="#firewall-prompts">Firewall prompts</a> below.</td></tr>
     </table>
-    <p>Still stuck? Export a redacted support bundle from the <strong>Zoom Diagnostics</strong> dock
-    and contact <a href="/support/">CoreVideo Support</a>.</p>
+
+    <h3 id="smartscreen">Installer blocked by Windows SmartScreen</h3>
+    <p>
+      CoreVideo's beta installer (<code>CoreVideo-Setup.exe</code>) is not yet
+      code-signed, so Windows SmartScreen will show <strong>"Windows protected your
+      PC"</strong> the first time you run it. This is expected during the beta —
+      it does not mean the download is unsafe, but you should still confirm you got
+      the file from <a href="https://corevideo.io/download">corevideo.io/download</a>
+      or the official <a href="https://github.com/iamfatness/CoreVideo/releases">GitHub Releases</a> page.
+    </p>
+    <div class="steps">
+      <div class="step"><div class="step-body">
+        <h4>1. Click "More info"</h4>
+        <p>On the SmartScreen dialog, click <strong>More info</strong>, then
+        <strong>Run anyway</strong>. If you don't see a "More info" link, your
+        organization's policy may be blocking unsigned installers entirely — check
+        with your IT administrator.</p>
+      </div></div>
+      <div class="step"><div class="step-body">
+        <h4>2. (Optional but recommended) Verify the checksum</h4>
+        <p>Every release publishes a matching <code>.sha256</code> file next to the
+        installer and ZIP. Compare it against a local hash before running the
+        installer:</p>
+        <pre><code>certutil -hashfile CoreVideo-Setup.exe SHA256</code></pre>
+        <p>or, in PowerShell:</p>
+        <pre><code>Get-FileHash .\CoreVideo-Setup.exe -Algorithm SHA256</code></pre>
+        <p>The result should match the contents of the corresponding
+        <code>.sha256</code> file from the same release.</p>
+      </div></div>
+    </div>
+
+    <h3 id="no-video-frames">"No video frames" checklist</h3>
+    <p>Work through these in order — each one rules out a different stage of the pipeline.</p>
+    <ol>
+      <li><strong>Assignment mode is set.</strong> A newly added Zoom Participant /
+      Spotlight / Screen Share source isn't subscribed to anything until you assign
+      it — in the source properties or the <strong>Zoom Output Manager</strong>
+      dock. An unassigned source shows the color-bar placeholder, not black.</li>
+      <li><strong>The participant actually has their camera on</strong> and has been
+      admitted from the waiting room (or the meeting allows guests). CoreVideo can
+      only capture video a participant is sending.</li>
+      <li><strong>Check requested vs. observed resolution in the Zoom Diagnostics
+      dock.</strong> Open <strong>Docks&nbsp;→&nbsp;Zoom Diagnostics</strong> (or
+      <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) and look at the Outputs
+      table. If <em>Observed</em> stays blank or 0×0 while <em>Requested</em> shows
+      a resolution, the subscription never came up — re-assign the source or click
+      <strong>Refresh</strong>. If observed resolution is consistently lower than
+      requested, that's usually a bandwidth or entitlement ceiling, not a bug.</li>
+      <li><strong>Confirm the engine is actually running.</strong> Every meeting
+      session launches <code>zoom-runtime\ZoomObsEngine.exe</code> as a child
+      process of OBS — all Zoom SDK access happens there, not in the plugin DLL. If
+      it isn't running (check Task Manager, or "Engine running" in a support
+      bundle's <code>summary.txt</code>), the plugin never receives frames.
+      Antivirus software occasionally quarantines or blocks a freshly-installed
+      <code>ZoomObsEngine.exe</code> — check your antivirus's quarantine/history if
+      it's missing.</li>
+      <li><strong>Bandwidth and entitlements.</strong> Your Zoom account and app
+      entitlements bound both quality and stream count: standard accounts are
+      commonly limited to ~30 Mbps incoming video (roughly 4-6 Mbps per 1080p
+      feed), while Enhanced Media / HBM can raise that to ~100 Mbps. If several
+      1080p feeds are requested at once on a standard account, expect some to
+      negotiate down or fail — see <a href="#requirements">Requirements</a>.</li>
+    </ol>
+
+    <h3 id="signin-loop">Sign-in loop / browser doesn't return to OBS</h3>
+    <p>
+      "Sign in with Zoom" opens your browser to Zoom's consent screen and expects
+      the browser to hand control back to CoreVideo afterward through the
+      <code>corevideo://</code> URL scheme. A few different things can break that
+      handoff:
+    </p>
+    <ul>
+      <li><strong>The <code>corevideo://</code> handler isn't registered yet.</strong>
+      CoreVideo registers it automatically the first time you click <strong>Sign in
+      with Zoom</strong>. If a browser prompt asks which app should open a
+      <code>corevideo://</code> link, choose CoreVideo (and "always allow" it) — if
+      you dismiss or block that prompt, the callback has nowhere to go and the
+      browser tab just sits there after you approve access in Zoom.</li>
+      <li><strong>The callback helper didn't launch.</strong> The last hop is a
+      small helper binary, <code>CoreVideoOAuthCallback.exe</code>, which the OS
+      launches for the <code>corevideo://oauth/callback</code> URL and which
+      forwards it to the plugin's local control server as an
+      <code>oauth_callback</code> command. If antivirus software or SmartScreen
+      blocked that helper from running, sign-in will look like it hung after you
+      approved access in the browser. Retry sign-in, and allow the helper if
+      prompted.</li>
+      <li><strong>Admin-managed Zoom account.</strong> If your organization
+      restricts Marketplace apps, the consent screen shows <strong>Request
+      pre-approval</strong> instead of <strong>Allow</strong> — sign-in cannot
+      complete until a Zoom admin approves CoreVideo. See <a href="#adding">Adding
+      CoreVideo to your Zoom account</a> for the pre-approval steps.</li>
+      <li>Whatever the cause, re-running sign-in from <strong>Tools&nbsp;→&nbsp;Zoom
+      Plugin Settings</strong> is safe and starts a fresh authorization attempt.</li>
+    </ul>
+
+    <h3 id="firewall-prompts">Firewall prompts for TCP 19870 / UDP 19871</h3>
+    <div class="callout info">
+      <div class="callout-title">ℹ️ Both ports are loopback-only</div>
+      The <a href="#control-api">TCP control API</a> and <a href="#osc-api">OSC
+      control API</a> both bind to <code>127.0.0.1</code> only — nothing outside
+      your machine can reach either port, regardless of how you answer a Windows
+      Firewall prompt. Windows may still prompt the first time one of these
+      servers binds, because it can't tell in advance that a listener is
+      loopback-restricted.
+    </div>
+    <p>
+      It's safe to <strong>Allow access</strong> on Private networks if you plan to
+      drive CoreVideo from an external control surface (Companion, a lighting
+      console, a custom script) running on the same machine. If you don't use the
+      TCP/OSC APIs, it's equally safe to <strong>Cancel</strong> or deny the
+      prompt — Zoom capture, sources, and sign-in do not depend on either server;
+      only external control does.
+    </p>
+
+    <h3>Zoom Diagnostics / Zoom Output Manager / other docks missing</h3>
+    <p>
+      Every CoreVideo dock — <strong>Zoom Control</strong>, <strong>Zoom
+      Diagnostics</strong>, <strong>Zoom Output Manager</strong>, and <strong>Zoom
+      ISO Recorder</strong> — can be re-shown from OBS's <strong>Docks</strong>
+      menu once it has appeared at least once. The first time, or if you closed it
+      permanently, use the matching item under the <strong>Tools</strong> menu
+      instead (e.g. <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) — the
+      Tools menu items create and show the dock even if OBS has never registered
+      it in the Docks list before.
+    </p>
+
+    <h3>Plugin not loading</h3>
+    <p>If OBS starts normally but none of the Zoom Control / Diagnostics / Output
+    Manager / ISO Recorder menu items or docks appear at all, the plugin itself
+    likely failed to load:</p>
+    <ul>
+      <li><strong>Confirm OBS Studio is 30 or newer</strong> (Help → About). CoreVideo
+      links against OBS 30's plugin API; older OBS builds cannot load it.</li>
+      <li><strong>Check the OBS log</strong> (Help&nbsp;→&nbsp;Log Files&nbsp;→&nbsp;View
+      Current Log) for a module-load failure mentioning
+      <code>obs-zoom-plugin.dll</code>. A missing-DLL style error there most often
+      means a required file didn't get installed alongside OBS — reinstall with
+      OBS fully closed (the installer refuses to proceed if <code>obs64.exe</code>
+      is still running, but a stuck background process can slip past that check).</li>
+      <li><strong>Missing Visual C++ runtime, in rare cases.</strong> CoreVideo's
+      Qt6 and plugin DLLs are built with the same MSVC toolchain as OBS Studio
+      itself, so if OBS runs at all the runtime is normally already present. On an
+      unusually minimal Windows install, installing the latest
+      <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist" target="_blank" rel="noopener">Microsoft Visual C++ x64 Redistributable</a>
+      is a reasonable thing to try if the log shows a generic DLL load failure.</li>
+    </ul>
+
+    <h3 id="filing-a-bug">Filing a bug</h3>
+    <p>
+      Still stuck? Open the <strong>Zoom Diagnostics</strong> dock
+      (<strong>Docks&nbsp;→&nbsp;Zoom Diagnostics</strong>, or
+      <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) and click <strong>Create
+      Support Bundle</strong>. It writes a redacted bundle — SDK keys, secrets,
+      OAuth tokens, and similar credentials are stripped before anything is written
+      to disk — plus a matching <code>.zip</code> under
+      <code>%AppData%\obs-studio\plugin_config\obs-zoom-plugin\support-bundles\</code>.
+      Attach that <code>.zip</code> when you
+      <a href="https://github.com/iamfatness/CoreVideo/issues/new?template=bug_report.yml">file a bug report</a>,
+      or contact <a href="/support/">CoreVideo Support</a> for anything that isn't
+      a clear bug.
+    </p>
   </section>
 
 

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -1477,6 +1477,12 @@ static void handle_start_media(const char *reason)
     }
 
     g_raw_media_active = true;
+    // The plugin flips its media-active flag on this exact debug stage
+    // (zoom-engine-client.cpp). Without it every output stays labelled
+    // "Raw media not ready" in the Output Manager while frames are visibly
+    // arriving — health that contradicts the picture on screen.
+    EngineIpc::write(R"({"cmd":"debug","stage":"raw_media_ready","reason":")" +
+                     std::string(reason ? reason : "") + "\"}");
     resubscribe_raw_media(reason);
 }
 

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -1,32 +1,39 @@
-// ── macOS ZoomObsEngine — SCAFFOLD, NOT YET FUNCTIONAL ───────────────────────
+// ── macOS ZoomObsEngine — Objective-C++ implementation ───────────────────────
 //
 // The Windows/Linux ZoomObsEngine (engine/src/main.cpp + engine-video.cpp /
 // engine-share.cpp / engine-audio.cpp) is written entirely against the Zoom
 // Meeting SDK's **C++** interface surface: <zoom_sdk.h>, the `ZOOMSDK`
 // namespace, IAuthService / IMeetingService / IMeetingParticipantsController,
-// SDKAuth(AuthContext), InitSDK(InitParam), the raw-recording + raw-data
-// controllers, etc.
+// SDKAuth(AuthContext), InitSDK(InitParam), the raw-data controllers, etc.
 //
 // The macOS Meeting SDK (ZoomSDK.framework, v7.1.5.84750) exposes **none** of
 // that. It is a pure Objective-C framework: ZoomSDKAuthService,
 // ZoomSDKMeetingService, ZoomSDKRawDataVideoSourceController,
-// ZoomSDKRawDataAudioSourceController and Objective-C delegate protocols. There
-// is no zoom_sdk.h and no ZOOMSDK:: C++ API anywhere in the archive. Porting the
-// engine is therefore a full Objective-C++ rewrite, not a set of #ifdef fixes —
-// it is tracked as an explicit gap in the macOS-port PR.
+// ZoomSDKRawDataAudioSourceController and Objective-C delegate protocols. So
+// this file is a full Objective-C++ rewrite rather than a set of #ifdef fixes,
+// implementing the SAME IPC wire protocol defined in src/engine-ipc.h.
 //
-// This translation unit exists so that macOS CI compiles AND links a real
-// ZoomObsEngine binary against the real ZoomSDK.framework — proving the SDK
-// fetch, framework detection, header parsing, and link path end-to-end — WHILE
-// REFUSING to fake any meeting functionality. It performs the platform-shared
-// POSIX IPC handshake (identical wire protocol to the Windows/Linux engine),
-// then, on any init/join request, reports a loud, explicit error over IPC and
-// exits with a non-zero code. It NEVER silently pretends a meeting joined.
+// ── Threading (the constraint that shapes this file) ─────────────────────────
+// The macOS SDK delivers every result through Objective-C delegate callbacks
+// dispatched on the main run loop — the SDK's own sample app is a plain Cocoa
+// app built on NSApplicationMain. The previous scaffold blocked the main thread
+// in `while (ipc_read_line(...))`, which would starve that run loop, so no
+// delegate could ever fire and auth would hang forever with no error.
 //
-// When the Objective-C++ engine is written, it should replace this file (or be
-// gated behind it) and implement the same IPC contract in engine-ipc.h.
+// Therefore: the main thread runs the Cocoa run loop and nothing else, the IPC
+// read loop runs on a background thread, and every SDK call is hopped back onto
+// the main queue. Delegate callbacks then arrive on the main thread and write
+// to IPC from there. EngineIpc::write is serialized with its own mutex, so
+// interleaved writes from the reader thread and the main thread stay
+// line-atomic.
+//
+// ── Implemented so far ───────────────────────────────────────────────────────
+//   init  -> SDK init + sdkAuth, emitting auth_ok / auth_fail
+// Everything else (join, roster, raw media) still fails loudly over IPC rather
+// than pretending, exactly as before. Do NOT fake frames.
 
 #import <ZoomSDK/ZoomSDK.h>
+#import <Cocoa/Cocoa.h>
 
 #include "../../src/engine-ipc.h"
 #include "engine-writer.h"
@@ -37,6 +44,223 @@
 #include <unistd.h>
 #include <cstring>
 #include <string>
+#include <thread>
+
+// ── JSON helpers ─────────────────────────────────────────────────────────────
+// Deliberately identical to the ones in main.cpp so both engines parse the
+// plugin's messages the same way. The plugin emits flat, well-formed objects;
+// this is the same intentionally-minimal scanner the Windows engine uses.
+static std::string json_str(const std::string &json, const std::string &key)
+{
+    const std::string needle = "\"" + key + "\":\"";
+    auto pos = json.find(needle);
+    if (pos == std::string::npos) return {};
+    pos += needle.size();
+    std::string result;
+    while (pos < json.size()) {
+        char c = json[pos++];
+        if (c == '\\') {
+            if (pos < json.size()) pos++; // skip escaped character
+            continue;
+        }
+        if (c == '"') break;
+        result += c;
+    }
+    return result;
+}
+
+static std::string json_escape(const std::string &in)
+{
+    std::string out;
+    out.reserve(in.size() + 8);
+    for (char c : in) {
+        switch (c) {
+        case '\\': out += "\\\\"; break;
+        case '"': out += "\\\""; break;
+        case '\n': out += "\\n"; break;
+        case '\r': out += "\\r"; break;
+        case '\t': out += "\\t"; break;
+        default: out += c; break;
+        }
+    }
+    return out;
+}
+
+static std::string redacted_tail(const std::string &value)
+{
+    if (value.empty()) return "empty";
+    if (value.size() <= 4) return "****";
+    return "****" + value.substr(value.size() - 4);
+}
+
+// ── Auth result naming ───────────────────────────────────────────────────────
+// The plugin classifies auth failures by NAME, not by numeric code:
+// zoom_join::classify_sdk_auth_result() in src/zoom-join-decision.h switches on
+// the AUTHRET_* strings the Windows engine reports, and the code is only echoed
+// into the operator message for support bundles. The macOS ZoomSDKAuthError
+// enum is a different type with different numeric values, so mapping it onto
+// the same AUTHRET_* vocabulary is what makes the plugin's existing error
+// catalog work unchanged on macOS. Do not "simplify" this into the raw ObjC
+// enum name -- that would silently degrade every auth error to the generic
+// fallback message.
+static const char *auth_result_name(ZoomSDKAuthError ret)
+{
+    switch (ret) {
+    case ZoomSDKAuthError_Success:                return "AUTHRET_SUCCESS";
+    case ZoomSDKAuthError_KeyOrSecretWrong:       return "AUTHRET_KEYORSECRETWRONG";
+    case ZoomSDKAuthError_AccountNotSupport:      return "AUTHRET_ACCOUNTNOTSUPPORT";
+    case ZoomSDKAuthError_AccountNotEnableSDK:    return "AUTHRET_ACCOUNTNOTENABLESDK";
+    case ZoomSDKAuthError_Timeout:                return "AUTHRET_OVERTIME";
+    case ZoomSDKAuthError_NetworkIssue:           return "AUTHRET_NETWORKISSUE";
+    case ZoomSDKAuthError_Client_Incompatible:    return "AUTHRET_CLIENT_INCOMPATIBLE";
+    case ZoomSDKAuthError_JwtTokenWrong:          return "AUTHRET_JWTTOKENWRONG";
+    case ZoomSDKAuthError_KeyOrSecretEmpty:       return "AUTHRET_KEYORSECRETEMPTY";
+    case ZoomSDKAuthError_LimitExceededException: return "AUTHRET_LIMIT_EXCEEDED_EXCEPTION";
+    case ZoomSDKAuthError_Unknown:                return "AUTHRET_UNKNOWN";
+    default:                                      return "AUTHRET_UNKNOWN";
+    }
+}
+
+// Auth mode of the in-flight sdkAuth call ("jwt" or "public_app_key"). The
+// plugin needs it to interpret a key/secret/jwt rejection correctly. Written on
+// the main queue before sdkAuth and read in the delegate callback, which also
+// runs on the main queue, so no additional synchronization is needed.
+static std::string g_current_auth_mode = "jwt";
+
+// ── Auth delegate ────────────────────────────────────────────────────────────
+@interface CVAuthDelegate : NSObject <ZoomSDKAuthDelegate>
+@end
+
+@implementation CVAuthDelegate
+
+- (void)onZoomSDKAuthReturn:(ZoomSDKAuthError)returnValue
+{
+    if (returnValue == ZoomSDKAuthError_Success) {
+        EngineIpc::write(R"({"cmd":"auth_ok"})");
+        return;
+    }
+    EngineIpc::write(std::string(R"({"cmd":"auth_fail","code":)") +
+                     std::to_string(static_cast<int>(returnValue)) +
+                     R"(,"name":")" + auth_result_name(returnValue) +
+                     R"(","auth_mode":")" + json_escape(g_current_auth_mode) +
+                     "\"}");
+}
+
+- (void)onZoomAuthIdentityExpired
+{
+    EngineIpc::write(R"({"cmd":"error","msg":"identity_expired"})");
+}
+
+- (void)onZoomIdentityExpired
+{
+    EngineIpc::write(R"({"cmd":"error","msg":"identity_expired"})");
+}
+
+@end
+
+static CVAuthDelegate *g_auth_delegate = nil;
+
+// ── init / auth ──────────────────────────────────────────────────────────────
+// Runs on the main queue. Mirrors the init branch of main.cpp's command loop,
+// including the debug breadcrumbs, which are what make a hung auth diagnosable.
+static void handle_init(const std::string &line)
+{
+    std::string jwt = json_str(line, "jwt");
+    const std::string public_app_key = json_str(line, "public_app_key");
+    EngineIpc::write(R"({"cmd":"debug","stage":"init_received"})");
+
+    ZoomSDK *sdk = [ZoomSDK sharedSDK];
+
+    ZoomSDKInitParams *params = [[ZoomSDKInitParams alloc] init];
+    params.needCustomizedUI = YES;   // headless helper: never show Zoom's own UI
+    params.enableLog = YES;
+    params.zoomDomain = @"https://zoom.us";
+
+    // Raw-data memory mode is configured on the ZoomSDK singleton, NOT on
+    // ZoomSDKInitParams (unlike Windows, where it lives in InitParam.rawdataOpts).
+    // Heap mode matches the Windows engine's ZoomSDKRawDataMemoryModeHeap so the
+    // SHM writer sees the same buffer lifetime rules once raw media lands.
+    sdk.videoRawDataMode = ZoomSDKRawDataMemoryMode_Heap;
+    sdk.shareRawDataMode = ZoomSDKRawDataMemoryMode_Heap;
+    sdk.audioRawDataMode = ZoomSDKRawDataMemoryMode_Heap;
+
+    EngineIpc::write(R"({"cmd":"debug","stage":"before_init_sdk"})");
+    ZoomSDKError err = [sdk initSDKWithParams:params];
+    EngineIpc::write(R"({"cmd":"debug","stage":"after_init_sdk","code":)" +
+                     std::to_string(static_cast<int>(err)) + "}");
+    if (err != ZoomSDKError_Success) {
+        EngineIpc::write(R"({"cmd":"auth_fail","stage":"init","code":)" +
+                         std::to_string(static_cast<int>(err)) +
+                         R"(,"name":"AUTHRET_UNKNOWN","auth_mode":")" +
+                         json_escape(public_app_key.empty() ? "jwt"
+                                                            : "public_app_key") +
+                         "\"}");
+        return;
+    }
+
+    EngineIpc::write(R"({"cmd":"debug","stage":"before_create_auth"})");
+    ZoomSDKAuthService *auth_svc = [sdk getAuthService];
+    if (!auth_svc) {
+        EngineIpc::write(R"({"cmd":"auth_fail","stage":"create_auth","code":0,)"
+                         R"("name":"AUTHRET_UNKNOWN","auth_mode":")" +
+                         json_escape(public_app_key.empty() ? "jwt"
+                                                            : "public_app_key") +
+                         "\"}");
+        return;
+    }
+
+    // The delegate is an assign (unowned) property, so this object must outlive
+    // the service; it is intentionally a never-released global.
+    if (!g_auth_delegate) g_auth_delegate = [[CVAuthDelegate alloc] init];
+    auth_svc.delegate = g_auth_delegate;
+
+    ZoomSDKAuthContext *ctx = [[ZoomSDKAuthContext alloc] init];
+    if (!public_app_key.empty()) {
+        // public_app_key and jwt are mutually exclusive; sending both lets the
+        // SDK pick, which makes failures impossible to attribute.
+        jwt.clear();
+        ctx.publicAppKey = [NSString stringWithUTF8String:public_app_key.c_str()];
+        ctx.jwtToken = nil;
+        g_current_auth_mode = "public_app_key";
+    } else {
+        ctx.jwtToken = [NSString stringWithUTF8String:jwt.c_str()];
+        ctx.publicAppKey = nil;
+        g_current_auth_mode = "jwt";
+    }
+
+    EngineIpc::write(
+        R"({"cmd":"debug","stage":"before_sdk_auth","auth_mode":")" +
+        std::string(public_app_key.empty() ? "jwt" : "public_app_key") +
+        R"(","jwt_present":)" + std::string(jwt.empty() ? "false" : "true") +
+        R"(,"public_app_key_present":)" +
+        std::string(public_app_key.empty() ? "false" : "true") +
+        R"(,"public_app_key_tail":")" +
+        json_escape(redacted_tail(public_app_key)) + "\"" + "}");
+
+    err = [auth_svc sdkAuth:ctx];
+    EngineIpc::write(R"({"cmd":"debug","stage":"after_sdk_auth","code":)" +
+                     std::to_string(static_cast<int>(err)) + "}");
+    if (err != ZoomSDKError_Success) {
+        // Synchronous rejection: onZoomSDKAuthReturn will never fire, so report
+        // here or the plugin would wait on a callback that is not coming.
+        EngineIpc::write(R"({"cmd":"auth_fail","stage":"sdk_auth","code":)" +
+                         std::to_string(static_cast<int>(err)) +
+                         R"(,"name":")" + auth_result_name(ZoomSDKAuthError_Unknown) +
+                         R"(","auth_mode":")" + json_escape(g_current_auth_mode) +
+                         "\"}");
+    }
+}
+
+// Anything not yet ported fails loudly and never silently pretends.
+static void handle_unimplemented(const char *stage)
+{
+    EngineIpc::write(
+        std::string(R"({"cmd":"error","msg":"macos_engine_unimplemented",)"
+                    R"("stage":")") + stage + R"(",)"
+        R"("reason":"This macOS ZoomObsEngine path is not implemented yet. )"
+        R"(SDK init and authentication are ported; join, roster and raw media )"
+        R"(are still in progress. See the CoreVideo macOS port PR."})");
+}
 
 // ── POSIX IPC setup (mirrors engine/src/main.cpp's POSIX branch) ─────────────
 static int unix_listen(const char *path)
@@ -92,18 +316,6 @@ static void ipc_teardown(IpcFd p2e, IpcFd e2p)
     unlink(SOCK_E2P);
 }
 
-// Reference a real Objective-C class from ZoomSDK.framework so this binary is
-// genuinely linked against the framework (forces resolution of the ObjC class
-// symbol) and the framework's headers are exercised at compile time. This does
-// NOT initialize the SDK, join a meeting, or start any Zoom activity.
-static void link_check_zoom_framework(void)
-{
-    @autoreleasepool {
-        ZoomSDKInitParams *params = [[ZoomSDKInitParams alloc] init];
-        (void)params;
-    }
-}
-
 int main()
 {
     IpcFd p2e = kIpcInvalidFd;
@@ -113,37 +325,50 @@ int main()
     EngineIpc::init(e2p); // must be called before any writes
 
     EngineIpc::write(R"({"cmd":"ready"})");
-    link_check_zoom_framework();
 
-    std::string line;
-    while (ipc_read_line(p2e, line)) {
-        if (line.empty())
-            continue;
+    // The IPC read loop must NOT run on the main thread: the main thread has to
+    // stay in the Cocoa run loop so the SDK's delegate callbacks can be
+    // delivered. Reading here and dispatching SDK work to the main queue is what
+    // makes asynchronous auth possible at all.
+    std::thread reader([p2e, e2p]() {
+        std::string line;
+        while (ipc_read_line(p2e, line)) {
+            if (line.empty())
+                continue;
 
-        if (line.find(IPC_CMD_QUIT) != std::string::npos)
-            break;
+            if (line.find(IPC_CMD_QUIT) != std::string::npos)
+                break;
 
-        // Any real Zoom operation is unimplemented on macOS. Fail loudly with an
-        // actionable message and a non-zero exit code so the plugin surfaces it
-        // (ZoomEngineClient maps exit code 3 to RecoveryReason::SdkError) rather
-        // than spinning as if a meeting were about to start.
-        if (line.find(IPC_CMD_INIT) != std::string::npos ||
-            line.find(IPC_CMD_JOIN) != std::string::npos) {
-            EngineIpc::write(
-                R"({"cmd":"auth_fail","stage":"macos_engine_unimplemented",)"
-                R"("code":3,"name":"MACOS_ENGINE_NOT_IMPLEMENTED",)"
-                R"("auth_mode":"unknown"})");
-            EngineIpc::write(
-                R"({"cmd":"error","msg":"macos_engine_unimplemented",)"
-                R"("reason":"The macOS ZoomObsEngine is not yet implemented. The )"
-                R"(macOS Zoom Meeting SDK is Objective-C only and requires an )"
-                R"(Objective-C++ rewrite of the engine; see the CoreVideo macOS )"
-                R"(port PR for the tracked gap."})");
-            ipc_teardown(p2e, e2p);
-            return 3; // SdkError — plugin treats this as a permanent SDK failure
+            // Copy for the block: `line` is reused by the next read.
+            const std::string msg = line;
+            if (msg.find(IPC_CMD_INIT) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(), ^{ handle_init(msg); });
+            } else if (msg.find(IPC_CMD_JOIN) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(),
+                               ^{ handle_unimplemented("join"); });
+            }
         }
-    }
 
-    ipc_teardown(p2e, e2p);
+        // Peer closed the socket or sent quit: unwind from the main thread,
+        // which owns the run loop.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ipc_teardown(p2e, e2p);
+            [[ZoomSDK sharedSDK] unInitSDK];
+            exit(0);
+        });
+    });
+    reader.detach();
+
+    // Hand the main thread to Cocoa. Delegate callbacks are delivered from here;
+    // the reader thread's final dispatch_async is what ends the process.
+    //
+    // A bare [[NSRunLoop currentRunLoop] run] is NOT sufficient: the SDK is an
+    // AppKit client (its own sample is built on NSApplicationMain), so an
+    // NSApplication instance must exist. Accessory activation policy keeps this
+    // helper out of the Dock and gives it no menu bar, which is what we want for
+    // a process OBS launches in the background.
+    [NSApplication sharedApplication];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    [NSApp run];
     return 0;
 }

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -242,7 +242,13 @@ static void handle_init(const std::string &line)
     ZoomSDK *sdk = [ZoomSDK sharedSDK];
 
     ZoomSDKInitParams *params = [[ZoomSDKInitParams alloc] init];
-    params.needCustomizedUI = YES;   // headless helper: never show Zoom's own UI
+    // Match the Windows engine, which leaves InitParam's customized-UI flag at
+    // its default and therefore runs with the SDK's own UI available. An earlier
+    // revision of this file forced customized UI on "headless helper" grounds;
+    // that was a macOS-only divergence with no counterpart on Windows, and it
+    // removed the operator's only view of what the engine is actually sending
+    // back into the meeting.
+    params.needCustomizedUI = NO;
     params.enableLog = YES;
     params.zoomDomain = @"https://zoom.us";
 
@@ -479,6 +485,85 @@ static void send_roster()
     EngineIpc::write(msg);
 }
 
+// ── Return video (OBS program back into the meeting) ─────────────────────────
+// The return feed is not something the engine renders: OBS's own Virtual Camera
+// publishes the program feed as a system capture device, and the engine's
+// participant simply uses it as its camera. That is how the Windows build does
+// it too — engine/src/main.cpp has no camera code at all, it joins with
+// isVideoOff=false and lets the SDK take the system default device.
+//
+// Relying on "the system default" is the part that does not survive a move to
+// macOS: the default here is whatever camera macOS feels like (FaceTime HD on
+// this machine), so the engine would helpfully send a webcam shot of the
+// operator's room into the meeting instead of the program feed. So pick the
+// device explicitly by name, and say plainly which one was chosen.
+static void start_return_video(ZoomSDKMeetingActionController *ctrl)
+{
+    ZoomSDKSettingService *settings = [[ZoomSDK sharedSDK] getSettingService];
+    ZoomSDKVideoSetting *video = settings ? [settings getVideoSetting] : nil;
+    if (!video) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"return_video_unavailable","reason":"no_video_setting"})");
+        return;
+    }
+
+    NSArray *cameras = [video getCameraList];
+    std::string names;
+    NSString *chosen_id = nil;
+    NSString *chosen_name = nil;
+    for (SDKDeviceInfo *dev in cameras) {
+        const std::string name = to_utf8([dev getDeviceName]);
+        if (!names.empty()) names += ", ";
+        names += name;
+        // Match OBS's virtual camera by name. Substring rather than equality so
+        // an OBS version that renames it slightly still matches.
+        if (!chosen_id && name.find("OBS Virtual Camera") != std::string::npos) {
+            chosen_id = [dev getDeviceID];
+            chosen_name = [dev getDeviceName];
+        }
+    }
+    EngineIpc::write(R"({"cmd":"debug","stage":"camera_list","cameras":")" +
+                     json_escape(names) + R"(","count":)" +
+                     std::to_string(cameras.count) + "}");
+
+    if (!chosen_id) {
+        // Loud, and specific about the fix: the operator has to start the
+        // virtual camera in OBS before the device exists at all.
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"return_video_unavailable",)"
+            R"("reason":"obs_virtual_camera_not_found","detail":"No OBS Virtual )"
+            R"(Camera device is present, so the program feed cannot be returned )"
+            R"(to the meeting. Start the Virtual Camera in OBS (Controls -> Start )"
+            R"(Virtual Camera), then rejoin.","cameras":")" +
+            json_escape(names) + "\"}");
+        return;
+    }
+
+    const ZoomSDKError sel = [video selectCamera:chosen_id];
+    EngineIpc::write(R"({"cmd":"debug","stage":"select_camera","name":")" +
+                     json_escape(to_utf8(chosen_name)) + R"(","code":)" +
+                     std::to_string(static_cast<int>(sel)) + "}");
+    if (sel != ZoomSDKError_Success) {
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"return_video_unavailable","reason":"select_camera_failed","code":)" +
+            std::to_string(static_cast<int>(sel)) + "}");
+        return;
+    }
+
+    ZoomSDKUserInfo *me = ctrl ? [ctrl getMyself] : nil;
+    if (!me) {
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"return_video_unavailable","reason":"no_self_user"})");
+        return;
+    }
+    const ZoomSDKError unmute = [ctrl actionMeetingWithCmd:ActionMeetingCmd_UnMuteVideo
+                                                   userID:[me getUserID]
+                                                 onScreen:ScreenType_First];
+    EngineIpc::write(R"({"cmd":"debug","stage":"return_video_started","camera":")" +
+                     json_escape(to_utf8(chosen_name)) + R"(","code":)" +
+                     std::to_string(static_cast<int>(unmute)) + "}");
+}
+
 // ── Meeting + roster delegate ────────────────────────────────────────────────
 // Reproduces onMeetingStatusChanged / the participants-controller callbacks from
 // engine/src/main.cpp. Every method of ZoomSDKMeetingActionControllerDelegate is
@@ -515,6 +600,7 @@ static void send_roster()
         ctrl.delegate = self;
         rebuild_roster();
         send_roster();
+        start_return_video(ctrl);
         break;
     }
     case ZoomSDKMeetingStatus_Disconnecting:
@@ -1703,11 +1789,14 @@ int main()
     //
     // A bare [[NSRunLoop currentRunLoop] run] is NOT sufficient: the SDK is an
     // AppKit client (its own sample is built on NSApplicationMain), so an
-    // NSApplication instance must exist. Accessory activation policy keeps this
-    // helper out of the Dock and gives it no menu bar, which is what we want for
-    // a process OBS launches in the background.
+    // NSApplication instance must exist.
+    //
+    // Regular activation policy, not Accessory: the SDK's meeting UI is enabled
+    // (matching Windows), and an Accessory app has no menu bar and cannot make
+    // its windows properly key — the meeting window would appear but behave
+    // badly. The cost is a Dock icon for the engine while it runs.
     [NSApplication sharedApplication];
-    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
     [NSApp run];
     return 0;
 }

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -485,85 +485,6 @@ static void send_roster()
     EngineIpc::write(msg);
 }
 
-// ── Return video (OBS program back into the meeting) ─────────────────────────
-// The return feed is not something the engine renders: OBS's own Virtual Camera
-// publishes the program feed as a system capture device, and the engine's
-// participant simply uses it as its camera. That is how the Windows build does
-// it too — engine/src/main.cpp has no camera code at all, it joins with
-// isVideoOff=false and lets the SDK take the system default device.
-//
-// Relying on "the system default" is the part that does not survive a move to
-// macOS: the default here is whatever camera macOS feels like (FaceTime HD on
-// this machine), so the engine would helpfully send a webcam shot of the
-// operator's room into the meeting instead of the program feed. So pick the
-// device explicitly by name, and say plainly which one was chosen.
-static void start_return_video(ZoomSDKMeetingActionController *ctrl)
-{
-    ZoomSDKSettingService *settings = [[ZoomSDK sharedSDK] getSettingService];
-    ZoomSDKVideoSetting *video = settings ? [settings getVideoSetting] : nil;
-    if (!video) {
-        EngineIpc::write(
-            R"({"cmd":"debug","stage":"return_video_unavailable","reason":"no_video_setting"})");
-        return;
-    }
-
-    NSArray *cameras = [video getCameraList];
-    std::string names;
-    NSString *chosen_id = nil;
-    NSString *chosen_name = nil;
-    for (SDKDeviceInfo *dev in cameras) {
-        const std::string name = to_utf8([dev getDeviceName]);
-        if (!names.empty()) names += ", ";
-        names += name;
-        // Match OBS's virtual camera by name. Substring rather than equality so
-        // an OBS version that renames it slightly still matches.
-        if (!chosen_id && name.find("OBS Virtual Camera") != std::string::npos) {
-            chosen_id = [dev getDeviceID];
-            chosen_name = [dev getDeviceName];
-        }
-    }
-    EngineIpc::write(R"({"cmd":"debug","stage":"camera_list","cameras":")" +
-                     json_escape(names) + R"(","count":)" +
-                     std::to_string(cameras.count) + "}");
-
-    if (!chosen_id) {
-        // Loud, and specific about the fix: the operator has to start the
-        // virtual camera in OBS before the device exists at all.
-        EngineIpc::write(
-            R"({"cmd":"error","msg":"return_video_unavailable",)"
-            R"("reason":"obs_virtual_camera_not_found","detail":"No OBS Virtual )"
-            R"(Camera device is present, so the program feed cannot be returned )"
-            R"(to the meeting. Start the Virtual Camera in OBS (Controls -> Start )"
-            R"(Virtual Camera), then rejoin.","cameras":")" +
-            json_escape(names) + "\"}");
-        return;
-    }
-
-    const ZoomSDKError sel = [video selectCamera:chosen_id];
-    EngineIpc::write(R"({"cmd":"debug","stage":"select_camera","name":")" +
-                     json_escape(to_utf8(chosen_name)) + R"(","code":)" +
-                     std::to_string(static_cast<int>(sel)) + "}");
-    if (sel != ZoomSDKError_Success) {
-        EngineIpc::write(
-            R"({"cmd":"error","msg":"return_video_unavailable","reason":"select_camera_failed","code":)" +
-            std::to_string(static_cast<int>(sel)) + "}");
-        return;
-    }
-
-    ZoomSDKUserInfo *me = ctrl ? [ctrl getMyself] : nil;
-    if (!me) {
-        EngineIpc::write(
-            R"({"cmd":"error","msg":"return_video_unavailable","reason":"no_self_user"})");
-        return;
-    }
-    const ZoomSDKError unmute = [ctrl actionMeetingWithCmd:ActionMeetingCmd_UnMuteVideo
-                                                   userID:[me getUserID]
-                                                 onScreen:ScreenType_First];
-    EngineIpc::write(R"({"cmd":"debug","stage":"return_video_started","camera":")" +
-                     json_escape(to_utf8(chosen_name)) + R"(","code":)" +
-                     std::to_string(static_cast<int>(unmute)) + "}");
-}
-
 // ── Meeting + roster delegate ────────────────────────────────────────────────
 // Reproduces onMeetingStatusChanged / the participants-controller callbacks from
 // engine/src/main.cpp. Every method of ZoomSDKMeetingActionControllerDelegate is
@@ -600,7 +521,6 @@ static void start_return_video(ZoomSDKMeetingActionController *ctrl)
         ctrl.delegate = self;
         rebuild_roster();
         send_roster();
-        start_return_video(ctrl);
         break;
     }
     case ZoomSDKMeetingStatus_Disconnecting:

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -76,8 +76,11 @@
 #include <vector>
 
 // Defined with the raw-media code further down; the meeting delegate has to
-// release renderers and SHM regions when the meeting ends.
+// release renderers and SHM regions when the meeting ends, and attach the
+// screen-share controller once the meeting is up.
 static void handle_stop_media(const char *reason);
+static void share_attach();
+static void share_teardown();
 
 // Set false during teardown so the heartbeat thread stops before the IPC
 // sockets close. File scope because the heartbeat thread is detached and
@@ -399,6 +402,11 @@ struct ParticipantInfo {
 static std::vector<ParticipantInfo> g_roster;
 static uint32_t g_active_speaker = 0;
 
+// Who is currently screen sharing, or 0. Written by the share delegate (main
+// queue) and read by user_to_info, which also runs there; atomic because the
+// share renderer's frame callback reads it from an SDK thread.
+static std::atomic<uint32_t> g_active_share_user{0};
+
 static ZoomSDKMeetingService *meeting_service()
 {
     return [[ZoomSDK sharedSDK] getMeetingService];
@@ -433,11 +441,8 @@ static ParticipantInfo user_to_info(ZoomSDKUserInfo *u)
                      audio == ZoomSDKAudioStatus_MutedByHost ||
                      audio == ZoomSDKAudioStatus_MutedAllByHost);
 
-    // Screen share is not ported yet. Reporting false is the honest answer for
-    // an unimplemented path; it is NOT a guess that nobody is sharing. When the
-    // share controller lands, set this from the active share user id the way
-    // main.cpp does.
-    info.is_sharing_screen = false;
+    info.is_sharing_screen =
+        info.user_id == g_active_share_user.load(std::memory_order_acquire);
     return info;
 }
 
@@ -519,6 +524,7 @@ static void send_roster()
             break;
         }
         ctrl.delegate = self;
+        share_attach();
         rebuild_roster();
         send_roster();
         break;
@@ -871,17 +877,75 @@ static ZoomSDKResolution sdk_resolution(uint32_t resolution)
     }
 }
 
-// Mirrors valid_i420_frame() in engine-video.cpp: reject anything whose Y plane
-// length we would compute wrongly, rather than memcpy'ing a bad size.
-static bool valid_i420_frame(ZoomSDKYUVRawDataI420 *data, uint32_t w, uint32_t h,
+// Validate a frame and CROP it to even dimensions, reporting the cropped size
+// through w/h.
+//
+// The SHM payload is laid out as y_len + y_len/4 + y_len/4, which only describes
+// an I420 frame whose width and height are both even — for odd dimensions the
+// real chroma planes are ceil(w/2) x ceil(h/2), which is larger than y_len/4.
+// engine-video.cpp and engine-share.cpp handle that by REJECTING odd frames.
+// That is fine for camera video, which is always even, and quietly fatal for
+// screen share: a shared window is whatever size the window happens to be, and
+// on macOS that is routinely odd (observed 1728x1117), so every single share
+// frame was discarded as invalid and the source stayed black.
+//
+// Cropping one row/column is imperceptible and keeps the wire format and the
+// plugin's reader exactly as they are, so that is what we do instead. The
+// caller must keep the ORIGINAL width for stride arithmetic — see
+// copy_i420_even.
+static bool valid_i420_frame(ZoomSDKYUVRawDataI420 *data, uint32_t &w, uint32_t &h,
                              size_t &y_len)
 {
     if (w == 0 || h == 0) return false;
     if (w > 8192 || h > 8192) return false;
-    if ((w & 1) != 0 || (h & 1) != 0) return false;
     if (![data getYBuffer] || ![data getUBuffer] || ![data getVBuffer]) return false;
+
+    w &= ~1u;
+    h &= ~1u;
+    if (w == 0 || h == 0) return false;
+
     y_len = static_cast<size_t>(w) * static_cast<size_t>(h);
     return true;
+}
+
+// Copy an I420 frame into the SHM payload, cropping to the even dimensions
+// valid_i420_frame settled on. `src_w` is the frame's real width, which sets the
+// source strides: the macOS SDK exposes no stride accessors on
+// ZoomSDKYUVRawDataI420, so planes are assumed tightly packed at w and
+// ceil(w/2). When nothing was cropped this degenerates to the same three plain
+// memcpys the Windows engine does.
+static void copy_i420_even(char *dst, ZoomSDKYUVRawDataI420 *data,
+                           uint32_t w, uint32_t h, uint32_t src_w)
+{
+    const char *sy = [data getYBuffer];
+    const char *su = [data getUBuffer];
+    const char *sv = [data getVBuffer];
+    const size_t y_len = static_cast<size_t>(w) * static_cast<size_t>(h);
+
+    if (w == src_w) {
+        std::memcpy(dst, sy, y_len);
+    } else {
+        for (uint32_t r = 0; r < h; ++r)
+            std::memcpy(dst + static_cast<size_t>(r) * w,
+                        sy + static_cast<size_t>(r) * src_w, w);
+    }
+
+    const uint32_t src_cstride = (src_w + 1) / 2;
+    const uint32_t cw = w / 2;
+    const uint32_t ch = h / 2;
+    char *du = dst + y_len;
+    char *dv = du + static_cast<size_t>(cw) * ch;
+    if (cw == src_cstride) {
+        std::memcpy(du, su, static_cast<size_t>(cw) * ch);
+        std::memcpy(dv, sv, static_cast<size_t>(cw) * ch);
+    } else {
+        for (uint32_t r = 0; r < ch; ++r) {
+            std::memcpy(du + static_cast<size_t>(r) * cw,
+                        su + static_cast<size_t>(r) * src_cstride, cw);
+            std::memcpy(dv + static_cast<size_t>(r) * cw,
+                        sv + static_cast<size_t>(r) * src_cstride, cw);
+        }
+    }
 }
 
 static bool video_ensure_shm(VideoTarget &target, const std::string &source_uuid,
@@ -900,18 +964,25 @@ static bool video_ensure_shm(VideoTarget &target, const std::string &source_uuid
 static void video_on_frame(uint32_t participant_id, ZoomSDKYUVRawDataI420 *data)
 {
     if (!data) return;
-    const uint32_t w = [data getStreamWidth];
-    const uint32_t h = [data getStreamHeight];
+    const uint32_t src_w = [data getStreamWidth];
+    const uint32_t src_h = [data getStreamHeight];
+    uint32_t w = src_w, h = src_h;
     size_t y_len = 0;
     if (!valid_i420_frame(data, w, h, y_len)) {
         EngineIpc::write(
             R"({"cmd":"debug","stage":"video_frame_invalid","participant_id":)" +
-            std::to_string(participant_id) + R"(,"w":)" + std::to_string(w) +
-            R"(,"h":)" + std::to_string(h) + "}");
+            std::to_string(participant_id) + R"(,"w":)" + std::to_string(src_w) +
+            R"(,"h":)" + std::to_string(src_h) + "}");
         return;
     }
 
-    std::lock_guard<std::mutex> lock(g_video_mtx);
+    // try_lock, never block: this runs on an SDK raw-data thread, and the SDK
+    // may wait for in-flight callbacks inside unSubscribe/destroyRender — which
+    // the main thread calls while holding g_video_mtx. Blocking here would
+    // recreate the renderer-teardown deadlock as an ABBA variant. Losing one
+    // frame under contention is invisible at 25–30 fps.
+    std::unique_lock<std::mutex> lock(g_video_mtx, std::try_to_lock);
+    if (!lock.owns_lock()) return;
     auto sub = g_video.find(participant_id);
     if (sub == g_video.end()) return;
 
@@ -953,13 +1024,18 @@ static void video_on_frame(uint32_t participant_id, ZoomSDKYUVRawDataI420 *data)
         hdr->height = h;
         hdr->y_len  = static_cast<uint32_t>(y_len);
 
-        std::memcpy(pixels,                     [data getYBuffer], y_len);
-        std::memcpy(pixels + y_len,             [data getUBuffer], y_len / 4);
-        std::memcpy(pixels + y_len + y_len / 4, [data getVBuffer], y_len / 4);
+        copy_i420_even(pixels, data, w, h, src_w);
         std::atomic_thread_fence(std::memory_order_release);
         hdr->sequence = seq + 1;
 
         ++target.frame_count;
+        if (target.frame_count == 1 && (w != src_w || h != src_h)) {
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"video_frame_cropped_to_even","source_uuid":")" +
+                source_uuid + R"(","src_w":)" + std::to_string(src_w) +
+                R"(,"src_h":)" + std::to_string(src_h) + R"(,"w":)" +
+                std::to_string(w) + R"(,"h":)" + std::to_string(h) + "}");
+        }
         if (target.frame_count == 1 || target.frame_count % 120 == 0) {
             EngineIpc::write(
                 R"({"cmd":"debug","stage":"video_frame_received","source_uuid":")" +
@@ -983,6 +1059,13 @@ static void video_teardown_locked(uint32_t participant_id)
     auto it = g_video.find(participant_id);
     if (it == g_video.end()) return;
     if (it->second.renderer) {
+        // Detach the delegate FIRST: destroyRender invokes
+        // onRendererBeDestroyed synchronously on this thread, and that
+        // callback locks g_video_mtx — which the caller already holds.
+        // Verified live: this exact cycle deadlocked the main thread
+        // (sample: video_teardown_locked → ZoomSDK → onRendererBeDestroyed
+        // → mutex::lock), freezing the SDK UI and all video for hours.
+        it->second.renderer.delegate = nil;
         [it->second.renderer unSubscribe];
         ZoomSDKRawDataController *rdc = raw_data_controller();
         if (rdc) [rdc destroyRender:it->second.renderer];
@@ -1137,6 +1220,414 @@ static void video_unsubscribe(const std::string &source_uuid)
         sub->second.targets.erase(t);
     }
     if (sub->second.targets.empty()) video_teardown_locked(participant_id);
+}
+
+// ── Raw screen share ─────────────────────────────────────────────────────────
+// Share differs from participant video in one structural way: there is a single
+// renderer for whatever share is currently viewable, not one per source. The
+// share source id is chosen by the SDK and changes whenever someone starts,
+// stops, or switches what they are sharing, so the renderer is torn down and
+// rebuilt on those transitions while the SHM targets (one per OBS source bound
+// in screenshare mode) persist across them.
+struct ShareTarget {
+    ShmRegion shm;
+    uint64_t  frame_count = 0;
+    uint32_t  shm_gen = 0;
+    bool      shm_fail_reported = false;
+};
+
+static std::mutex g_share_mtx;
+static std::unordered_map<std::string, ShareTarget> g_share_targets;
+static ZoomSDKRenderer *g_share_renderer = nil;
+static id g_share_renderer_delegate = nil;
+static uint32_t g_share_source_id = 0;
+
+static ZoomSDKASController *as_controller()
+{
+    ZoomSDKMeetingService *svc = meeting_service();
+    return svc ? [svc getASController] : nil;
+}
+
+static void share_on_frame(ZoomSDKYUVRawDataI420 *data);
+
+@interface CVShareRenderer : NSObject <ZoomSDKRendererDelegate>
+@end
+
+@implementation CVShareRenderer
+
+- (void)onRawDataReceived:(ZoomSDKYUVRawDataI420 *)data { share_on_frame(data); }
+
+- (void)onSubscribedUserDataOn
+{
+    EngineIpc::write(R"({"cmd":"debug","stage":"share_raw_status","status":1})");
+}
+
+- (void)onSubscribedUserDataOff
+{
+    EngineIpc::write(R"({"cmd":"debug","stage":"share_raw_status","status":0})");
+}
+
+- (void)onSubscribedUserLeft {}
+
+- (void)onRendererBeDestroyed
+{
+    std::lock_guard<std::mutex> lock(g_share_mtx);
+    g_share_renderer = nil;
+    g_share_source_id = 0;
+}
+
+@end
+
+static bool share_ensure_shm(ShareTarget &target, const std::string &source_uuid,
+                             size_t y_len)
+{
+    const size_t total = sizeof(ShmFrameHeader) + y_len + y_len / 4 + y_len / 4;
+    if (total < y_len) return false;
+    if (target.shm.ptr && target.shm.size >= total) return true;
+
+    const std::string region_name = IPC_SHM_PREFIX + source_uuid;
+    if (!shm_region_create(target.shm, region_name, total)) return false;
+    ++target.shm_gen;
+    return true;
+}
+
+static void share_on_frame(ZoomSDKYUVRawDataI420 *data)
+{
+    if (!data) return;
+    const uint32_t src_w = [data getStreamWidth];
+    const uint32_t src_h = [data getStreamHeight];
+    uint32_t w = src_w, h = src_h;
+    size_t y_len = 0;
+    if (!valid_i420_frame(data, w, h, y_len)) {
+        EngineIpc::write(R"({"cmd":"debug","stage":"share_frame_invalid","w":)" +
+                         std::to_string(src_w) + R"(,"h":)" +
+                         std::to_string(src_h) + "}");
+        return;
+    }
+
+    // The plugin keys share frames by the SHARING participant, matching the
+    // Windows engine, so an operator sees the share attributed to a person.
+    const uint32_t share_user_id = g_active_share_user.load(std::memory_order_acquire);
+
+    // try_lock for the same reason as video_on_frame: never block an SDK
+    // callback thread on a mutex the main thread holds across SDK teardown
+    // calls. A dropped share frame at 1-30 fps is repainted by the next one.
+    std::unique_lock<std::mutex> lock(g_share_mtx, std::try_to_lock);
+    if (!lock.owns_lock()) return;
+    for (auto &entry : g_share_targets) {
+        const std::string &source_uuid = entry.first;
+        ShareTarget &target = entry.second;
+
+        if (!share_ensure_shm(target, source_uuid, y_len) || !target.shm.ptr) {
+            if (!target.shm_fail_reported) {
+                target.shm_fail_reported = true;
+                EngineIpc::write(
+                    R"({"cmd":"debug","stage":"share_shm_create_failed","source_uuid":")" +
+                    source_uuid + R"(","w":)" + std::to_string(w) +
+                    R"(,"h":)" + std::to_string(h) + "}");
+                EngineIpc::write(
+                    R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
+                    source_uuid + R"(","w":)" + std::to_string(w) +
+                    R"(,"h":)" + std::to_string(h) + "}");
+            }
+            continue;
+        }
+        if (target.shm_fail_reported) {
+            target.shm_fail_reported = false;
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"share_shm_recovered","source_uuid":")" +
+                source_uuid + "\"}");
+        }
+
+        auto *hdr    = static_cast<ShmFrameHeader *>(target.shm.ptr);
+        auto *pixels = static_cast<char *>(target.shm.ptr) + sizeof(ShmFrameHeader);
+        const uint32_t seq = shm_seq_begin(hdr->sequence);
+        hdr->sequence = seq;
+        std::atomic_thread_fence(std::memory_order_release);
+        hdr->width  = w;
+        hdr->height = h;
+        hdr->y_len  = static_cast<uint32_t>(y_len);
+
+        copy_i420_even(pixels, data, w, h, src_w);
+        std::atomic_thread_fence(std::memory_order_release);
+        hdr->sequence = seq + 1;
+
+        ++target.frame_count;
+        if (target.frame_count == 1 && (w != src_w || h != src_h)) {
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"share_frame_cropped_to_even","source_uuid":")" +
+                source_uuid + R"(","src_w":)" + std::to_string(src_w) +
+                R"(,"src_h":)" + std::to_string(src_h) + R"(,"w":)" +
+                std::to_string(w) + R"(,"h":)" + std::to_string(h) + "}");
+        }
+        if (target.frame_count == 1 || target.frame_count % 120 == 0) {
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"share_frame_received","source_uuid":")" +
+                source_uuid + R"(","share_source_id":)" +
+                std::to_string(g_share_source_id) + R"(,"count":)" +
+                std::to_string(target.frame_count) + R"(,"w":)" + std::to_string(w) +
+                R"(,"h":)" + std::to_string(h) + "}");
+        }
+
+        EngineIpc::write(
+            R"({"cmd":"frame","source_uuid":")" + source_uuid +
+            R"(","participant_id":)" + std::to_string(share_user_id) +
+            R"(,"w":)" + std::to_string(w) + R"(,"h":)" + std::to_string(h) +
+            R"(,"shm_gen":)" + std::to_string(target.shm_gen) + "}");
+    }
+}
+
+// Caller must hold g_share_mtx.
+static void share_unsubscribe_renderer_locked()
+{
+    ZoomSDKRenderer *renderer = g_share_renderer;
+    g_share_renderer = nil;
+    g_share_source_id = 0;
+    if (!renderer) return;
+    // Same synchronous-callback deadlock as video_teardown_locked: detach the
+    // delegate before destroyRender or onRendererBeDestroyed relocks
+    // g_share_mtx on this thread.
+    renderer.delegate = nil;
+    [renderer unSubscribe];
+    ZoomSDKRawDataController *rdc = raw_data_controller();
+    if (rdc) [rdc destroyRender:renderer];
+    [g_share_renderer_delegate release];
+    g_share_renderer_delegate = nil;
+}
+
+// Caller must hold g_share_mtx.
+static bool share_subscribe_to_locked(uint32_t share_source_id, const char *reason)
+{
+    if (share_source_id == 0) return false;
+    if (g_share_renderer && g_share_source_id == share_source_id) return true;
+
+    share_unsubscribe_renderer_locked();
+
+    ZoomSDKRawDataController *rdc = raw_data_controller();
+    if (!rdc) return false;
+    ZoomSDKRenderer *renderer = nil;
+    const ZoomSDKError create_err = [rdc createRender:&renderer];
+    if (create_err != ZoomSDKError_Success || !renderer) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"share_create_renderer_failed","code":)" +
+            std::to_string(static_cast<int>(create_err)) +
+            R"(,"share_source_id":)" + std::to_string(share_source_id) + "}");
+        return false;
+    }
+
+    CVShareRenderer *delegate = [[CVShareRenderer alloc] init];
+    renderer.delegate = delegate;
+
+    const ZoomSDKError res_err = [renderer setResolution:ZoomSDKResolution_1080P];
+    EngineIpc::write(R"({"cmd":"debug","stage":"share_set_resolution","code":)" +
+                     std::to_string(static_cast<int>(res_err)) +
+                     R"(,"share_source_id":)" + std::to_string(share_source_id) + "}");
+
+    const ZoomSDKError err =
+        [renderer subscribe:share_source_id rawDataType:ZoomSDKRawDataType_Share];
+    EngineIpc::write(R"({"cmd":"debug","stage":"share_subscribe","code":)" +
+                     std::to_string(static_cast<int>(err)) +
+                     R"(,"share_source_id":)" + std::to_string(share_source_id) +
+                     R"(,"reason":")" + std::string(reason ? reason : "unknown") + "\"}");
+    if (err != ZoomSDKError_Success) {
+        renderer.delegate = nil;
+        [delegate release];
+        [rdc destroyRender:renderer];
+        return false;
+    }
+
+    g_share_renderer = renderer;
+    g_share_renderer_delegate = delegate;
+    g_share_source_id = share_source_id;
+    return true;
+}
+
+// Find whatever share is currently viewable and subscribe to it. Caller must
+// hold g_share_mtx.
+static void share_subscribe_active_locked(const char *reason)
+{
+    ZoomSDKASController *as = as_controller();
+    if (!as) {
+        EngineIpc::write(R"({"cmd":"debug","stage":"share_controller","code":-1})");
+        return;
+    }
+    NSArray<NSNumber *> *sharers = [as getViewableSharingUserList];
+    for (NSNumber *uid in sharers) {
+        const unsigned int user_id = uid.unsignedIntValue;
+        NSArray<ZoomSDKSharingSourceInfo *> *sources =
+            [as getSharingSourceInfoList:user_id];
+        for (ZoomSDKSharingSourceInfo *info in sources) {
+            if (info.shareSourceID == 0) continue;
+            g_active_share_user.store(user_id, std::memory_order_release);
+            share_subscribe_to_locked(info.shareSourceID, reason);
+            return;
+        }
+    }
+    // Nobody is sharing. Drop any renderer we still hold (mirrors the Windows
+    // engine's share_unavailable branch) — a subscription to a share that no
+    // longer exists is exactly the state that crashed the SDK in live testing.
+    share_unsubscribe_renderer_locked();
+    g_active_share_user.store(0, std::memory_order_release);
+    EngineIpc::write(R"({"cmd":"debug","stage":"share_none_active","reason":")" +
+                     std::string(reason ? reason : "unknown") + R"(","sharers":)" +
+                     std::to_string(sharers.count) + "}");
+}
+
+static void share_subscribe(const std::string &source_uuid)
+{
+    std::lock_guard<std::mutex> lock(g_share_mtx);
+    const bool present = g_share_targets.find(source_uuid) != g_share_targets.end();
+    if (shm_source_over_cap(g_share_targets.size(), present)) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"share_subscribe_rejected_capacity","source_uuid":")" +
+            source_uuid + R"(","limit":)" + std::to_string(kMaxShmSources) + "}");
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"subscribe_rejected","reason":"shm_capacity","source_uuid":")" +
+            source_uuid + R"(","limit":)" + std::to_string(kMaxShmSources) + "}");
+        return;
+    }
+    g_share_targets.emplace(source_uuid, ShareTarget{});
+    if (!g_raw_media_active) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"share_subscribe_deferred","source_uuid":")" +
+            source_uuid + "\"}");
+        return;
+    }
+    share_subscribe_active_locked("share_subscribe");
+}
+
+static void share_unsubscribe(const std::string &source_uuid)
+{
+    std::lock_guard<std::mutex> lock(g_share_mtx);
+    auto it = g_share_targets.find(source_uuid);
+    if (it == g_share_targets.end()) return;
+    shm_region_destroy(it->second.shm);
+    g_share_targets.erase(it);
+    // Last consumer gone: drop the Zoom subscription too rather than decoding a
+    // share nobody is showing.
+    if (g_share_targets.empty()) share_unsubscribe_renderer_locked();
+}
+
+static void share_teardown()
+{
+    std::lock_guard<std::mutex> lock(g_share_mtx);
+    share_unsubscribe_renderer_locked();
+    for (auto &entry : g_share_targets) shm_region_destroy(entry.second.shm);
+    g_share_targets.clear();
+    g_active_share_user.store(0, std::memory_order_release);
+}
+
+@interface CVShareDelegate : NSObject <ZoomSDKASControllerDelegate>
+@end
+
+// The SDK does not support raw-data subscriptions to the local user's own
+// share: a self share never appears in getViewableSharingUserList, delivers at
+// most one frame, and a renderer left bound to it after SelfEnd crashed the
+// SDK in live testing (engine killed by signal ~16s later). The Windows engine
+// is immune by construction — its Sharing_Self_* enum values fall through the
+// event switch — but on macOS onShareContentChanged fires for self shares with
+// the same signature as everyone else's, so filter by user id.
+static bool share_is_self(unsigned int user_id)
+{
+    ZoomSDKMeetingActionController *ctrl = action_controller();
+    ZoomSDKUserInfo *me = ctrl ? [ctrl getMyself] : nil;
+    return me && user_id != 0 && [me getUserID] == user_id;
+}
+
+@implementation CVShareDelegate
+
+- (void)onSharingStatusChanged:(ZoomSDKSharingSourceInfo *)shareInfo
+{
+    if (!shareInfo) return;
+    const bool self_share = share_is_self(shareInfo.userID);
+    EngineIpc::write(R"({"cmd":"debug","stage":"share_status","user_id":)" +
+                     std::to_string(shareInfo.userID) +
+                     R"(,"share_source_id":)" + std::to_string(shareInfo.shareSourceID) +
+                     R"(,"status":)" +
+                     std::to_string(static_cast<int>(shareInfo.status)) +
+                     R"(,"self":)" + (self_share ? "true" : "false") + "}");
+
+    // Scoped: rebuild_roster below calls back into the SDK (getUserList), and
+    // SDK calls must not run under g_share_mtx — the SDK's own callbacks take
+    // that mutex from its threads.
+    {
+    std::lock_guard<std::mutex> lock(g_share_mtx);
+    switch (shareInfo.status) {
+    case ZoomSDKShareStatus_OtherBegin:
+    case ZoomSDKShareStatus_ViewOther:
+    case ZoomSDKShareStatus_Resume:
+        if (self_share) break;
+        if (shareInfo.userID != 0)
+            g_active_share_user.store(shareInfo.userID, std::memory_order_release);
+        if (shareInfo.shareSourceID != 0)
+            share_subscribe_to_locked(shareInfo.shareSourceID, "share_status");
+        else
+            share_subscribe_active_locked("share_status");
+        break;
+    case ZoomSDKShareStatus_SelfEnd:
+        // Safety net only: we never subscribe to a self share, so tear down
+        // solely if a renderer is somehow bound to this exact source.
+        if (shareInfo.shareSourceID != 0 &&
+            shareInfo.shareSourceID == g_share_source_id) {
+            share_unsubscribe_renderer_locked();
+            share_subscribe_active_locked("self_share_end");
+        }
+        break;
+    case ZoomSDKShareStatus_OtherEnd:
+        if (shareInfo.shareSourceID == 0 ||
+            shareInfo.shareSourceID == g_share_source_id) {
+            share_unsubscribe_renderer_locked();
+            g_active_share_user.store(0, std::memory_order_release);
+            // Someone else may still be sharing — re-evaluate rather than
+            // assuming the meeting has no share left.
+            share_subscribe_active_locked("share_end");
+        }
+        break;
+    default:
+        break;
+    }
+    } // release g_share_mtx before touching the SDK again
+    rebuild_roster();
+    send_roster();
+}
+
+- (void)onShareContentChanged:(ZoomSDKSharingSourceInfo *)shareInfo
+{
+    if (!shareInfo) return;
+    const bool self_share = share_is_self(shareInfo.userID);
+    EngineIpc::write(
+        R"({"cmd":"debug","stage":"share_content_changed","user_id":)" +
+        std::to_string(shareInfo.userID) + R"(,"share_source_id":)" +
+        std::to_string(shareInfo.shareSourceID) +
+        R"(,"self":)" + (self_share ? "true" : "false") + "}");
+    if (self_share) return; // see share_is_self
+    std::lock_guard<std::mutex> lock(g_share_mtx);
+    if (shareInfo.userID != 0)
+        g_active_share_user.store(shareInfo.userID, std::memory_order_release);
+    if (shareInfo.shareSourceID != 0)
+        share_subscribe_to_locked(shareInfo.shareSourceID, "share_content_changed");
+}
+
+- (void)onFailedToStartShare
+{
+    EngineIpc::write(R"({"cmd":"debug","stage":"share_failed_to_start"})");
+}
+
+@end
+
+static CVShareDelegate *g_share_delegate = nil;
+
+static void share_attach()
+{
+    ZoomSDKASController *as = as_controller();
+    if (!as) {
+        EngineIpc::write(R"({"cmd":"debug","stage":"share_controller","code":-1})");
+        return;
+    }
+    if (!g_share_delegate) g_share_delegate = [[CVShareDelegate alloc] init];
+    as.delegate = g_share_delegate;
+    std::lock_guard<std::mutex> lock(g_share_mtx);
+    if (g_raw_media_active) share_subscribe_active_locked("meeting_joined");
 }
 
 // ── Raw audio ────────────────────────────────────────────────────────────────
@@ -1362,6 +1853,14 @@ static void resubscribe_raw_media(const char *reason)
     }
     if (!audio_sources.empty())
         audio_subscribe_if_needed(audio_sources.front(), "audio_resubscribe");
+
+    // Share targets bound before raw media started are deferred the same way
+    // video subscriptions are; pick up whatever is being shared now.
+    {
+        std::lock_guard<std::mutex> lock(g_share_mtx);
+        if (!g_share_targets.empty())
+            share_subscribe_active_locked(reason);
+    }
 }
 
 // Guards the privilege-request retry loop: without it, a host who denies the
@@ -1510,6 +2009,7 @@ static void handle_stop_media(const char *reason)
         for (auto &entry : g_audio) shm_region_destroy(entry.second.shm);
         g_audio.clear();
     }
+    share_teardown();
     if (g_audio_subscribed) {
         ZoomSDKRawDataController *rdc = raw_data_controller();
         ZoomSDKAudioRawDataHelper *helper = nil;
@@ -1608,12 +2108,22 @@ int main()
     // cosmetic — zoom-engine-client.cpp declares the engine dead after 10s of
     // IPC silence, so the macOS engine was reported as "stopped responding"
     // after every idle stretch, including a perfectly healthy sit in a meeting.
+    // The ping is written from the MAIN QUEUE, not from this thread: every SDK
+    // delegate and every subscribe/teardown runs on the main thread, so a ping
+    // from a side thread vouches for an engine that may no longer be able to do
+    // any work. A renderer-teardown deadlock froze the main thread for hours
+    // while a detached-thread heartbeat kept the plugin convinced all was well.
+    // Routed through the main queue, a hung main thread silences the heartbeat
+    // and the plugin's 10 s watchdog kills and recovers the engine.
     std::thread heartbeat([]() {
         while (g_running.load(std::memory_order_acquire)) {
             for (int i = 0; i < 20 && g_running.load(std::memory_order_acquire); ++i)
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             if (!g_running.load(std::memory_order_acquire)) break;
-            if (!EngineIpc::write(R"({"cmd":"ping"})")) break;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (g_running.load(std::memory_order_acquire))
+                    EngineIpc::write(R"({"cmd":"ping"})");
+            });
         }
     });
     heartbeat.detach();
@@ -1665,7 +2175,11 @@ int main()
                 dispatch_async(dispatch_get_main_queue(), ^{
                     const std::string uuid = json_str(msg, "source_uuid");
                     if (!is_valid_source_uuid(uuid)) return;
+                    // The plugin does not say which kind the source was, so
+                    // clear it from all three paths; each is a no-op if the
+                    // source was never bound there.
                     video_unsubscribe(uuid);
+                    share_unsubscribe(uuid);
                     audio_remove(uuid);
                 });
             } else if (msg.find(IPC_CMD_SUBSCRIBE) != std::string::npos) {
@@ -1673,10 +2187,7 @@ int main()
                     const std::string uuid = json_str(msg, "source_uuid");
                     if (!is_valid_source_uuid(uuid)) return;
                     if (json_str(msg, "mode") == "screenshare") {
-                        // Screen share needs its own share-source subscription;
-                        // not ported yet, so say so rather than silently binding
-                        // it to a participant renderer that shows the wrong feed.
-                        handle_unimplemented("subscribe_screenshare");
+                        share_subscribe(uuid);
                         return;
                     }
                     uint32_t res = json_uint(msg, "resolution");

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -27,6 +27,27 @@
 // interleaved writes from the reader thread and the main thread stay
 // line-atomic.
 //
+// ── The SDK runtime must live in the app bundle (hard-won) ───────────────────
+// ZoomSDK.framework is not self-contained. At auth time the SDK loads a set of
+// sibling *bundles* (ssb_sdk, zNet, zPTUIEx, ZoomSDKChatUI, ...) and it finds
+// them through the MAIN BUNDLE's Frameworks directory — NOT through the linker's
+// rpath and NOT relative to ZoomSDK.framework's own location. Linking and
+// loading the framework therefore proves nothing about whether auth can work.
+//
+// When those bundles are missing the failure is silent and misleading:
+// initSDKWithParams still returns Success, getAuthService still returns a live
+// object, and then sdkAuth returns ZoomSDKError_Failed(1) *synchronously* with
+// no delegate callback ever firing — because the internal auth manager has no
+// web-service module to hand the request to. Disassembling -[ZoomSDKAuthService
+// sdkAuth:] confirms the auth context itself parses fine (an empty context
+// returns InvalidParameter(5), which we never saw); the Failed(1) comes from an
+// internal manager returning false before anything reaches the network.
+//
+// So the engine must ship as ZoomObsEngine.app with the SDK runtime in
+// Contents/Frameworks (see scripts/make-macos-bundle.sh). preflight_sdk_runtime
+// below turns that requirement into one explicit IPC error instead of a
+// synchronous auth failure with no explanation.
+//
 // ── Implemented so far ───────────────────────────────────────────────────────
 //   init  -> SDK init + sdkAuth, emitting auth_ok / auth_fail
 // Everything else (join, roster, raw media) still fails loudly over IPC rather
@@ -160,6 +181,24 @@ static std::string g_current_auth_mode = "jwt";
 
 static CVAuthDelegate *g_auth_delegate = nil;
 
+// ── SDK runtime preflight ────────────────────────────────────────────────────
+// See the header note: the SDK resolves its runtime bundles through the main
+// bundle's Frameworks directory, and their absence surfaces only as a
+// synchronous sdkAuth failure with no callback. Check it up front so the cause
+// is stated instead of inferred. Returns the directory it checked so the error
+// can name it.
+static bool preflight_sdk_runtime(std::string &frameworks_dir)
+{
+    NSString *frameworks = [[NSBundle mainBundle] privateFrameworksPath];
+    if (!frameworks) {
+        frameworks_dir = "(no main bundle: the engine is not running from a .app)";
+        return false;
+    }
+    frameworks_dir = frameworks.UTF8String ? frameworks.UTF8String : "";
+    NSString *sdk = [frameworks stringByAppendingPathComponent:@"ZoomSDK.framework"];
+    return [[NSFileManager defaultManager] fileExistsAtPath:sdk];
+}
+
 // ── init / auth ──────────────────────────────────────────────────────────────
 // Runs on the main queue. Mirrors the init branch of main.cpp's command loop,
 // including the debug breadcrumbs, which are what make a hung auth diagnosable.
@@ -168,6 +207,20 @@ static void handle_init(const std::string &line)
     std::string jwt = json_str(line, "jwt");
     const std::string public_app_key = json_str(line, "public_app_key");
     EngineIpc::write(R"({"cmd":"debug","stage":"init_received"})");
+
+    std::string frameworks_dir;
+    if (!preflight_sdk_runtime(frameworks_dir)) {
+        EngineIpc::write(
+            std::string(R"({"cmd":"auth_fail","stage":"sdk_runtime_missing","code":0,)"
+                        R"("name":"AUTHRET_UNKNOWN","auth_mode":")") +
+            json_escape(public_app_key.empty() ? "jwt" : "public_app_key") +
+            R"(","reason":"ZoomSDK.framework is not in the engine app's )"
+            R"(Frameworks directory. The macOS Zoom SDK loads its runtime )"
+            R"(bundles from there, so authentication cannot work without it. )"
+            R"(Rebuild the bundle with scripts/make-macos-bundle.sh. Looked in: )" +
+            json_escape(frameworks_dir) + "\"}");
+        return;
+    }
 
     ZoomSDK *sdk = [ZoomSDK sharedSDK];
 

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -63,9 +63,18 @@
 #include <sys/un.h>
 #include <poll.h>
 #include <unistd.h>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <thread>
+#include <vector>
+
+// Set false during teardown so the heartbeat thread stops before the IPC
+// sockets close. File scope because the heartbeat thread is detached and
+// outlives any narrower scope.
+static std::atomic<bool> g_running{true};
 
 // ── JSON helpers ─────────────────────────────────────────────────────────────
 // Deliberately identical to the ones in main.cpp so both engines parse the
@@ -304,6 +313,420 @@ static void handle_init(const std::string &line)
     }
 }
 
+// ── Meeting failure names ────────────────────────────────────────────────────
+// Keyed on the raw integer rather than the ObjC enum on purpose. The plugin
+// classifies join failures by NUMERIC CODE (zoom_join::classify_join_failure in
+// src/zoom-join-decision.h switches on 23/60/62/63/64/82/500..506), and those
+// numbers are identical in Windows' MeetingFailCode and macOS'
+// ZoomSDKMeetingError — only the spellings differ. So the code passes through
+// untouched and this table only supplies the human-readable name for operator
+// messages and support bundles, in the same MEETING_FAIL_* vocabulary the
+// Windows engine emits. Do NOT switch on the ObjC enum names here: that would
+// read as a translation and invite someone to "fix" the codes to match it.
+static const char *meeting_fail_name(int code)
+{
+    switch (code) {
+    case 1:   return "MEETING_FAIL_CONNECTION_ERR";
+    case 2:   return "MEETING_FAIL_RECONNECT_ERR";
+    case 3:   return "MEETING_FAIL_MMR_ERR";
+    case 4:   return "MEETING_FAIL_PASSWORD_ERR";
+    case 5:   return "MEETING_FAIL_SESSION_ERR";
+    case 6:   return "MEETING_FAIL_MEETING_OVER";
+    case 7:   return "MEETING_FAIL_MEETING_NOT_START";
+    case 8:   return "MEETING_FAIL_MEETING_NOT_EXIST";
+    case 9:   return "MEETING_FAIL_MEETING_USER_FULL";
+    case 10:  return "MEETING_FAIL_CLIENT_INCOMPATIBLE";
+    case 11:  return "MEETING_FAIL_NO_MMR";
+    case 12:  return "MEETING_FAIL_CONFLOCKED";
+    case 13:  return "MEETING_FAIL_MEETING_RESTRICTED";
+    case 14:  return "MEETING_FAIL_MEETING_RESTRICTED_JBH";
+    case 15:  return "MEETING_FAIL_CANNOT_EMIT_WEBREQUEST";
+    case 16:  return "MEETING_FAIL_CANNOT_START_TOKENEXPIRE";
+    case 19:  return "MEETING_FAIL_REGISTERWEBINAR_FULL";
+    case 20:  return "MEETING_FAIL_REGISTERWEBINAR_HOSTREGISTER";
+    case 21:  return "MEETING_FAIL_REGISTERWEBINAR_PANELISTREGISTER";
+    case 22:  return "MEETING_FAIL_REGISTERWEBINAR_DENIED_EMAIL";
+    case 23:  return "MEETING_FAIL_ENFORCE_LOGIN";
+    case 50:  return "MEETING_FAIL_WRITE_CONFIG_FILE";
+    case 60:  return "MEETING_FAIL_FORBID_TO_JOIN_INTERNAL_MEETING";
+    case 62:  return "MEETING_FAIL_HOST_DISALLOW_OUTSIDE_USER_JOIN";
+    case 63:  return "MEETING_FAIL_UNABLE_TO_JOIN_EXTERNAL_MEETING";
+    case 64:  return "MEETING_FAIL_BLOCKED_BY_ACCOUNT_ADMIN";
+    case 82:  return "MEETING_FAIL_NEED_SIGN_IN_FOR_PRIVATE_MEETING";
+    case 500: return "MEETING_FAIL_APP_PRIVILEGE_TOKEN_ERROR";
+    case 501: return "MEETING_FAIL_AUTHORIZED_USER_NOT_INMEETING";
+    case 502: return "MEETING_FAIL_ON_BEHALF_TOKEN_CONFLICT_LOGIN_ERROR";
+    case 503: return "MEETING_FAIL_USER_LEVEL_TOKEN_NOT_HAVE_HOST_ZAK_OBF";
+    case 504: return "MEETING_FAIL_APP_CAN_NOT_ANONYMOUS_JOIN_MEETING";
+    case 505: return "MEETING_FAIL_ON_BEHALF_TOKEN_INVALID";
+    case 506: return "MEETING_FAIL_ON_BEHALF_TOKEN_NOT_MATCH_MEETING";
+    default:  return "MEETING_FAIL_UNKNOWN";
+    }
+}
+
+// ── Roster state ─────────────────────────────────────────────────────────────
+// Mirrors ParticipantInfo in engine/src/main.cpp so `participants` is emitted
+// byte for byte identically — the plugin's read side is shared and unchanged.
+//
+// The Windows engine guards this state with a mutex because the SDK fires its
+// callbacks from arbitrary threads. Here everything — delegate callbacks and
+// every command hopped over from the reader thread — runs on the main queue, so
+// there is nothing to race with. That invariant is load-bearing: never touch
+// g_roster from the reader thread.
+struct ParticipantInfo {
+    uint32_t user_id = 0;
+    std::string display_name;
+    bool has_video = false;
+    bool is_talking = false;
+    bool is_muted = false;
+    bool is_sharing_screen = false;
+};
+
+static std::vector<ParticipantInfo> g_roster;
+static uint32_t g_active_speaker = 0;
+
+static ZoomSDKMeetingService *meeting_service()
+{
+    return [[ZoomSDK sharedSDK] getMeetingService];
+}
+
+static ZoomSDKMeetingActionController *action_controller()
+{
+    ZoomSDKMeetingService *svc = meeting_service();
+    return svc ? [svc getMeetingActionController] : nil;
+}
+
+static std::string to_utf8(NSString *s)
+{
+    if (!s) return {};
+    const char *c = s.UTF8String;
+    return c ? std::string(c) : std::string();
+}
+
+static ParticipantInfo user_to_info(ZoomSDKUserInfo *u)
+{
+    ParticipantInfo info;
+    if (!u) return info;
+    info.user_id      = [u getUserID];
+    info.display_name = to_utf8([u getUserName]);
+    info.has_video    = [u isVideoOn] ? true : false;
+    info.is_talking   = [u isTalking] ? true : false;
+
+    // Windows reads IsAudioMuted() directly; macOS only exposes a status enum,
+    // so fold the three muted variants onto the same boolean.
+    const ZoomSDKAudioStatus audio = [u getAudioStatus];
+    info.is_muted = (audio == ZoomSDKAudioStatus_Muted ||
+                     audio == ZoomSDKAudioStatus_MutedByHost ||
+                     audio == ZoomSDKAudioStatus_MutedAllByHost);
+
+    // Screen share is not ported yet. Reporting false is the honest answer for
+    // an unimplemented path; it is NOT a guess that nobody is sharing. When the
+    // share controller lands, set this from the active share user id the way
+    // main.cpp does.
+    info.is_sharing_screen = false;
+    return info;
+}
+
+static void rebuild_roster()
+{
+    ZoomSDKMeetingActionController *ctrl = action_controller();
+    if (!ctrl) return;
+    NSArray *list = [ctrl getParticipantsList];
+    if (!list) return;
+
+    std::vector<ParticipantInfo> next;
+    next.reserve(list.count);
+    for (NSNumber *uid in list) {
+        ZoomSDKUserInfo *user = [ctrl getUserByUserID:uid.unsignedIntValue];
+        if (!user) continue;
+        next.push_back(user_to_info(user));
+    }
+    g_roster = std::move(next);
+
+    g_active_speaker = 0;
+    for (const auto &p : g_roster) {
+        if (p.is_talking) {
+            g_active_speaker = p.user_id;
+            break;
+        }
+    }
+}
+
+static void send_roster()
+{
+    std::string msg = R"({"cmd":"participants","active_speaker_id":)" +
+        std::to_string(g_active_speaker) + R"(,"participants":[)";
+    for (size_t i = 0; i < g_roster.size(); ++i) {
+        const auto &p = g_roster[i];
+        if (i) msg += ",";
+        msg += R"({"id":)" + std::to_string(p.user_id) +
+            R"(,"name":")" + json_escape(p.display_name) +
+            R"(","has_video":)" + (p.has_video ? "true" : "false") +
+            R"(,"is_talking":)" + (p.is_talking ? "true" : "false") +
+            R"(,"is_muted":)" + (p.is_muted ? "true" : "false") +
+            R"(,"is_sharing_screen":)" +
+            (p.is_sharing_screen ? "true" : "false") + "}";
+    }
+    msg += "]}";
+    EngineIpc::write(msg);
+}
+
+// ── Meeting + roster delegate ────────────────────────────────────────────────
+// Reproduces onMeetingStatusChanged / the participants-controller callbacks from
+// engine/src/main.cpp. Every method of ZoomSDKMeetingActionControllerDelegate is
+// @required (the protocol declares no @optional section), so the ones we do not
+// use are stubbed rather than omitted — same shape as the Windows engine's block
+// of empty overrides. An omitted @required method is an unrecognized-selector
+// crash the moment the SDK calls it.
+@interface CVMeetingDelegate : NSObject <ZoomSDKMeetingServiceDelegate,
+                                         ZoomSDKMeetingActionControllerDelegate>
+@end
+
+@implementation CVMeetingDelegate
+
+- (void)onMeetingStatusChange:(ZoomSDKMeetingStatus)state
+                 meetingError:(ZoomSDKMeetingError)error
+                    EndReason:(EndMeetingReason)reason
+{
+    EngineIpc::write(R"({"cmd":"debug","stage":"meeting_status","status":)" +
+                     std::to_string(static_cast<int>(state)) +
+                     R"(,"result":)" + std::to_string(static_cast<int>(error)) + "}");
+
+    switch (state) {
+    case ZoomSDKMeetingStatus_InMeeting: {
+        EngineIpc::write(R"({"cmd":"joined"})");
+        ZoomSDKMeetingActionController *ctrl = action_controller();
+        if (!ctrl) {
+            // Without it there is no roster at all (getParticipantsList and
+            // getUserByUserID both live here), so say so rather than silently
+            // reporting an empty meeting.
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"participants_controller","code":-1})");
+            break;
+        }
+        ctrl.delegate = self;
+        rebuild_roster();
+        send_roster();
+        break;
+    }
+    case ZoomSDKMeetingStatus_Disconnecting:
+    case ZoomSDKMeetingStatus_Ended: {
+        ZoomSDKMeetingActionController *ctrl = action_controller();
+        if (ctrl && ctrl.delegate == self) ctrl.delegate = nil;
+        g_roster.clear();
+        g_active_speaker = 0;
+        EngineIpc::write(R"({"cmd":"left"})");
+        break;
+    }
+    case ZoomSDKMeetingStatus_Failed: {
+        ZoomSDKMeetingActionController *ctrl = action_controller();
+        if (ctrl && ctrl.delegate == self) ctrl.delegate = nil;
+        g_roster.clear();
+        g_active_speaker = 0;
+        EngineIpc::write(R"({"cmd":"error","msg":"meeting_failed","code":)" +
+                         std::to_string(static_cast<int>(error)) +
+                         R"(,"reason":")" +
+                         meeting_fail_name(static_cast<int>(error)) + "\"}");
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+// ── Roster-affecting callbacks (the ones main.cpp acts on) ───────────────────
+- (void)onUserJoin:(NSArray *)array { rebuild_roster(); send_roster(); }
+- (void)onUserLeft:(NSArray *)array { rebuild_roster(); send_roster(); }
+- (void)onUserNamesChanged:(NSArray<NSNumber *> *)userList { rebuild_roster(); send_roster(); }
+- (void)onUserAudioStatusChange:(NSArray *)userAudioStatusArray { rebuild_roster(); send_roster(); }
+- (void)onVideoStatusChange:(ZoomSDKVideoStatus)videoStatus UserID:(unsigned int)userID
+{
+    rebuild_roster();
+    send_roster();
+}
+
+- (void)onUserActiveAudioChange:(NSArray *)useridArray
+{
+    // main.cpp's onUserActiveAudioChange: the head of the list is the active
+    // speaker, and every id in it is currently talking.
+    const uint32_t active =
+        (useridArray.count > 0)
+            ? [(NSNumber *)useridArray.firstObject unsignedIntValue]
+            : 0;
+    g_active_speaker = active;
+    for (auto &p : g_roster) p.is_talking = false;
+    for (NSNumber *uid in useridArray) {
+        const uint32_t id = uid.unsignedIntValue;
+        for (auto &p : g_roster) {
+            if (p.user_id == id) p.is_talking = true;
+        }
+    }
+    EngineIpc::write(R"({"cmd":"active_speaker","participant_id":)" +
+                     std::to_string(active) + "}");
+    send_roster();
+}
+
+- (void)onActiveSpeakerVideoUserChanged:(unsigned int)userID
+{
+    if (g_active_speaker == 0) g_active_speaker = userID;
+    EngineIpc::write(R"({"cmd":"active_speaker","participant_id":)" +
+                     std::to_string(userID) + "}");
+}
+
+// ── Required-but-unused (see the class comment) ──────────────────────────────
+- (void)onUserInfoUpdate:(unsigned int)userID {}
+- (void)onVirtualNameTagStatusChanged:(BOOL)bOn userID:(unsigned int)userID {}
+- (void)onVirtualNameTagRosterInfoUpdated:(unsigned int)userID {}
+- (void)onHostChange:(unsigned int)userID {}
+- (void)onMeetingCoHostChanged:(unsigned int)userID isCoHost:(BOOL)isCoHost {}
+- (void)onSpotlightVideoUserChange:(NSArray *)spotlightedUserList {}
+- (void)onLowOrRaiseHandStatusChange:(BOOL)raise UserID:(unsigned int)userID {}
+- (void)onJoinMeetingResponse:(ZoomSDKJoinMeetingHelper *)joinMeetingHelper {}
+- (void)onMultiToSingleShareNeedConfirm:(ZoomSDKMultiToSingleShareConfirmHandler *)confirmHandle {}
+- (void)onActiveVideoUserChanged:(unsigned int)userID {}
+- (void)onHostAskUnmute {}
+- (void)onHostAskStartVideo {}
+- (void)onInvalidReclaimHostKey {}
+- (void)onHostVideoOrderUpdated:(NSArray *)orderList {}
+- (void)onLocalVideoOrderUpdated:(NSArray *)localOrderList {}
+- (void)onFollowHostVideoOrderChanged:(BOOL)follow {}
+- (void)onAllHandsLowered {}
+- (void)onUserVideoQualityChanged:(ZoomSDKVideoQuality)quality userID:(unsigned int)userID {}
+- (void)onChatMsgDeleteNotification:(NSString *)msgID
+                  messageDeleteType:(ZoomSDKChatMessageDeleteType)deleteBy {}
+- (void)onChatStatusChangedNotification:(ZoomSDKChatStatus *)chatStatus {}
+- (void)onShareMeetingChatStatusChanged:(BOOL)isStart {}
+- (void)onSuspendParticipantsActivities {}
+- (void)onAllowParticipantsStartVideoNotification:(BOOL)allow {}
+- (void)onAllowParticipantsRenameNotification:(BOOL)allow {}
+- (void)onAllowParticipantsUnmuteSelfNotification:(BOOL)allow {}
+- (void)onAllowParticipantsShareWhiteBoardNotification:(BOOL)allow {}
+- (void)onMeetingLockStatus:(BOOL)isLock {}
+- (void)onRequestLocalRecordingPrivilegeChanged:(ZoomSDKLocalRecordingRequestPrivilegeStatus)status {}
+- (void)onAllowParticipantsRequestCloudRecording:(BOOL)allow {}
+- (void)onInMeetingUserAvatarPathUpdated:(unsigned int)userID {}
+- (void)onAICompanionActiveChangeNotice:(BOOL)active {}
+- (void)onParticipantProfilePictureStatusChange:(BOOL)hidden {}
+- (void)onVideoAlphaChannelStatusChanged:(BOOL)isAlphaModeOn {}
+- (void)onFocusModeStateChanged:(BOOL)on {}
+- (void)onFocusModeShareTypeChanged:(ZoomSDKFocusModeShareType)shareType {}
+- (void)onMeetingQAStatusChanged:(BOOL)isMeetingQAFeatureOn {}
+- (void)onCameraControlRequestReceived:(unsigned int)userId
+                           requestType:(ZoomSDKCameraControlRequestType)requestType
+                         actionApprove:(ZoomSDKError (^)(void))actionApprove
+                         actionDecline:(ZoomSDKError (^)(void))actionDecline {}
+- (void)onCameraControlRequestResult:(unsigned int)userId
+                          resultType:(ZoomSDKCameraControlRequestResult)resultType {}
+- (void)onMuteOnEntryStatusChange:(BOOL)enable {}
+- (void)onMeetingTopicChanged:(NSString *)topic {}
+- (void)onBotAuthorizerRelationChanged:(unsigned int)authorizeUserID {}
+- (void)onCreateCompanionRelation:(unsigned int)parentUserID
+                      childUserID:(unsigned int)childUserID {}
+- (void)onRemoveCompanionRelation:(unsigned int)childUserID {}
+- (void)onGrantCoOwnerPrivilegeChanged:(BOOL)canGrantOther {}
+- (void)notifyToJoin3rdPartyTelephonyAudio:(NSString *)audioInfo {}
+
+@end
+
+static CVMeetingDelegate *g_meeting_delegate = nil;
+
+// The join context is deliberately a never-released global. main.cpp keeps its
+// JoinParam strings alive for the same reason: Join/joinMeeting: is asynchronous
+// and this file is built without ARC, so releasing the context on return would
+// risk pulling it out from under an in-flight call.
+static ZoomSDKJoinMeetingElements *g_join_ctx = nil;
+
+static NSString *ns_or_nil(const std::string &s)
+{
+    return s.empty() ? nil : [NSString stringWithUTF8String:s.c_str()];
+}
+
+// ── join / leave ─────────────────────────────────────────────────────────────
+// Runs on the main queue. Mirrors the join branch of main.cpp's command loop,
+// including the breadcrumb shape, so the two engines are diffable in a log.
+static void handle_join(const std::string &line)
+{
+    const std::string meeting_id          = json_str(line, "meeting_id");
+    const std::string passcode            = json_str(line, "passcode");
+    std::string       display_name        = json_str(line, "display_name");
+    const std::string on_behalf_token     = json_str(line, "on_behalf_token");
+    const std::string user_zak            = json_str(line, "user_zak");
+    const std::string app_privilege_token = json_str(line, "app_privilege_token");
+    if (display_name.empty()) display_name = "OBS";
+
+    EngineIpc::write(R"({"cmd":"debug","stage":"join_received","meeting_id":")" +
+        json_escape(meeting_id) + R"(","has_on_behalf_token":)" +
+        std::string(on_behalf_token.empty() ? "false" : "true") +
+        R"(,"has_user_zak":)" +
+        std::string(user_zak.empty() ? "false" : "true") +
+        R"(,"has_app_privilege_token":)" +
+        std::string(app_privilege_token.empty() ? "false" : "true") + "}");
+
+    ZoomSDKMeetingService *svc = meeting_service();
+    if (!svc) {
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"meeting_service_unavailable","stage":"join",)"
+            R"("reason":"getMeetingService returned nil; the SDK is not )"
+            R"(authenticated or was not initialized."})");
+        return;
+    }
+
+    if (!g_meeting_delegate) g_meeting_delegate = [[CVMeetingDelegate alloc] init];
+    svc.delegate = g_meeting_delegate;
+
+    long long meeting_number = 0;
+    try {
+        meeting_number = std::stoll(meeting_id);
+    } catch (...) {
+        EngineIpc::write(R"({"cmd":"error","msg":"invalid_meeting_id"})");
+        return;
+    }
+
+    g_join_ctx = [[ZoomSDKJoinMeetingElements alloc] init];
+    g_join_ctx.userType          = ZoomSDKUserType_WithoutLogin;
+    g_join_ctx.meetingNumber     = meeting_number;
+    g_join_ctx.displayName       = [NSString stringWithUTF8String:display_name.c_str()];
+    g_join_ctx.password          = ns_or_nil(passcode);
+    g_join_ctx.onBehalfToken     = ns_or_nil(on_behalf_token);
+    g_join_ctx.zak               = ns_or_nil(user_zak);
+    g_join_ctx.appPrivilegeToken = ns_or_nil(app_privilege_token);
+    g_join_ctx.isNoVideo         = NO;
+    g_join_ctx.isNoAudio         = NO;
+    g_join_ctx.isMyVoiceInMix    = YES;
+    // Match the Windows engine's raw-media negotiation exactly: the plugin's
+    // read side assumes 48 kHz PCM and full-range BT.709 I420.
+    g_join_ctx.audioRawdataSamplingRate = ZoomSDKAudioRawdataSamplingRate_48K;
+    g_join_ctx.videoRawdataColorspace   = ZoomSDKVideoRawdataColorspace_BT709_F;
+
+    const ZoomSDKError err = [svc joinMeeting:g_join_ctx];
+    EngineIpc::write(R"({"cmd":"debug","stage":"after_join","code":)" +
+                     std::to_string(static_cast<int>(err)) + "}");
+    if (err != ZoomSDKError_Success) {
+        // A synchronous rejection means onMeetingStatusChange will never fire,
+        // so without this the plugin waits on a status that is not coming and
+        // eventually reports the engine as hung — blaming the transport for a
+        // rejected argument.
+        //
+        // Deliberately NOT reported as "meeting_failed": that message carries a
+        // MeetingFailCode, and this is a ZoomSDKError from the call itself. The
+        // two enums overlap numerically (5 is InvalidParameter here but
+        // MEETING_FAIL_SESSION_ERR there), so reusing it would hand the plugin's
+        // error catalog a confidently wrong diagnosis.
+        EngineIpc::write(R"({"cmd":"error","msg":"join_rejected","stage":"join","code":)" +
+                         std::to_string(static_cast<int>(err)) +
+                         R"(,"reason":"joinMeeting: was rejected by the Meeting SDK )"
+                         R"(before contacting Zoom (ZoomSDKError )" +
+                         std::to_string(static_cast<int>(err)) +
+                         R"(). Check the meeting number and join tokens."})");
+    }
+}
+
+static void handle_leave()
+{
+    ZoomSDKMeetingService *svc = meeting_service();
+    if (svc) [svc leaveMeetingWithCmd:LeaveMeetingCmd_Leave];
+}
+
 // Anything not yet ported fails loudly and never silently pretends.
 static void handle_unimplemented(const char *stage)
 {
@@ -379,6 +802,21 @@ int main()
 
     EngineIpc::write(R"({"cmd":"ready"})");
 
+    // Heartbeat, matching engine/src/main.cpp: ping every ~2s so the plugin can
+    // tell a hung-but-alive engine from a quiet one. Its absence here was not
+    // cosmetic — zoom-engine-client.cpp declares the engine dead after 10s of
+    // IPC silence, so the macOS engine was reported as "stopped responding"
+    // after every idle stretch, including a perfectly healthy sit in a meeting.
+    std::thread heartbeat([]() {
+        while (g_running.load(std::memory_order_acquire)) {
+            for (int i = 0; i < 20 && g_running.load(std::memory_order_acquire); ++i)
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (!g_running.load(std::memory_order_acquire)) break;
+            if (!EngineIpc::write(R"({"cmd":"ping"})")) break;
+        }
+    });
+    heartbeat.detach();
+
     // The IPC read loop must NOT run on the main thread: the main thread has to
     // stay in the Cocoa run loop so the SDK's delegate callbacks can be
     // delivered. Reading here and dispatching SDK work to the main queue is what
@@ -394,17 +832,34 @@ int main()
 
             // Copy for the block: `line` is reused by the next read.
             const std::string msg = line;
+            // Ordered like main.cpp's command loop. These are substring matches
+            // on the whole line, so the order is the disambiguation: check the
+            // longer/more specific commands before their prefixes.
             if (msg.find(IPC_CMD_INIT) != std::string::npos) {
                 dispatch_async(dispatch_get_main_queue(), ^{ handle_init(msg); });
             } else if (msg.find(IPC_CMD_JOIN) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(), ^{ handle_join(msg); });
+            } else if (msg.find(IPC_CMD_LEAVE) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(), ^{ handle_leave(); });
+            } else if (msg.find(IPC_CMD_SUBSCRIBE_AUDIO) != std::string::npos) {
                 dispatch_async(dispatch_get_main_queue(),
-                               ^{ handle_unimplemented("join"); });
+                               ^{ handle_unimplemented("subscribe_audio"); });
+            } else if (msg.find(IPC_CMD_SUBSCRIBE) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(),
+                               ^{ handle_unimplemented("subscribe"); });
+            } else if (msg.find(IPC_CMD_START_MEDIA) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(),
+                               ^{ handle_unimplemented("start_media"); });
             }
         }
 
         // Peer closed the socket or sent quit: unwind from the main thread,
         // which owns the run loop.
         dispatch_async(dispatch_get_main_queue(), ^{
+            // Stop the heartbeat before closing the sockets, or it can write
+            // into a descriptor that teardown has already closed (and that the
+            // process may have handed to something else).
+            g_running.store(false, std::memory_order_release);
             ipc_teardown(p2e, e2p);
             [[ZoomSDK sharedSDK] unInitSDK];
             exit(0);

--- a/engine/src/main-macos.mm
+++ b/engine/src/main-macos.mm
@@ -63,13 +63,21 @@
 #include <sys/un.h>
 #include <poll.h>
 #include <unistd.h>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 #include <string>
 #include <thread>
+#include <tuple>
+#include <unordered_map>
 #include <vector>
+
+// Defined with the raw-media code further down; the meeting delegate has to
+// release renderers and SHM regions when the meeting ends.
+static void handle_stop_media(const char *reason);
 
 // Set false during teardown so the heartbeat thread stops before the IPC
 // sockets close. File scope because the heartbeat thread is detached and
@@ -511,6 +519,7 @@ static void send_roster()
     }
     case ZoomSDKMeetingStatus_Disconnecting:
     case ZoomSDKMeetingStatus_Ended: {
+        handle_stop_media("meeting_left");
         ZoomSDKMeetingActionController *ctrl = action_controller();
         if (ctrl && ctrl.delegate == self) ctrl.delegate = nil;
         g_roster.clear();
@@ -519,6 +528,7 @@ static void send_roster()
         break;
     }
     case ZoomSDKMeetingStatus_Failed: {
+        handle_stop_media("meeting_failed");
         ZoomSDKMeetingActionController *ctrl = action_controller();
         if (ctrl && ctrl.delegate == self) ctrl.delegate = nil;
         g_roster.clear();
@@ -727,6 +737,785 @@ static void handle_leave()
     if (svc) [svc leaveMeetingWithCmd:LeaveMeetingCmd_Leave];
 }
 
+// ── Raw media: shared helpers ────────────────────────────────────────────────
+// Same validators as engine/src/main.cpp. A source uuid becomes part of a POSIX
+// shm object name, so the character set is deliberately narrow.
+static uint32_t json_uint(const std::string &json, const std::string &key)
+{
+    const std::string needle = "\"" + key + "\":";
+    auto pos = json.find(needle);
+    if (pos == std::string::npos) return 0;
+    pos += needle.size();
+    try {
+        return static_cast<uint32_t>(std::stoul(json.substr(pos)));
+    } catch (...) {
+        return 0;
+    }
+}
+
+static bool is_valid_source_uuid(const std::string &uuid)
+{
+    if (uuid.empty() || uuid.size() > 64) return false;
+    return std::all_of(uuid.begin(), uuid.end(), [](char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+               (c >= '0' && c <= '9') || c == '-' || c == '_';
+    });
+}
+
+static ZoomSDKRawDataController *raw_data_controller()
+{
+    return [[ZoomSDK sharedSDK] getRawDataController];
+}
+
+// Seqlock write, byte-identical to the Windows engine's: bump the sequence to an
+// odd value, publish the header, copy the payload, then bump it to even. The
+// plugin's reader spins until it sees a stable even sequence, so an odd value
+// means "a write is in flight, discard".
+static uint32_t shm_seq_begin(uint32_t current)
+{
+    uint32_t seq = current + 1;
+    if ((seq & 1u) == 0) ++seq;
+    return seq;
+}
+
+// ── Raw video ────────────────────────────────────────────────────────────────
+// One ZoomSDKRenderer per participant, fanned out to every source uuid bound to
+// that participant — the same shape as ParticipantSubscription in
+// engine/src/engine-video.cpp, and for the same reason: two OBS sources showing
+// the same participant must not cost two Zoom subscriptions.
+//
+// The SDK delivers onRawDataReceived: on its own thread, so unlike the roster
+// this state IS mutex-guarded. CVRenderer deliberately holds only a POD ivar and
+// forwards into C++ — keeping the containers at file scope avoids non-trivial
+// C++ ivars inside an ObjC class.
+struct VideoTarget {
+    ShmRegion shm;
+    uint64_t  frame_count = 0;
+    uint32_t  shm_gen = 0;          // bumped per region (re)create; sent per frame
+    bool      shm_fail_reported = false;
+};
+
+struct VideoSubscription {
+    uint32_t participant_id = 0;
+    uint32_t resolution = 1;
+    ZoomSDKRenderer *renderer = nil;
+    id delegate = nil;              // CVRenderer, retained for the renderer's life
+    std::unordered_map<std::string, VideoTarget> targets;
+};
+
+static std::mutex g_video_mtx;
+static std::unordered_map<uint32_t, VideoSubscription> g_video;      // by participant
+static std::unordered_map<std::string, uint32_t> g_source_participant;
+static bool g_raw_media_active = false;
+
+static void video_on_frame(uint32_t participant_id, ZoomSDKYUVRawDataI420 *data);
+
+@interface CVRenderer : NSObject <ZoomSDKRendererDelegate>
+{
+    uint32_t _participantId;
+}
+- (instancetype)initWithParticipant:(uint32_t)participantId;
+@end
+
+@implementation CVRenderer
+
+- (instancetype)initWithParticipant:(uint32_t)participantId
+{
+    if ((self = [super init])) _participantId = participantId;
+    return self;
+}
+
+- (void)onRawDataReceived:(ZoomSDKYUVRawDataI420 *)data
+{
+    video_on_frame(_participantId, data);
+}
+
+- (void)onSubscribedUserDataOn
+{
+    EngineIpc::write(R"({"cmd":"debug","stage":"video_raw_status","participant_id":)" +
+                     std::to_string(_participantId) + R"(,"status":1})");
+}
+
+- (void)onSubscribedUserDataOff
+{
+    EngineIpc::write(R"({"cmd":"debug","stage":"video_raw_status","participant_id":)" +
+                     std::to_string(_participantId) + R"(,"status":0})");
+}
+
+- (void)onSubscribedUserLeft {}
+
+- (void)onRendererBeDestroyed
+{
+    // The SDK is tearing the renderer down under us; drop our pointer so no
+    // later unSubscribe/destroyRender touches freed memory.
+    std::lock_guard<std::mutex> lock(g_video_mtx);
+    auto it = g_video.find(_participantId);
+    if (it != g_video.end()) it->second.renderer = nil;
+}
+
+@end
+
+static ZoomSDKResolution sdk_resolution(uint32_t resolution)
+{
+    switch (resolution) {
+    case 0:  return ZoomSDKResolution_360P;
+    case 2:  return ZoomSDKResolution_1080P;
+    case 1:
+    default: return ZoomSDKResolution_720P;
+    }
+}
+
+// Mirrors valid_i420_frame() in engine-video.cpp: reject anything whose Y plane
+// length we would compute wrongly, rather than memcpy'ing a bad size.
+static bool valid_i420_frame(ZoomSDKYUVRawDataI420 *data, uint32_t w, uint32_t h,
+                             size_t &y_len)
+{
+    if (w == 0 || h == 0) return false;
+    if (w > 8192 || h > 8192) return false;
+    if ((w & 1) != 0 || (h & 1) != 0) return false;
+    if (![data getYBuffer] || ![data getUBuffer] || ![data getVBuffer]) return false;
+    y_len = static_cast<size_t>(w) * static_cast<size_t>(h);
+    return true;
+}
+
+static bool video_ensure_shm(VideoTarget &target, const std::string &source_uuid,
+                             size_t y_len)
+{
+    const size_t total = sizeof(ShmFrameHeader) + y_len + y_len / 4 + y_len / 4;
+    if (total < y_len) return false;
+    if (target.shm.ptr && target.shm.size >= total) return true;
+
+    const std::string region_name = IPC_SHM_PREFIX + source_uuid;
+    if (!shm_region_create(target.shm, region_name, total)) return false;
+    ++target.shm_gen; // new region — any plugin-side mapping is now stale
+    return true;
+}
+
+static void video_on_frame(uint32_t participant_id, ZoomSDKYUVRawDataI420 *data)
+{
+    if (!data) return;
+    const uint32_t w = [data getStreamWidth];
+    const uint32_t h = [data getStreamHeight];
+    size_t y_len = 0;
+    if (!valid_i420_frame(data, w, h, y_len)) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"video_frame_invalid","participant_id":)" +
+            std::to_string(participant_id) + R"(,"w":)" + std::to_string(w) +
+            R"(,"h":)" + std::to_string(h) + "}");
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_video_mtx);
+    auto sub = g_video.find(participant_id);
+    if (sub == g_video.end()) return;
+
+    for (auto &entry : sub->second.targets) {
+        const std::string &source_uuid = entry.first;
+        VideoTarget &target = entry.second;
+
+        if (!video_ensure_shm(target, source_uuid, y_len) || !target.shm.ptr) {
+            // Once per failure episode, not once per frame.
+            if (!target.shm_fail_reported) {
+                target.shm_fail_reported = true;
+                EngineIpc::write(
+                    R"({"cmd":"debug","stage":"video_shm_create_failed","source_uuid":")" +
+                    source_uuid + R"(","participant_id":)" +
+                    std::to_string(participant_id) + R"(,"w":)" + std::to_string(w) +
+                    R"(,"h":)" + std::to_string(h) + "}");
+                EngineIpc::write(
+                    R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
+                    source_uuid + R"(","participant_id":)" +
+                    std::to_string(participant_id) + R"(,"w":)" + std::to_string(w) +
+                    R"(,"h":)" + std::to_string(h) + "}");
+            }
+            continue;
+        }
+        if (target.shm_fail_reported) {
+            target.shm_fail_reported = false;
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"video_shm_recovered","source_uuid":")" +
+                source_uuid + R"(","participant_id":)" +
+                std::to_string(participant_id) + "}");
+        }
+
+        auto *hdr    = static_cast<ShmFrameHeader *>(target.shm.ptr);
+        auto *pixels = static_cast<char *>(target.shm.ptr) + sizeof(ShmFrameHeader);
+        const uint32_t seq = shm_seq_begin(hdr->sequence);
+        hdr->sequence = seq;
+        std::atomic_thread_fence(std::memory_order_release);
+        hdr->width  = w;
+        hdr->height = h;
+        hdr->y_len  = static_cast<uint32_t>(y_len);
+
+        std::memcpy(pixels,                     [data getYBuffer], y_len);
+        std::memcpy(pixels + y_len,             [data getUBuffer], y_len / 4);
+        std::memcpy(pixels + y_len + y_len / 4, [data getVBuffer], y_len / 4);
+        std::atomic_thread_fence(std::memory_order_release);
+        hdr->sequence = seq + 1;
+
+        ++target.frame_count;
+        if (target.frame_count == 1 || target.frame_count % 120 == 0) {
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"video_frame_received","source_uuid":")" +
+                source_uuid + R"(","participant_id":)" +
+                std::to_string(participant_id) + R"(,"count":)" +
+                std::to_string(target.frame_count) + R"(,"w":)" + std::to_string(w) +
+                R"(,"h":)" + std::to_string(h) + "}");
+        }
+
+        EngineIpc::write(
+            R"({"cmd":"frame","source_uuid":")" + source_uuid +
+            R"(","participant_id":)" + std::to_string(participant_id) +
+            R"(,"w":)" + std::to_string(w) + R"(,"h":)" + std::to_string(h) +
+            R"(,"shm_gen":)" + std::to_string(target.shm_gen) + "}");
+    }
+}
+
+// Caller must hold g_video_mtx.
+static void video_teardown_locked(uint32_t participant_id)
+{
+    auto it = g_video.find(participant_id);
+    if (it == g_video.end()) return;
+    if (it->second.renderer) {
+        [it->second.renderer unSubscribe];
+        ZoomSDKRawDataController *rdc = raw_data_controller();
+        if (rdc) [rdc destroyRender:it->second.renderer];
+        it->second.renderer = nil;
+    }
+    [it->second.delegate release];
+    it->second.delegate = nil;
+    for (auto &t : it->second.targets) shm_region_destroy(t.second.shm);
+    g_video.erase(it);
+}
+
+static void video_subscribe(uint32_t participant_id, const std::string &source_uuid,
+                            uint32_t resolution)
+{
+    if (participant_id == 0) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"video_subscribe_skipped","source_uuid":")" +
+            source_uuid + R"(","participant_id":0,"reason":"missing_participant"})");
+        return;
+    }
+    if (resolution > 2) resolution = 1;
+
+    std::lock_guard<std::mutex> lock(g_video_mtx);
+
+    // Rebinding a source to a different participant must release the old one.
+    auto bound = g_source_participant.find(source_uuid);
+    if (bound != g_source_participant.end() && bound->second != participant_id) {
+        auto old = g_video.find(bound->second);
+        if (old != g_video.end()) {
+            auto t = old->second.targets.find(source_uuid);
+            if (t != old->second.targets.end()) {
+                shm_region_destroy(t->second.shm);
+                old->second.targets.erase(t);
+            }
+            if (old->second.targets.empty()) video_teardown_locked(bound->second);
+        }
+    }
+    g_source_participant[source_uuid] = participant_id;
+
+    auto existing = g_video.find(participant_id);
+    if (existing != g_video.end()) {
+        existing->second.targets.emplace(source_uuid, VideoTarget{});
+        return;                     // one renderer already serves this participant
+    }
+
+    if (!g_raw_media_active) {
+        // Remember the binding; the renderer is created when raw media starts.
+        VideoSubscription pending;
+        pending.participant_id = participant_id;
+        pending.resolution = resolution;
+        pending.targets.emplace(source_uuid, VideoTarget{});
+        g_video.emplace(participant_id, std::move(pending));
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"video_subscribe_deferred","source_uuid":")" +
+            source_uuid + R"(","participant_id":)" +
+            std::to_string(participant_id) + "}");
+        return;
+    }
+
+    ZoomSDKRawDataController *rdc = raw_data_controller();
+    if (!rdc) {
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"raw_data_controller_unavailable","source_uuid":")" +
+            source_uuid + R"(","participant_id":)" +
+            std::to_string(participant_id) + "}");
+        return;
+    }
+
+    // Walk the requested resolution down on failure, exactly as the Windows
+    // engine does — a 1080p subscription that the account or link will not carry
+    // should degrade, not drop the participant entirely.
+    for (int candidate = static_cast<int>(resolution); candidate >= 0; --candidate) {
+        ZoomSDKRenderer *renderer = nil;
+        const ZoomSDKError create_err = [rdc createRender:&renderer];
+        if (create_err != ZoomSDKError_Success || !renderer) {
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"create_renderer_failed","source_uuid":")" +
+                source_uuid + R"(","participant_id":)" +
+                std::to_string(participant_id) + R"(,"code":)" +
+                std::to_string(static_cast<int>(create_err)) + R"(,"resolution":)" +
+                std::to_string(candidate) + "}");
+            continue;
+        }
+
+        CVRenderer *delegate = [[CVRenderer alloc] initWithParticipant:participant_id];
+        renderer.delegate = delegate;
+
+        const ZoomSDKError res_err =
+            [renderer setResolution:sdk_resolution(static_cast<uint32_t>(candidate))];
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"set_resolution","source_uuid":")" +
+            source_uuid + R"(","participant_id":)" +
+            std::to_string(participant_id) + R"(,"code":)" +
+            std::to_string(static_cast<int>(res_err)) + R"(,"resolution":)" +
+            std::to_string(candidate) + "}");
+
+        const ZoomSDKError sub_err =
+            [renderer subscribe:participant_id rawDataType:ZoomSDKRawDataType_Video];
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"video_subscribe","source_uuid":")" +
+            source_uuid + R"(","participant_id":)" +
+            std::to_string(participant_id) + R"(,"code":)" +
+            std::to_string(static_cast<int>(sub_err)) + R"(,"resolution":)" +
+            std::to_string(candidate) + "}");
+
+        if (sub_err == ZoomSDKError_Success) {
+            VideoSubscription sub;
+            sub.participant_id = participant_id;
+            sub.resolution = static_cast<uint32_t>(candidate);
+            sub.renderer = renderer;
+            sub.delegate = delegate;
+            sub.targets.emplace(source_uuid, VideoTarget{});
+            g_video.emplace(participant_id, std::move(sub));
+            if (static_cast<uint32_t>(candidate) != resolution) {
+                EngineIpc::write(
+                    R"({"cmd":"debug","stage":"video_resolution_downgraded","source_uuid":")" +
+                    source_uuid + R"(","participant_id":)" +
+                    std::to_string(participant_id) + R"(,"requested":)" +
+                    std::to_string(resolution) + R"(,"actual":)" +
+                    std::to_string(candidate) + "}");
+            }
+            return;
+        }
+
+        renderer.delegate = nil;
+        [delegate release];
+        [rdc destroyRender:renderer];
+    }
+
+    EngineIpc::write(
+        R"({"cmd":"debug","stage":"video_subscribe_failed_all","source_uuid":")" +
+        source_uuid + R"(","participant_id":)" + std::to_string(participant_id) +
+        R"(,"requested":)" + std::to_string(resolution) + "}");
+    EngineIpc::write(
+        R"({"cmd":"error","msg":"video_subscribe_failed","source_uuid":")" +
+        source_uuid + R"(","participant_id":)" + std::to_string(participant_id) + "}");
+}
+
+static void video_unsubscribe(const std::string &source_uuid)
+{
+    std::lock_guard<std::mutex> lock(g_video_mtx);
+    auto bound = g_source_participant.find(source_uuid);
+    if (bound == g_source_participant.end()) return;
+    const uint32_t participant_id = bound->second;
+    g_source_participant.erase(bound);
+
+    auto sub = g_video.find(participant_id);
+    if (sub == g_video.end()) return;
+    auto t = sub->second.targets.find(source_uuid);
+    if (t != sub->second.targets.end()) {
+        shm_region_destroy(t->second.shm);
+        sub->second.targets.erase(t);
+    }
+    if (sub->second.targets.empty()) video_teardown_locked(participant_id);
+}
+
+// ── Raw audio ────────────────────────────────────────────────────────────────
+// One subscription to the shared audio helper, fanned out per source. Routing
+// matches engine/src/engine-audio.cpp: isolate → that participant's one-way
+// audio only; audience → every non-isolated participant's one-way audio;
+// neither → the full meeting mix.
+struct AudioTarget {
+    uint32_t participant_id = 0;
+    bool     isolate_audio = false;
+    bool     audience_audio = false;
+    ShmRegion shm;
+    uint64_t frame_count = 0;
+    bool     shm_fail_reported = false;
+};
+
+static std::mutex g_audio_mtx;
+static std::unordered_map<std::string, AudioTarget> g_audio;
+static bool g_audio_subscribed = false;
+
+static bool audio_ensure_shm(AudioTarget &target, const std::string &source_uuid,
+                             uint32_t byte_len)
+{
+    const size_t total = sizeof(ShmAudioHeader) + byte_len;
+    if (target.shm.ptr && target.shm.size >= total) return true;
+    const std::string region_name = IPC_SHM_PREFIX + source_uuid + "_audio";
+    return shm_region_create(target.shm, region_name, total);
+}
+
+// Caller must hold g_audio_mtx.
+static void audio_output_frame(AudioTarget &target, const std::string &source_uuid,
+                               ZoomSDKAudioRawData *data, const char *stage)
+{
+    const uint32_t byte_len = [data getBufferLen];
+    if (byte_len == 0) return;
+
+    if (!audio_ensure_shm(target, source_uuid, byte_len) || !target.shm.ptr) {
+        if (!target.shm_fail_reported) {
+            target.shm_fail_reported = true;
+            EngineIpc::write(
+                R"({"cmd":"debug","stage":"audio_shm_create_failed","source_uuid":")" +
+                source_uuid + R"(","byte_len":)" + std::to_string(byte_len) + "}");
+            EngineIpc::write(
+                R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
+                source_uuid + R"(","byte_len":)" + std::to_string(byte_len) + "}");
+        }
+        return;
+    }
+    if (target.shm_fail_reported) {
+        target.shm_fail_reported = false;
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"audio_shm_recovered","source_uuid":")" +
+            source_uuid + "\"}");
+    }
+
+    auto *hdr = static_cast<ShmAudioHeader *>(target.shm.ptr);
+    const uint32_t seq = shm_seq_begin(hdr->sequence);
+    hdr->sequence = seq;
+    std::atomic_thread_fence(std::memory_order_release);
+    hdr->sample_rate = [data getSampleRate];
+    hdr->channels    = static_cast<uint16_t>([data getChannelNum]);
+    hdr->reserved    = 0;
+    hdr->byte_len    = byte_len;
+    std::memcpy(static_cast<char *>(target.shm.ptr) + sizeof(ShmAudioHeader),
+                [data getBuffer], byte_len);
+    std::atomic_thread_fence(std::memory_order_release);
+    hdr->sequence = seq + 1;
+
+    ++target.frame_count;
+    if (target.frame_count == 1 || target.frame_count % 250 == 0) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":")" + std::string(stage) +
+            R"(","source_uuid":")" + source_uuid + R"(","count":)" +
+            std::to_string(target.frame_count) + R"(,"sample_rate":)" +
+            std::to_string([data getSampleRate]) + R"(,"channels":)" +
+            std::to_string([data getChannelNum]) + R"(,"byte_len":)" +
+            std::to_string(byte_len) + R"(,"participant_id":)" +
+            std::to_string(target.participant_id) + "}");
+    }
+
+    EngineIpc::write(
+        R"({"cmd":"audio","source_uuid":")" + source_uuid +
+        R"(","participant_id":)" + std::to_string(target.participant_id) +
+        R"(,"byte_len":)" + std::to_string(byte_len) + "}");
+}
+
+@interface CVAudioDelegate : NSObject <ZoomSDKAudioRawDataDelegate>
+@end
+
+@implementation CVAudioDelegate
+
+- (void)onMixedAudioRawDataReceived:(ZoomSDKAudioRawData *)data
+{
+    if (!data || [data getBufferLen] == 0) return;
+    std::lock_guard<std::mutex> lock(g_audio_mtx);
+    for (auto &entry : g_audio) {
+        // isolate and audience targets both take one-way audio only.
+        if (entry.second.isolate_audio || entry.second.audience_audio) continue;
+        audio_output_frame(entry.second, entry.first, data, "audio_frame_received");
+    }
+}
+
+- (void)onOneWayAudioRawDataReceived:(ZoomSDKAudioRawData *)data userID:(unsigned int)userID
+{
+    if (!data || [data getBufferLen] == 0) return;
+    std::lock_guard<std::mutex> lock(g_audio_mtx);
+
+    bool claimed_by_isolate = false;
+    for (auto &entry : g_audio) {
+        if (!entry.second.isolate_audio) continue;
+        if (entry.second.participant_id != userID) continue;
+        claimed_by_isolate = true;
+        audio_output_frame(entry.second, entry.first, data,
+                           "audio_one_way_frame_received");
+    }
+    if (claimed_by_isolate) return;
+
+    for (auto &entry : g_audio) {
+        if (!entry.second.audience_audio) continue;
+        audio_output_frame(entry.second, entry.first, data,
+                           "audio_audience_frame_received");
+    }
+}
+
+- (void)onOneWayAudioRawDataReceived:(ZoomSDKAudioRawData *)data nodeID:(unsigned int)nodeID {}
+- (void)onShareAudioRawDataReceived:(ZoomSDKAudioRawData *)data {}
+- (void)onShareAudioRawDataReceived:(ZoomSDKAudioRawData *)data userID:(unsigned int)userID {}
+- (void)onOneWayInterpreterAudioRawDataReceived:(ZoomSDKAudioRawData *)data
+                                strLanguageName:(NSString *)languageName {}
+
+@end
+
+static CVAudioDelegate *g_audio_delegate = nil;
+
+static bool audio_subscribe_if_needed(const std::string &source_uuid,
+                                      const char *stage)
+{
+    if (g_audio_subscribed) return true;
+    if (!g_raw_media_active) return false;
+
+    ZoomSDKRawDataController *rdc = raw_data_controller();
+    if (!rdc) return false;
+    ZoomSDKAudioRawDataHelper *helper = nil;
+    const ZoomSDKError get_err = [rdc getAudioRawDataHelper:&helper];
+    if (get_err != ZoomSDKError_Success || !helper) {
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"audio_helper_unavailable","source_uuid":")" +
+            source_uuid + R"(","code":)" +
+            std::to_string(static_cast<int>(get_err)) + "}");
+        return false;
+    }
+
+    if (!g_audio_delegate) g_audio_delegate = [[CVAudioDelegate alloc] init];
+    helper.delegate = g_audio_delegate;
+    const ZoomSDKError err = [helper subscribe];
+    EngineIpc::write(
+        R"({"cmd":"debug","stage":")" + std::string(stage) +
+        R"(","source_uuid":")" + source_uuid + R"(","code":)" +
+        std::to_string(static_cast<int>(err)) + "}");
+    if (err != ZoomSDKError_Success) return false;
+
+    g_audio_subscribed = true;
+    return true;
+}
+
+static void audio_init(const std::string &source_uuid, uint32_t participant_id,
+                       bool isolate_audio, bool audience_audio)
+{
+    {
+        std::lock_guard<std::mutex> lock(g_audio_mtx);
+        AudioTarget &target = g_audio[source_uuid];
+        target.participant_id = participant_id;
+        // Both set is treated as isolate, matching engine-audio.cpp.
+        target.isolate_audio = isolate_audio;
+        target.audience_audio = isolate_audio ? false : audience_audio;
+    }
+    audio_subscribe_if_needed(source_uuid, "audio_subscribe");
+}
+
+static void audio_remove(const std::string &source_uuid)
+{
+    std::lock_guard<std::mutex> lock(g_audio_mtx);
+    auto it = g_audio.find(source_uuid);
+    if (it == g_audio.end()) return;
+    shm_region_destroy(it->second.shm);
+    g_audio.erase(it);
+    EngineIpc::write(
+        R"({"cmd":"debug","stage":"audio_target_removed","source_uuid":")" +
+        source_uuid + "\"}");
+}
+
+// ── start / stop raw media ───────────────────────────────────────────────────
+// Raw data requires raw recording to be running. Subscriptions requested before
+// that are held as pending bindings and created here, so the plugin can assign
+// sources in any order relative to start_media.
+static void resubscribe_raw_media(const char *reason)
+{
+    std::vector<std::tuple<uint32_t, std::string, uint32_t>> pending;
+    {
+        std::lock_guard<std::mutex> lock(g_video_mtx);
+        for (auto &entry : g_video) {
+            if (entry.second.renderer) continue;   // already live
+            for (auto &t : entry.second.targets) {
+                pending.emplace_back(entry.first, t.first, entry.second.resolution);
+            }
+        }
+        // video_subscribe re-creates these entries; drop the placeholders first
+        // so it does not short-circuit on "a subscription already exists".
+        for (auto &p : pending) g_video.erase(std::get<0>(p));
+    }
+
+    EngineIpc::write(R"({"cmd":"debug","stage":"raw_media_resubscribe","reason":")" +
+                     std::string(reason ? reason : "") + R"(","count":)" +
+                     std::to_string(pending.size()) + "}");
+
+    for (auto &p : pending)
+        video_subscribe(std::get<0>(p), std::get<1>(p), std::get<2>(p));
+
+    std::vector<std::string> audio_sources;
+    {
+        std::lock_guard<std::mutex> lock(g_audio_mtx);
+        for (auto &entry : g_audio) audio_sources.push_back(entry.first);
+    }
+    if (!audio_sources.empty())
+        audio_subscribe_if_needed(audio_sources.front(), "audio_resubscribe");
+}
+
+// Guards the privilege-request retry loop: without it, a host who denies the
+// request would have us re-ask on every callback.
+static bool g_privilege_requested = false;
+
+// Defined below; the record delegate retries the start once the host grants
+// local-recording permission.
+static void handle_start_media(const char *reason);
+
+@interface CVRecordDelegate : NSObject <ZoomSDKMeetingRecordDelegate>
+@end
+
+@implementation CVRecordDelegate
+
+- (void)onLocalRecordingPrivilegeRequestStatus:(ZoomSDKRequestLocalRecordingStatus)status
+{
+    EngineIpc::write(
+        R"({"cmd":"debug","stage":"local_recording_privilege_status","status":)" +
+        std::to_string(static_cast<int>(status)) + "}");
+    if (status == ZoomSDKRequestLocalRecordingStatus_Granted) {
+        handle_start_media("privilege_granted");
+        return;
+    }
+    EngineIpc::write(
+        R"({"cmd":"error","msg":"raw_media_start_failed","reason":"local_recording_privilege_denied","status":)" +
+        std::to_string(static_cast<int>(status)) + "}");
+}
+
+- (void)onRecordPrivilegeChange:(BOOL)canRec
+{
+    EngineIpc::write(R"({"cmd":"debug","stage":"record_privilege_change","can_record":)" +
+                     std::string(canRec ? "true" : "false") + "}");
+    if (canRec && !g_raw_media_active) handle_start_media("privilege_changed");
+}
+
+- (void)onRecord2MP4Done:(BOOL)success Path:(NSString *)recordPath {}
+- (void)onRecord2MP4Progressing:(int)percentage {}
+- (void)onCloudRecordingStatus:(ZoomSDKRecordingStatus)status {}
+- (void)onCustomizedRecordingSourceReceived:(CustomizedRecordingLayoutHelper *)helper {}
+- (void)onLocalRecordStatus:(ZoomSDKRecordingStatus)status userID:(unsigned int)userID {}
+- (void)onLocalRecordingPrivilegeRequested:(ZoomSDKRequestLocalRecordingPrivilegeHandler *)handler {}
+- (void)onCloudRecordingStorageFull:(time_t)gracePeriodDate {}
+- (void)onRequestCloudRecordingResponse:(ZoomSDKRequestStartCloudRecordingStatus)status {}
+- (void)onStartCloudRecordingRequested:(ZoomSDKRequestStartCloudRecordingHandler *)handler {}
+- (void)onEnableAndStartSmartRecordingRequested:(ZoomSDKRequestEnableAndStartSmartRecordingHandler *)handler {}
+- (void)onSmartRecordingEnableActionCallback:(ZoomSDKSmartRecordingEnableActionHandler *)handler {}
+
+@end
+
+static CVRecordDelegate *g_record_delegate = nil;
+
+static void handle_start_media(const char *reason)
+{
+    ZoomSDKMeetingService *svc = meeting_service();
+    if (!svc) {
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"raw_media_start_failed","reason":"not_in_meeting"})");
+        return;
+    }
+    ZoomSDKMeetingRecordController *rec = [svc getRecordController];
+    if (!rec) {
+        EngineIpc::write(R"({"cmd":"debug","stage":"recording_controller","code":-1})");
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"raw_media_start_failed",)"
+            R"("reason":"recording_controller_unavailable"})");
+        return;
+    }
+
+    // Attach before asking: the grant arrives asynchronously on this delegate.
+    if (!g_record_delegate) g_record_delegate = [[CVRecordDelegate alloc] init];
+    rec.delegate = g_record_delegate;
+
+    const ZoomSDKError can_raw = [rec canStartRawRecording];
+    EngineIpc::write(R"({"cmd":"debug","stage":"can_start_raw_recording","code":)" +
+                     std::to_string(static_cast<int>(can_raw)) + "}");
+    if (can_raw != ZoomSDKError_Success && g_privilege_requested) {
+        // Already asked once this meeting; do not re-prompt the host on every
+        // retry. Report and stop.
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"raw_media_start_failed","reason":"cannot_start_raw_recording",)"
+            R"("code":)" + std::to_string(static_cast<int>(can_raw)) +
+            R"(,"privilege_requested":true,"detail":"Local-recording permission was )"
+            R"(already requested and has not been granted."})");
+        return;
+    }
+    if (can_raw != ZoomSDKError_Success) {
+        // Usually NoPermission(6): the engine joined as a participant and the
+        // host has not granted local recording. Ask for it rather than giving
+        // up — same fallback as main.cpp. The host sees a prompt; when they
+        // accept, onLocalRecordingPrivilegeRequestStatus fires and we retry.
+        const ZoomSDKError support_req = [rec isSupportRequestLocalRecordingPrivilege];
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"support_recording_privilege_request","code":)" +
+            std::to_string(static_cast<int>(support_req)) + "}");
+        const ZoomSDKError req = [rec requestLocalRecordingPrivilege];
+        g_privilege_requested = true;
+        EngineIpc::write(
+            R"({"cmd":"debug","stage":"request_recording_privilege","code":)" +
+            std::to_string(static_cast<int>(req)) + "}");
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"raw_media_start_failed","reason":"cannot_start_raw_recording",)"
+            R"("code":)" + std::to_string(static_cast<int>(can_raw)) +
+            R"(,"privilege_requested":)" +
+            std::string(req == ZoomSDKError_Success ? "true" : "false") +
+            R"(,"detail":"Raw recording needs local-recording permission. )"
+            R"(The meeting host must allow this participant to record."})");
+        return;
+    }
+
+    const ZoomSDKError start_raw = [rec startRawRecording];
+    EngineIpc::write(R"({"cmd":"debug","stage":"start_raw_recording","code":)" +
+                     std::to_string(static_cast<int>(start_raw)) + "}");
+    if (start_raw != ZoomSDKError_Success) {
+        EngineIpc::write(
+            R"({"cmd":"error","msg":"raw_media_start_failed","reason":"start_raw_recording_failed","code":)" +
+            std::to_string(static_cast<int>(start_raw)) + "}");
+        return;
+    }
+
+    g_raw_media_active = true;
+    resubscribe_raw_media(reason);
+}
+
+static void handle_stop_media(const char *reason)
+{
+    g_raw_media_active = false;
+    // Per-meeting state: a fresh meeting should be allowed to ask again.
+    g_privilege_requested = false;
+    {
+        std::lock_guard<std::mutex> lock(g_video_mtx);
+        std::vector<uint32_t> ids;
+        ids.reserve(g_video.size());
+        for (auto &entry : g_video) ids.push_back(entry.first);
+        for (uint32_t id : ids) video_teardown_locked(id);
+        g_source_participant.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_audio_mtx);
+        for (auto &entry : g_audio) shm_region_destroy(entry.second.shm);
+        g_audio.clear();
+    }
+    if (g_audio_subscribed) {
+        ZoomSDKRawDataController *rdc = raw_data_controller();
+        ZoomSDKAudioRawDataHelper *helper = nil;
+        if (rdc && [rdc getAudioRawDataHelper:&helper] == ZoomSDKError_Success && helper)
+            [helper unSubscribe];
+        g_audio_subscribed = false;
+    }
+    ZoomSDKMeetingService *svc = meeting_service();
+    ZoomSDKMeetingRecordController *rec = svc ? [svc getRecordController] : nil;
+    if (rec) {
+        const ZoomSDKError err = [rec stopRawRecording];
+        EngineIpc::write(R"({"cmd":"debug","stage":"stop_raw_recording","code":)" +
+                         std::to_string(static_cast<int>(err)) + "}");
+    }
+    EngineIpc::write(R"({"cmd":"debug","stage":"raw_media_stopped","reason":")" +
+                     std::string(reason ? reason : "") + "\"}");
+}
+
 // Anything not yet ported fails loudly and never silently pretends.
 static void handle_unimplemented(const char *stage)
 {
@@ -841,15 +1630,51 @@ int main()
                 dispatch_async(dispatch_get_main_queue(), ^{ handle_join(msg); });
             } else if (msg.find(IPC_CMD_LEAVE) != std::string::npos) {
                 dispatch_async(dispatch_get_main_queue(), ^{ handle_leave(); });
-            } else if (msg.find(IPC_CMD_SUBSCRIBE_AUDIO) != std::string::npos) {
-                dispatch_async(dispatch_get_main_queue(),
-                               ^{ handle_unimplemented("subscribe_audio"); });
-            } else if (msg.find(IPC_CMD_SUBSCRIBE) != std::string::npos) {
-                dispatch_async(dispatch_get_main_queue(),
-                               ^{ handle_unimplemented("subscribe"); });
             } else if (msg.find(IPC_CMD_START_MEDIA) != std::string::npos) {
                 dispatch_async(dispatch_get_main_queue(),
-                               ^{ handle_unimplemented("start_media"); });
+                               ^{ handle_start_media("manual_start"); });
+            } else if (msg.find(IPC_CMD_STOP_MEDIA) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(),
+                               ^{ handle_stop_media("manual_stop"); });
+            } else if (msg.find(IPC_CMD_SUBSCRIBE_AUDIO) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    const std::string uuid = json_str(msg, "source_uuid");
+                    if (!is_valid_source_uuid(uuid)) return;
+                    audio_init(uuid, json_uint(msg, "participant_id"),
+                               msg.find(R"("isolate_audio":true)") != std::string::npos,
+                               msg.find(R"("audience_audio":true)") != std::string::npos);
+                });
+            // Checked BEFORE subscribe: "unsubscribe" contains "subscribe", so the
+            // reverse order routes an unsubscribe into the subscribe branch. (The
+            // Windows engine has that ordering and gets away with it only because
+            // participant_id parses as 0 there, which its subscribe path treats as
+            // an unsubscribe — but it never drops the audio target.)
+            } else if (msg.find(IPC_CMD_UNSUBSCRIBE) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    const std::string uuid = json_str(msg, "source_uuid");
+                    if (!is_valid_source_uuid(uuid)) return;
+                    video_unsubscribe(uuid);
+                    audio_remove(uuid);
+                });
+            } else if (msg.find(IPC_CMD_SUBSCRIBE) != std::string::npos) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    const std::string uuid = json_str(msg, "source_uuid");
+                    if (!is_valid_source_uuid(uuid)) return;
+                    if (json_str(msg, "mode") == "screenshare") {
+                        // Screen share needs its own share-source subscription;
+                        // not ported yet, so say so rather than silently binding
+                        // it to a participant renderer that shows the wrong feed.
+                        handle_unimplemented("subscribe_screenshare");
+                        return;
+                    }
+                    uint32_t res = json_uint(msg, "resolution");
+                    if (res > 2) res = 1;
+                    const uint32_t pid = json_uint(msg, "participant_id");
+                    video_subscribe(pid, uuid, res);
+                    audio_init(uuid, pid,
+                               msg.find(R"("isolate_audio":true)") != std::string::npos,
+                               msg.find(R"("audience_audio":true)") != std::string::npos);
+                });
             }
         }
 

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -1142,6 +1142,11 @@ int main()
             for (int i = 0; i < 20 && running.load(std::memory_order_acquire); ++i)
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             if (!running.load(std::memory_order_acquire)) break;
+            // cppcheck-suppress knownConditionTrueFalse ; false positive --
+            // cppcheck's bounded (--check-level=normal) branch analysis of
+            // ipc_write_line() (engine-ipc.h), which has multiple return
+            // points inside a retry loop, misreads it as always returning
+            // false. It legitimately returns true on a successful write.
             if (!EngineIpc::write(R"({"cmd":"ping"})")) break;
         }
     });

--- a/installer/corevideo.nsi
+++ b/installer/corevideo.nsi
@@ -161,6 +161,19 @@ FunctionEnd
 
 Section "CoreVideo for OBS" SecCoreVideo
   Call CheckObsClosed
+
+  ; v0.1.29 and earlier left the FFmpeg runtime loose in obs-plugins\64bit,
+  ; where it collides with the same-named FFmpeg 8 DLLs OBS 32.2+ keeps in
+  ; bin\64bit and stops OBS's own obs-ffmpeg module from loading. The runtime
+  ; now lives in obs-plugins\64bit\corevideo-ffmpeg\; sweep any leftovers.
+  Delete "$INSTDIR\obs-plugins\64bit\avcodec-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avdevice-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avfilter-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avformat-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\avutil-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\swresample-*.dll"
+  Delete "$INSTDIR\obs-plugins\64bit\swscale-*.dll"
+
   SetOutPath "$INSTDIR"
   File /r "${SOURCE_DIR}\*.*"
   Call VerifyInstalledRuntime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1590 @@
+{
+  "name": "corevideo-site",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "corevideo-site",
+      "version": "0.0.0",
+      "devDependencies": {
+        "wrangler": "^4.118.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.19.tgz",
+      "integrity": "sha512-e2KpEP+MOl8QAAUIJCjaQvnAOOvNl1Y5FFg5wTAbaDel+3SbFwGMX6/9mBd3dBmopzHKdUKwVanuVHvvxBaWZQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260730.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260730.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260730.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+        "@cloudflare/workerd-linux-64": "1.20260730.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
+        "@cloudflare/workerd-windows-64": "1.20260730.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.118.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260730.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260730.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260730.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "corevideo-site",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Build and deploy tooling for the corevideo.io static site Worker. Not part of the C++ build.",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "node scripts/build-site.mjs",
+    "dev": "npm run build && wrangler dev",
+    "check": "npm run build && wrangler deploy --dry-run",
+    "deploy": "npm run build && wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "wrangler": "^4.118.0"
+  }
+}

--- a/public/assets/docs-init.js
+++ b/public/assets/docs-init.js
@@ -1,0 +1,46 @@
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      darkMode: true,
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
+  });
+
+  const sections = document.querySelectorAll('section[id]');
+  const navLinks = document.querySelectorAll('#sidebar a');
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        navLinks.forEach(a => a.classList.remove('active'));
+        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
+        if (active) active.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  sections.forEach(s => observer.observe(s));

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -1984,53 +1984,6 @@ sequenceDiagram
   </footer>
 </main>
 
-<script>
-  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
-  // v10 — with theme:'dark' they are silently ignored (that was the source of
-  // the unreadable khaki clusters).
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      darkMode: true,
-      fontSize: '16px',
-      background: '#16191b',
-      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
-      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
-      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
-      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
-      edgeLabelBackground: '#0a0b0c',
-      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
-      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
-      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
-      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
-      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
-      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
-      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
-      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    },
-    // useMaxWidth:false renders every diagram at its natural size — text stays
-    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
-    // instead of shrinking to fit the column.
-    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
-    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
-      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
-    state: { useMaxWidth: false },
-    class: { useMaxWidth: false },
-  });
-
-  const sections = document.querySelectorAll('section[id]');
-  const navLinks = document.querySelectorAll('#sidebar a');
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting) {
-        navLinks.forEach(a => a.classList.remove('active'));
-        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
-        if (active) active.classList.add('active');
-      }
-    });
-  }, { rootMargin: '-20% 0px -70% 0px' });
-  sections.forEach(s => observer.observe(s));
-</script>
+<script src="/assets/docs-init.js"></script>
 </body>
 </html>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -382,6 +382,45 @@
         (details in <a href="#signin">Sign in with Zoom</a> below). That's it — you're ready to use it.</p>
       </div></div>
     </div>
+
+    <h3>Adding CoreVideo to your Zoom account</h3>
+    <p>
+      In Zoom's terms, an app is <strong>added</strong> to your Zoom account the first time you
+      authorize it. There are two equivalent ways to do that:
+    </p>
+    <ul>
+      <li><strong>From OBS (recommended):</strong> click <strong>Sign in with Zoom</strong> in the
+      Zoom Control dock or Tools&nbsp;→&nbsp;Zoom Plugin Settings. Your browser opens Zoom's
+      authorization page; review the requested permissions and click <strong>Allow</strong>.
+      CoreVideo is added to your account automatically and the sign-in completes back in OBS.</li>
+      <li><strong>From the Zoom App Marketplace:</strong> open the
+      <a href="https://marketplace.zoom.us/" target="_blank" rel="noopener">Zoom App Marketplace</a>,
+      search for <strong>CoreVideo</strong>, open the listing, and click <strong>Add</strong>.
+      After you click <strong>Allow</strong> on the permissions screen, install the Windows app
+      (steps above) and sign in — the account authorization is already in place.</li>
+    </ul>
+    <p>
+      Either way, CoreVideo then appears under
+      <a href="https://marketplace.zoom.us/user/installed" target="_blank" rel="noopener">Zoom App Marketplace&nbsp;→&nbsp;Manage&nbsp;→&nbsp;Added Apps</a>,
+      where you can review or <a href="#removing">remove</a> it at any time.
+    </p>
+    <div class="callout info">
+      <div class="callout-title">ℹ️ What you are granting</div>
+      CoreVideo requests only two read-only scopes: <code>user:read:user</code> (your profile /
+      display name) and <code>user:read:token</code> (a short-lived Zoom Access Key used to join
+      meetings as you). It requests no write access, no recording access, and no access to other
+      users' data. Tokens are stored encrypted on your machine — see
+      <a href="#signin">Sign in with Zoom</a>.
+    </div>
+    <div class="callout warning">
+      <div class="callout-title">⚠️ Admin-managed accounts</div>
+      If your organization restricts Marketplace apps, the authorization page may show
+      <strong>Request pre-approval</strong> instead of <strong>Allow</strong>. Send the request (or
+      ask your Zoom admin to approve CoreVideo under
+      <strong>Admin&nbsp;→&nbsp;Advanced&nbsp;→&nbsp;App&nbsp;Marketplace</strong>), then sign in
+      again once it's approved.
+    </div>
+
     <div class="callout info">
       <div class="callout-title">ℹ️ Having trouble?</div>
       See <a href="#troubleshooting">Troubleshooting</a> for installer, dock-not-showing, and sign-in

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -41,18 +41,17 @@
 
     #sidebar {
       position: fixed; top: 52px; left: 0; bottom: 0; width: 260px;
-      background: var(--surface); border-right: 1px solid var(--border);
-      padding: 24px 0; overflow-y: auto; z-index: 100;
+      background: var(--bg); border-right: 1px solid var(--border);
+      padding: 18px 0 32px; overflow-y: auto; z-index: 100;
     }
-    .nav-logo { padding: 0 20px 20px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-    .nav-logo h1 { font-size: 1.1rem; color: var(--accent); font-weight: 700; }
-    .nav-logo p  { font-size: 0.75rem; color: var(--muted); margin-top: 2px; }
     #sidebar a {
-      display: block; padding: 7px 20px; color: var(--muted); text-decoration: none;
-      font-size: 0.95rem; border-left: 2px solid transparent; transition: all 0.15s;
+      display: block; padding: 6px 20px; color: var(--muted); text-decoration: none;
+      font-size: 0.88rem; border-left: 2px solid transparent; transition: color .15s, background .15s, border-color .15s;
     }
-    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.1); }
-    .nav-section { padding: 14px 20px 4px; font-size: 0.78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); }
+    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.08); }
+    .nav-section { padding: 18px 20px 6px; font-family: "IBM Plex Mono", ui-monospace, monospace;
+      font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: .14em; color: #77828a; }
+    .nav-section-first { padding-top: 4px; }
     main { margin-left: 260px; max-width: 960px; padding: 48px 56px; }
     section[id] { scroll-margin-top: 72px; }
 
@@ -116,12 +115,16 @@
     .card h4 { margin: 0 0 6px; font-size: 0.9rem; }
     .card p { font-size: 0.8rem; color: var(--muted); margin: 0; }
 
+    .diagram-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     .diagram-wrap {
       background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
-      padding: 28px; margin: 20px 0; overflow-x: auto;
+      padding: 24px; margin: 20px 0; overflow-x: auto;
     }
-    .diagram-wrap .mermaid { display: flex; justify-content: center; }
-    .diagram-caption { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 12px; font-style: italic; }
+    .diagram-wrap .mermaid { display: flex; justify-content: safe center; min-width: min-content; }
+    .diagram-wrap .mermaid svg { max-width: none; }
+    .diagram-wrap > svg.arch { display: block; width: 100%; height: auto; min-width: 720px; }
+    .diagram-caption { font-size: 0.85rem; color: var(--muted); text-align: center; margin-top: 14px;
+      font-family: "IBM Plex Mono", ui-monospace, monospace; }
 
     table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.875rem; }
     th { background: #16191b; border: 1px solid var(--border); padding: 10px 14px; text-align: left; font-weight: 600; color: var(--muted); }
@@ -146,9 +149,16 @@
 
     section { scroll-margin-top: 24px; }
 
-    @media (max-width: 768px) {
-      #sidebar { display: none; }
-      main { margin-left: 0; padding: 24px 20px; }
+    @media (max-width: 960px) {
+      /* Sidebar becomes a horizontal on-page index instead of disappearing. */
+      #sidebar { position: static; width: auto; bottom: auto; display: flex; align-items: center;
+        overflow-x: auto; white-space: nowrap; padding: 10px 12px; gap: 2px;
+        border-right: none; border-bottom: 1px solid var(--border); }
+      .nav-section { padding: 0 6px 0 14px; }
+      .nav-section-first { padding-left: 6px; }
+      #sidebar a { padding: 6px 10px; border-left: none; border-radius: 6px; font-size: 0.82rem; }
+      #sidebar a:hover, #sidebar a.active { background: rgba(34,200,110,.12); }
+      main { margin-left: 0; padding: 28px 20px; }
       .site-topbar { flex-direction: column; align-items: flex-start; gap: 10px; }
       .site-topbar .topnav { justify-content: flex-start; }
       main > footer { margin-left: 0 !important; }
@@ -173,12 +183,8 @@
   </nav>
 </header>
 
-<nav id="sidebar">
-  <div class="nav-logo">
-    <h1>📹 CoreVideo</h1>
-    <p>OBS Plugin for Live Zoom Video</p>
-  </div>
-  <div class="nav-section">Overview</div>
+<nav id="sidebar" aria-label="On this page">
+  <div class="nav-section nav-section-first">Overview</div>
   <a href="#overview">Introduction</a>
   <a href="#features">Features</a>
   <div class="nav-section">Get Started</div>
@@ -557,65 +563,89 @@
       which feed they subscribe to: a fixed participant, the active speaker, a
       spotlight slot, or the active screen share.
     </p>
-    <div class="diagram-wrap">
-      <div class="mermaid">
-graph TB
-    subgraph Machine["User's Machine"]
-      subgraph OBS["OBS Studio"]
-        Canvas["Canvas / Output"]
-        VSrc["Zoom Participant\nSource"]
-        Canvas --> VSrc
-      end
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
+      <svg class="arch" viewBox="0 0 1140 600" role="img" aria-labelledby="fig1-t fig1-d" xmlns="http://www.w3.org/2000/svg">
+  <title id="fig1-t">CoreVideo system overview</title>
+  <desc id="fig1-d">Zoom Cloud feeds the ZoomObsEngine child process over HTTPS/WSS. The engine owns all Zoom SDK access and writes I420 video and PCM audio into shared memory, which the obs-zoom-plugin reads and hands to OBS Studio sources. Plugin and engine exchange JSON IPC over a named pipe or Unix socket. External controllers reach the plugin over TCP 19870 and OSC 19871.</desc>
+  <defs>
+    <marker id="ar-g" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#22c86e"/></marker>
+    <marker id="ar-n" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#8b949b"/></marker>
+    <marker id="ar-nr" markerWidth="9" markerHeight="8" refX="0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M8,0 L8,6 L0,3 z" fill="#8b949b"/></marker>
+  </defs>
+  <style>
+    .p-title { font: 700 13px "Space Grotesk", sans-serif; letter-spacing: .1em; fill: #e9edef; }
+    .p-tag   { font: 400 9.5px "IBM Plex Mono", monospace; letter-spacing: .06em; fill: #77828a; }
+    .chip    { fill: #1a2025; stroke: #2c343b; }
+    .c-txt   { font: 400 12px "IBM Plex Mono", monospace; fill: #dbe3e8; }
+    .e-lab   { font: 600 11px "IBM Plex Mono", monospace; letter-spacing: .08em; fill: #8b949b; }
+    .e-lab.g { fill: #4fd88f; }
+    .e-sub   { font: 400 10px "IBM Plex Mono", monospace; fill: #6d777d; }
+  </style>
 
-      subgraph Plugin["obs-zoom-plugin  (no SDK dependency)"]
-        ZDock["ZoomDock\n(Control UI · CvStatusDot · CvBanner)"]
-        ZEC["ZoomEngineClient\n★ central singleton"]
-        ZRM["ZoomReconnectManager\n(auto-reconnect)"]
-        ZOAuth["ZoomOAuthManager\n(OAuth broker · ZAK fetch · DPAPI)"]
-        ZS["ZoomSource\n(ShmRegion · AssignmentMode)"]
-        ZOM["ZoomOutputManager"]
-        ZCS["ZoomControlServer :19870"]
-        ZOSC["ZoomOscServer :19871"]
+  <!-- Zoom Cloud -->
+  <rect x="16" y="210" width="160" height="128" rx="12" fill="#10151a" stroke="rgba(188,140,255,.38)" stroke-width="1.5"/>
+  <circle cx="34" cy="234" r="4" fill="#bc8cff"/>
+  <text class="p-title" x="46" y="238">ZOOM CLOUD</text>
+  <text class="p-tag" x="30" y="258">RAW A/V SOURCE</text>
+  <rect class="chip" x="30" y="274" width="132" height="30" rx="7"/>
+  <text class="c-txt" x="42" y="293">Live meeting</text>
 
-        ZDock --> ZEC
-        ZDock --> ZOAuth
-        ZRM --> ZEC
-        ZEC --> ZS
-        ZCS & ZOSC --> ZOM & ZEC
-        ZEC --> ZRM
-        ZOAuth -->|"ZAK + publicAppKey"| ZEC
-      end
+  <!-- Engine -->
+  <rect x="252" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(34,200,110,.5)" stroke-width="1.5"/>
+  <circle cx="270" cy="94" r="4" fill="#22c86e"/>
+  <text class="p-title" x="282" y="98">ZOOMOBSENGINE</text>
+  <text class="p-tag" x="266" y="118">ALL ZOOM SDK ACCESS &#183; CHILD PROCESS</text>
+  <rect class="chip" x="266" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="155">Zoom SDK &#183; auth / meeting / raw</text>
+  <rect class="chip" x="266" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="197">Participant + spotlight tracking</text>
+  <rect class="chip" x="266" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="239">EngineVideo &#8212; I420 &#8594; SHM</text>
+  <rect class="chip" x="266" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="281">EngineAudio &#8212; PCM &#8594; SHM</text>
+  <rect class="chip" x="266" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="323">ISO recorder &#8212; FFmpeg</text>
+  <rect class="chip" x="266" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="365">IPC loop</text>
 
-      subgraph Engine["ZoomObsEngine  (ALL SDK access)"]
-        ELoop["IPC Loop"]
-        EVid["EngineVideo\n(SHM write)"]
-        EAud["EngineAudio\n(SHM write)"]
-        EPart["Participant &amp; Spotlight\ntracking"]
-        SDK["Zoom SDK\nAuth · Meeting · Webinar · Raw data"]
-        ELoop --> EVid & EAud & EPart --> SDK
-      end
+  <!-- Plugin -->
+  <rect x="632" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="650" cy="94" r="4" fill="#e9edef"/>
+  <text class="p-title" x="662" y="98">OBS-ZOOM-PLUGIN</text>
+  <text class="p-tag" x="646" y="118">OBS MODULE &#183; NO SDK DEPENDENCY</text>
+  <rect class="chip" x="646" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="155">ZoomEngineClient &#183; singleton</text>
+  <rect class="chip" x="646" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="197">ZoomSource &#215;N &#8212; SHM read</text>
+  <rect class="chip" x="646" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="239">ZoomDock &#8212; control UI</text>
+  <rect class="chip" x="646" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="281">OAuth manager &#8212; PKCE &#183; ZAK</text>
+  <rect class="chip" x="646" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="323">Output manager &#183; reconnect</text>
+  <rect class="chip" x="646" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="365">Control APIs &#8212; TCP &#183; OSC</text>
 
-      subgraph ZoomCloud["Zoom Cloud"]
-        Mtg["Live Meeting / Webinar"]
-      end
+  <!-- OBS Studio -->
+  <rect x="972" y="199" width="152" height="150" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="990" cy="223" r="4" fill="#e9edef"/>
+  <text class="p-title" x="1002" y="227">OBS STUDIO</text>
+  <rect class="chip" x="986" y="244" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="263">Zoom sources</text>
+  <rect class="chip" x="986" y="286" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="305">Program out</text>
 
-      subgraph External["External Control"]
-        Ctrl["Script / Dashboard"]
-      end
-    end
+  <!-- External control -->
+  <rect x="632" y="506" width="280" height="64" rx="12" fill="#10151a" stroke="rgba(232,164,31,.4)" stroke-width="1.5"/>
+  <circle cx="650" cy="530" r="4" fill="#e8a41f"/>
+  <text class="p-title" x="662" y="534">EXTERNAL CONTROL</text>
+  <text class="p-tag" x="646" y="554">COMPANION &#183; SCRIPTS &#183; CONSOLES</text>
 
-    OBS -->|loads| Plugin
-    VSrc <--> ZS
-    Plugin <-->|"JSON IPC\n(named pipe / Unix socket)"| ELoop
-    EVid & EAud -->|"Named Shared Memory\nI420 frames · PCM audio"| ZS
-    SDK <-->|HTTPS/WSS| Mtg
-    Ctrl <-->|"TCP :19870\nUDP OSC :19871"| ZCS & ZOSC
-    style OBS fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Plugin fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style ZoomCloud fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style External fill:#2d2000,stroke:#d29922,color:#e6edf3
-      </div>
+  <!-- Edges -->
+  <path d="M176,274 L244,274" stroke="#8b949b" stroke-width="2" fill="none" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="210" y="252" text-anchor="middle">HTTPS</text>
+  <text class="e-sub" x="210" y="264" text-anchor="middle">/ WSS</text>
+
+  <path d="M532,250 L624,250" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="582" y="226" text-anchor="middle">SHARED MEMORY</text>
+  <text class="e-sub" x="582" y="240" text-anchor="middle">I420 &#183; PCM</text>
+
+  <path d="M540,340 L624,340" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="582" y="316" text-anchor="middle">JSON IPC</text>
+  <text class="e-sub" x="582" y="330" text-anchor="middle">pipe / socket</text>
+
+  <path d="M912,274 L964,274" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="938" y="258" text-anchor="middle">FRAMES</text>
+
+  <path d="M772,498 L772,478" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-sub" x="786" y="492" text-anchor="start">TCP :19870 &#183; UDP OSC :19871</text>
+</svg>
       <div class="diagram-caption">Fig 1 - All SDK access is in ZoomObsEngine. ZoomOAuthManager handles broker-backed OAuth PKCE, token storage, and ZAK fetches. TCP and OSC provide external control without linking the Zoom SDK into OBS.</div>
     </div>
   </section>
@@ -629,39 +659,26 @@ graph TB
       New additions: <code>ZoomDock</code> (join UI), <code>ZoomReconnectManager</code>
       (auto-reconnect), and <code>HwVideoPipeline</code> (hardware I420→NV12).
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 classDiagram
     class ZoomEngineClient {
         &lt;&lt;Singleton&gt;&gt;
-        +start(auth_token, public_app_key) / stop() / stop_for_reconnect()
-        +join(id, pass, name, kind: MeetingKind)
-        +leave()
-        +subscribe(uuid, pid, isolate_audio)
+        +start() / stop()
+        +join() / leave()
+        +subscribe(uuid, pid)
         +subscribe_spotlight(uuid, slot)
         +subscribe_screenshare(uuid)
-        +unsubscribe(uuid)
-        +state() MeetingState
-        +is_authenticated() bool
-        +active_speaker_id() uint32_t
-        +roster() vector~ParticipantInfo~
+        +state() / roster()
         +register_source(uuid, callbacks)
-        +add_roster_callback(key, cb)
     }
     class ZoomSource {
         +assignment : AssignmentMode
-        +participant_id : atomic~uint32_t~
-        +spotlight_slot : atomic~uint32_t~
-        +failover_participant_id : atomic~uint32_t~
         +resolution : VideoResolution
         +video_loss_mode : VideoLossMode
-        +hw_accel_override : int
-        +speaker_sensitivity_ms, speaker_hold_ms
-        +configure_output_ex(mode, pid, slot, failover, …)
+        +configure_output_ex(...)
         +on_engine_frame(w, h)
-        +on_engine_audio(byte_len)
-        +m_hk_active_on_id, m_hk_active_off_id
-        +m_hw_pipeline : HwVideoPipeline
+        +on_engine_audio(bytes)
     }
     class ZoomOAuthManager {
         &lt;&lt;Singleton&gt;&gt;
@@ -670,29 +687,19 @@ classDiagram
         +register_url_scheme() bool
         +refresh_access_token_blocking() bool
         +fetch_user_zak_blocking(zak) bool
-        -m_pending_state : QString
-        -m_pending_verifier : QString
     }
     class ZoomDock {
         +on_join_clicked()
         +on_leave_clicked()
         +on_cancel_recovery_clicked()
         +update_state_indicator()
-        +update_recovery_panel()
-        +update_credentials_banner()
-        -m_state_dot : CvStatusDot
-        -m_credentials_banner : CvBanner
-        -m_join_token_type : QComboBox
-        -m_output_table : QTableWidget
     }
     class ZoomReconnectManager {
         &lt;&lt;Singleton&gt;&gt;
         +set_policy(policy)
-        +store_session(auth_token, id, pass, name)
-        +trigger(reason: RecoveryReason)
-        +cancel()
-        +on_join_success() / on_join_failed(permanent)
-        +is_recovering() bool
+        +store_session(...)
+        +trigger(reason) / cancel()
+        +on_join_success() / on_join_failed()
         +next_retry_ms() int
     }
     class HwVideoPipeline {
@@ -743,23 +750,17 @@ classDiagram
       All Zoom SDK state (auth, meeting, roster, active speaker) is owned by the
       engine; the client tracks it locally by processing the event stream.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 graph TB
     subgraph Plugin["obs-zoom-plugin process"]
         ZEC["ZoomEngineClient\n★ singleton"]
         Reader["reader_loop()\n(dedicated thread)"]
-        S1["ZoomSource A\n(ShmRegion video+audio)"]
-        S2["ZoomSource B\n(ShmRegion video+audio)"]
+        S1["ZoomSource A"]
+        S2["ZoomSource B"]
         ZEC --> Reader
-        ZEC -->|"on_frame / on_audio callbacks"| S1
-        ZEC -->|"on_frame / on_audio callbacks"| S2
-    end
-
-    subgraph IPC["IPC"]
-        P2E["Plugin → Engine\njson cmds"]
-        E2P["Engine → Plugin\njson events"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        ZEC -->|"frame / audio callbacks"| S1
+        ZEC -->|"frame / audio callbacks"| S2
     end
 
     subgraph Engine["ZoomObsEngine process"]
@@ -768,14 +769,11 @@ graph TB
         SDK3 --- ETrack
     end
 
-    ZEC -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> Engine
-    Engine -- "ready · auth_ok · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> Reader
-    Engine -- "write frames" --> SHM
+    ZEC -- "commands · JSON" --> SDK3
+    SDK3 -- "events · JSON" --> Reader
+    SDK3 -- "frame write" --> SHM["Named shared memory"]
     S1 & S2 -- "mmap read" --> SHM
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 3 — ZoomEngineClient launches the engine, owns IPC channels, and dispatches callbacks to each ZoomSource.</div>
     </div>
@@ -827,35 +825,23 @@ graph TB
       Frame data flows through named shared memory to avoid copying large buffers.
       <code>ZoomEngineClient</code> in the plugin abstracts all IPC details.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-graph LR
+flowchart LR
     subgraph Plugin["obs-zoom-plugin"]
         ZEC2["ZoomEngineClient"]
-        SHM_R["ZoomSource\nShmRegion (mmap read)"]
-    end
-
-    subgraph IPC["IPC Channels"]
-        P2E["Plugin → Engine\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        E2P["Engine → Plugin\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        SHM_R["ZoomSource\nSHM read (mmap)"]
     end
 
     subgraph Engine["ZoomObsEngine"]
-        ELoop["IPC Loop\n+ reader_loop"]
-        EVid["EngineVideo"]
-        EAud["EngineAudio"]
-        SDK2["Zoom SDK\n(all SDK access)"]
-        ELoop --> EVid & EAud --> SDK2
+        ELoop["IPC loop"]
+        EMed["EngineVideo · EngineAudio"]
     end
 
-    ZEC2 -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> ELoop
-    ELoop -- "ready · auth_ok · auth_fail · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> ZEC2
-    EVid & EAud -- "write I420 + PCM" --> SHM --> SHM_R
+    ZEC2 -- "commands · JSON" --> ELoop
+    ELoop -- "events · JSON" --> ZEC2
+    EMed -- "I420 + PCM" --> SHM["Named shared memory"] --> SHM_R
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 4 — Cross-platform IPC: JSON over named pipes (Windows) or Unix sockets (macOS/Linux); frames through shared memory.</div>
     </div>
@@ -868,9 +854,9 @@ graph LR
 
   <section id="arch-video">
     <h2>Architecture: Video Pipeline</h2>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     CAM["Participant\nCamera"] --> ZC["Zoom Cloud"]
     ZC -->|decoded I420| EV["Engine EngineVideo\n(IZoomSDKRenderer)"]
     EV -->|"write I420 to\nShmRegion"| SHM2["Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
@@ -879,14 +865,6 @@ flowchart LR
     ZS5 -->|"VideoLossMode:\nLastFrame / Black"| LOSS["Loss handling"]
     LOSS -->|"I420 planar\nPreviewCallback ≤5fps"| OBS_V["OBS Video\nobs_source_output_video()"]
 
-    style CAM fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EV fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM2 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC3 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZS5 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style LOSS fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style OBS_V fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 5 — Video path: engine writes I420 to shared memory; ZoomSource reads via ShmRegion and forwards to OBS.</div>
     </div>
@@ -910,7 +888,7 @@ flowchart LR
       pushes it to OBS. Stereo sources use an internal <code>m_stereo_buf</code> to
       interleave channels before output.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart TB
     SDK4["Zoom SDK\n(inside engine)"]
@@ -923,10 +901,6 @@ flowchart TB
 
     ZS6 -->|"Mono: direct S16\nStereo: interleaved"| OBS_A["OBS Audio\nobs_source_output_audio()"]
 
-    style SDK4 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EAud2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM3 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZS6 fill:#0d2137,stroke:#22c86e,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 6 — Audio pipeline: engine mixes/isolates audio in-process and delivers chunks through shared memory.</div>
     </div>
@@ -950,9 +924,9 @@ flowchart TB
       <code>frame</code> events on the share source UUID and forwards them to OBS
       exactly like participant video.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     SC2["Screen Share\nIn Meeting"] --> ZC3["Zoom Cloud"]
     ZC3 -->|onSharingStatus| EShare["Engine\nShareDelegate\n(inside ZoomObsEngine)"]
     EShare -->|subscribe share renderer| Rnd["IZoomSDKRenderer"]
@@ -960,12 +934,6 @@ flowchart LR
     SHM4 -->|"frame event"| ZEC4["ZoomEngineClient\n→ ZoomSource (share)"]
     ZEC4 -->|obs_source_output_video| OBS_SS["OBS Zoom\nShare Source"]
 
-    style SC2 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC3 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EShare fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM4 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC4 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style OBS_SS fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 7 — Screen share: engine-side delegate writes I420 to shared memory; plugin receives via ZoomEngineClient frame callback.</div>
     </div>
@@ -982,7 +950,7 @@ flowchart LR
       the helper with <code>AuthContext.publicAppKey</code>. The engine is not
       started on module load; it is launched the first time a join is requested.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant OBS as OBS Studio
@@ -998,7 +966,7 @@ sequenceDiagram
     PM->>ZOA2: load OAuth tokens and broker URL
     PM->>ZoomControlServer: start(control_server_port)
     PM->>ZoomOscServer: start(osc_server_port)
-    PM->>ZDock: ensure_zoom_dock() [after OBS_FRONTEND_EVENT_FINISHED_LOADING]
+    PM->>ZDock: ensure_zoom_dock() after frontend loaded
 
     Note over ZDock: User clicks Join or API sends join cmd
 
@@ -1068,7 +1036,7 @@ sequenceDiagram
     </div>
 
     <h3>Authorization Flow</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant User
@@ -1086,17 +1054,17 @@ sequenceDiagram
     ZOA->>Browser: QDesktopServices::openUrl(/oauth/start?state=…)
     Browser->>Broker2: GET /oauth/start
     Broker2->>Broker2: generate PKCE verifier/challenge
-    Broker2->>ZoomCloud2: redirect to /v2/authorize?client_id=…&code_challenge=…
+    Broker2->>ZoomCloud2: redirect → /v2/authorize (PKCE)
     ZoomCloud2-->>Browser: consent screen
     User->>Browser: approve
     ZoomCloud2-->>Broker2: redirect to /oauth/callback?code=…&state=…
-    Broker2-->>Browser: redirect to corevideo://oauth/callback?broker_token=…&state=…
-    Browser->>Helper: launch CoreVideoOAuthCallback (Windows: .exe / macOS: .app)
-    Helper->>ZCS2: POST {"cmd":"oauth_callback","url":"corevideo://oauth/callback?broker_token=…&state=…"}
+    Broker2-->>Browser: redirect → corevideo://oauth/callback
+    Browser->>Helper: launch CoreVideoOAuthCallback helper
+    Helper->>ZCS2: POST {"cmd":"oauth_callback", url}
     ZCS2->>ZOA: handle_redirect_url(url)
     ZOA->>ZOA: verify state matches m_pending_state
     ZOA->>Broker2: POST /oauth/redeem broker_token=…
-    Broker2->>ZoomCloud2: POST /oauth/token client_id + code_verifier, no secret
+    Broker2->>ZoomCloud2: POST /oauth/token (PKCE, no secret)
     Broker2-->>ZOA: {access_token, refresh_token, expires_in}
     ZOA->>ZOA: store tokens (DPAPI on Windows)
     Note over ZOA: Ready to fetch ZAK on next join
@@ -1105,7 +1073,7 @@ sequenceDiagram
     </div>
 
     <h3>ZAK Fetch and publicAppKey SDK Auth (before each join)</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZDock4 as ZoomDock
@@ -1115,12 +1083,12 @@ sequenceDiagram
     participant ZEC8 as ZoomEngineClient
 
     ZDock4->>ZOA2: fetch_user_zak_blocking(zak)
-    ZOA2->>ZOA2: check token expiry\nrefresh_access_token_blocking() if expired
-    ZOA2->>ZoomAPI: GET /v2/users/me/token?type=zak\nAuthorization: Bearer {access_token}
+    ZOA2->>ZOA2: refresh access token if expired
+    ZOA2->>ZoomAPI: GET /users/me/token?type=zak
     ZoomAPI-->>ZOA2: signed-in user ZAK
     ZOA2-->>ZDock4: zak string
-    ZDock4->>ZEC8: start(public_app_key), then join(id, pass, name, kind, zak)
-    ZEC8->>Engine: {"cmd":"init","public_app_key":"…"} then {"cmd":"join","meeting_id":"…","user_zak":"…"}
+    ZDock4->>ZEC8: start(publicAppKey) → join(…, zak)
+    ZEC8->>Engine: {"cmd":"init"} then {"cmd":"join"}
       </div>
       <div class="diagram-caption">Fig 8c - A user ZAK is fetched before each join using the stored OAuth access token; token refresh is automatic when expired.</div>
     </div>
@@ -1150,7 +1118,7 @@ sequenceDiagram
       Joining is centralized in <code>ZoomDock</code> (or the TCP/OSC control APIs) —
       not in individual sources. Sources subscribe to the already-joined meeting.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant U as User / Control API
@@ -1160,23 +1128,23 @@ sequenceDiagram
     participant ZS3 as ZoomSource
     participant Engine as ZoomObsEngine
 
-    U->>ZDock2: click Join (meeting_id, passcode, display_name, [webinar])
+    U->>ZDock2: click Join
     ZDock2->>ZRM2: store_session(auth_token, id, pass, name)
-    ZDock2->>ZEC6: start(public_app_key) [launches engine if not running]
+    ZDock2->>ZEC6: start() — launch engine if needed
     ZDock2->>ZEC6: join(id, pass, name, kind=Meeting|Webinar)
-    ZEC6->>Engine: {"cmd":"join","meeting_id":"…","kind":"meeting|webinar"}
+    ZEC6->>Engine: {"cmd":"join", kind}
     Engine-->>ZEC6: {"cmd":"joined"}
     ZEC6-->>ZRM2: on_join_success()
 
     Note over ZS3: ZoomSource.activate() when OBS activates source
 
-    ZS3->>ZEC6: subscribe(uuid, pid, isolate) OR subscribe_spotlight(uuid, slot)
-    ZEC6->>Engine: {"cmd":"subscribe","source_uuid":"…","participant_id":N}
+    ZS3->>ZEC6: subscribe() / subscribe_spotlight()
+    ZEC6->>Engine: {"cmd":"subscribe", uuid, pid}
 
     loop Live capture
         Engine-->>ZEC6: {"cmd":"frame","uuid":"…","w":W,"h":H}
         ZEC6-->>ZS3: on_engine_frame(w, h)
-        ZS3->>ZS3: read I420 from video shm, process with HwVideoPipeline if enabled
+        ZS3->>ZS3: read I420 from SHM (+HW pipeline)
         ZS3->>OBS: obs_source_output_video()
         Engine-->>ZEC6: {"cmd":"audio","uuid":"…","byte_len":B}
         ZEC6-->>ZS3: on_engine_audio(byte_len)
@@ -1260,7 +1228,7 @@ sequenceDiagram
       This mirrors the ZoomISO "Spotlight 1/2/3" output model.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart LR
     subgraph Source["ZoomSource (AssignmentMode)"]
@@ -1277,9 +1245,6 @@ flowchart LR
 
     ZEC7 -->|JSON IPC| Engine2["ZoomObsEngine\n(resolves → SDK renderer)"]
 
-    style Source fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZEC7 fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
       </div>
       <div class="diagram-caption">Assignment modes map to different ZoomEngineClient subscribe calls; the engine resolves each to the correct SDK renderer.</div>
     </div>
@@ -1329,7 +1294,7 @@ flowchart LR
       <code>obs_queue_task(OBS_TASK_UI, …)</code> to re-evaluate on the OBS UI thread.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 stateDiagram-v2
     [*] --> Idle : active_speaker_mode = off
@@ -1361,7 +1326,7 @@ stateDiagram-v2
     </div>
 
     <h3>Switch Sequence</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZP as ZoomEngineClient\n(roster_callback)
@@ -1370,8 +1335,8 @@ sequenceDiagram
     participant UI as OBS UI Thread
     participant VD as VideoDelegate
 
-    ZP-->>ZS4: roster callback\n(active_speaker_id from engine event = X)
-    ZS4->>ZS4: on_active_speaker_changed()\npending = X, candidate_since = now
+    ZP-->>ZS4: roster callback: active_speaker = X
+    ZS4->>ZS4: pending = X, start hold timer
 
     alt delay == 0
         ZS4->>ZS4: do_speaker_switch(X)
@@ -1530,7 +1495,7 @@ sequenceDiagram
       position in OBS. It is the primary UI for meeting management.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-obs-workspace.svg" alt="CoreVideo OBS workspace with Zoom Control dock" style="max-width:100%;height:auto;">
       <div class="diagram-caption">CoreVideo runs as normal OBS UI: the Zoom Control dock manages meeting state and raw media while Zoom Participant sources render inside OBS scenes.</div>
     </div>
@@ -1732,7 +1697,7 @@ sequenceDiagram
       <tr><td><code>ZoomOutputProfile::remove(name)</code></td><td>Deletes profile JSON file</td></tr>
     </table>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-output-manager.svg" alt="CoreVideo Output Manager with participant and output mapping" style="max-width:100%;height:auto;">
       <div class="diagram-caption">The Output Manager mirrors the dock assignment controls and remains useful for named profile save/load workflows.</div>
     </div>
@@ -1821,7 +1786,7 @@ sequenceDiagram
     </table>
 
     <h3>Zoom Participant Source Properties</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-source-properties.svg" alt="CoreVideo Zoom Participant source properties" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Each Zoom Participant source keeps its own assignment mode, audio routing, requested resolution, and failover behavior.</div>
     </div>
@@ -1888,7 +1853,7 @@ sequenceDiagram
       state in the panel and TCP status payload.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/iso-recording-flow.svg" alt="CoreVideo ISO recording flow" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Assignments resolve the participant IDs. Each assigned Zoom source can feed an FFmpeg writer for video/audio ISO files while OBS continues to own the program output.</div>
     </div>
@@ -1981,27 +1946,38 @@ sequenceDiagram
 </main>
 
 <script>
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
   mermaid.initialize({
     startOnLoad: true,
-    theme: 'dark',
+    theme: 'base',
     themeVariables: {
       darkMode: true,
-      background: '#0d1117',
-      mainBkg: '#1e2a35', primaryColor: '#1e2a35', primaryTextColor: '#eaf2f6',
-      primaryBorderColor: '#2fd07f', nodeBorder: '#2fd07f',
-      secondaryColor: '#26313c', tertiaryColor: '#1a222b',
-      lineColor: '#aeb7bf', textColor: '#eaf2f6', nodeTextColor: '#eaf2f6',
-      edgeLabelBackground: '#0d1117', clusterBkg: '#161d25', clusterBorder: '#3a4650', titleColor: '#eaf2f6',
-      actorBkg: '#1e2a35', actorBorder: '#2fd07f', actorTextColor: '#ffffff',
-      actorLineColor: '#aeb7bf', signalColor: '#aeb7bf', signalTextColor: '#eaf2f6',
-      noteBkgColor: '#2a3742', noteTextColor: '#eaf2f6', noteBorderColor: '#4a5762',
-      activationBorderColor: '#2fd07f', activationBkgColor: '#183a2a',
-      sequenceNumberColor: '#0d1117', labelBoxBkgColor: '#1e2a35',
-      labelBoxBorderColor: '#4a5762', labelTextColor: '#eaf2f6', loopTextColor: '#eaf2f6',
-      fontFamily: 'Space Grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     },
-    flowchart: { curve: 'basis', htmlLabels: true },
-    sequence: { actorMargin: 60, messageMargin: 30 },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
   });
 
   const sections = document.querySelectorAll('section[id]');

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -233,6 +233,18 @@
       and TCP/OSC control APIs for full broadcast automation.
     </p>
     <div class="callout warning" style="margin-top:18px;">
+      <div class="callout-title">🧪 Beta status</div>
+      CoreVideo is in <strong>public beta</strong>. The supported platform is
+      <strong>Windows x64</strong> (installer or ZIP) — see
+      <a href="https://github.com/iamfatness/CoreVideo/blob/main/docs/ROADMAP.md">the Roadmap</a> for known limitations and what's
+      planned next. To report a problem, use
+      <a href="https://github.com/iamfatness/CoreVideo/issues/new/choose">GitHub Issues</a>
+      (the bug report template walks you through attaching a redacted
+      <a href="#troubleshooting">support bundle</a>). New releases are announced
+      through a dismissible in-app update banner in the Zoom Control dock and on the
+      <a href="https://github.com/iamfatness/CoreVideo/releases">GitHub Releases</a> page.
+    </div>
+    <div class="callout warning" style="margin-top:18px;">
       <div class="callout-title">Zoom Raw Data Bandwidth Planning</div>
       CoreVideo uses Zoom Meeting SDK raw data APIs. Raw data access does not require Enhanced Media by itself,
       but quality and stream count follow Zoom account and app entitlements. Standard accounts are commonly
@@ -240,6 +252,7 @@
       100 Mbps. Plan around 4-6 Mbps per standard 1080p feed.
     </div>
     <div class="hero-badges" style="margin-top:16px;">
+      <span class="badge orange">Public beta</span>
       <span class="badge green">Free</span>
       <span class="badge green">OBS Studio 30+</span>
       <span class="badge orange">Windows installer</span>
@@ -570,16 +583,183 @@
   <!-- ── Troubleshooting ────────────────────────────────────────── -->
   <section id="troubleshooting">
     <h2>Troubleshooting</h2>
+    <div class="callout warning">
+      <div class="callout-title">⚠️ Public beta</div>
+      CoreVideo is in public beta. The Windows installer is not yet code-signed, and
+      the issues below are the ones we expect to see most from new installs. If
+      something isn't covered here, see <a href="#filing-a-bug">Filing a bug</a> below.
+    </div>
     <table>
       <tr><th>Symptom</th><th>Fix</th></tr>
-      <tr><td>Zoom Control dock not visible after install</td><td>Enable it from OBS <strong>Docks&nbsp;→&nbsp;Zoom Control</strong>. Confirm OBS is version 30+ and was fully closed during install.</td></tr>
-      <tr><td>"Sign in with Zoom" doesn't complete</td><td>Finish the browser consent and allow the <code>corevideo://</code> link to open CoreVideo. Re-run sign-in from Tools&nbsp;→&nbsp;Zoom Plugin Settings.</td></tr>
-      <tr><td>Joined, but no video</td><td>Confirm the host admitted "OBS" from the waiting room, the participant has their camera on, and your Zoom account/app entitlements allow raw video (see Requirements).</td></tr>
+      <tr><td>Zoom Control dock not visible after install</td><td>Enable it from OBS <strong>Docks&nbsp;→&nbsp;Zoom Control</strong> (or <strong>Tools&nbsp;→&nbsp;Zoom Control</strong>, which creates and shows it even if you've never opened it before). Confirm OBS is version 30+ and was fully closed during install.</td></tr>
+      <tr><td>"Sign in with Zoom" doesn't complete</td><td>Finish the browser consent and allow the <code>corevideo://</code> link to open CoreVideo. Re-run sign-in from Tools&nbsp;→&nbsp;Zoom Plugin Settings. See <a href="#signin-loop">Sign-in loop</a> below for more.</td></tr>
+      <tr><td>Joined, but no video</td><td>Work through the <a href="#no-video-frames">No video frames</a> checklist below.</td></tr>
       <tr><td>Source shows color bars</td><td>The source isn't subscribed yet — assign a participant or slot in the source properties or the Output Manager.</td></tr>
       <tr><td>Choppy or low-resolution feeds</td><td>Reduce the number of concurrent 1080p feeds or the requested resolution, and check available bandwidth (~4-6 Mbps per 1080p feed).</td></tr>
+      <tr><td>Windows warns "Windows protected your PC" during install</td><td>Expected for the unsigned beta installer — see <a href="#smartscreen">SmartScreen</a> below.</td></tr>
+      <tr><td>Windows Firewall prompts for CoreVideo or ZoomObsEngine</td><td>Both control ports are loopback-only — see <a href="#firewall-prompts">Firewall prompts</a> below.</td></tr>
     </table>
-    <p>Still stuck? Export a redacted support bundle from the <strong>Zoom Diagnostics</strong> dock
-    and contact <a href="/support/">CoreVideo Support</a>.</p>
+
+    <h3 id="smartscreen">Installer blocked by Windows SmartScreen</h3>
+    <p>
+      CoreVideo's beta installer (<code>CoreVideo-Setup.exe</code>) is not yet
+      code-signed, so Windows SmartScreen will show <strong>"Windows protected your
+      PC"</strong> the first time you run it. This is expected during the beta —
+      it does not mean the download is unsafe, but you should still confirm you got
+      the file from <a href="https://corevideo.io/download">corevideo.io/download</a>
+      or the official <a href="https://github.com/iamfatness/CoreVideo/releases">GitHub Releases</a> page.
+    </p>
+    <div class="steps">
+      <div class="step"><div class="step-body">
+        <h4>1. Click "More info"</h4>
+        <p>On the SmartScreen dialog, click <strong>More info</strong>, then
+        <strong>Run anyway</strong>. If you don't see a "More info" link, your
+        organization's policy may be blocking unsigned installers entirely — check
+        with your IT administrator.</p>
+      </div></div>
+      <div class="step"><div class="step-body">
+        <h4>2. (Optional but recommended) Verify the checksum</h4>
+        <p>Every release publishes a matching <code>.sha256</code> file next to the
+        installer and ZIP. Compare it against a local hash before running the
+        installer:</p>
+        <pre tabindex="0"><code>certutil -hashfile CoreVideo-Setup.exe SHA256</code></pre>
+        <p>or, in PowerShell:</p>
+        <pre tabindex="0"><code>Get-FileHash .\CoreVideo-Setup.exe -Algorithm SHA256</code></pre>
+        <p>The result should match the contents of the corresponding
+        <code>.sha256</code> file from the same release.</p>
+      </div></div>
+    </div>
+
+    <h3 id="no-video-frames">"No video frames" checklist</h3>
+    <p>Work through these in order — each one rules out a different stage of the pipeline.</p>
+    <ol>
+      <li><strong>Assignment mode is set.</strong> A newly added Zoom Participant /
+      Spotlight / Screen Share source isn't subscribed to anything until you assign
+      it — in the source properties or the <strong>Zoom Output Manager</strong>
+      dock. An unassigned source shows the color-bar placeholder, not black.</li>
+      <li><strong>The participant actually has their camera on</strong> and has been
+      admitted from the waiting room (or the meeting allows guests). CoreVideo can
+      only capture video a participant is sending.</li>
+      <li><strong>Check requested vs. observed resolution in the Zoom Diagnostics
+      dock.</strong> Open <strong>Docks&nbsp;→&nbsp;Zoom Diagnostics</strong> (or
+      <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) and look at the Outputs
+      table. If <em>Observed</em> stays blank or 0×0 while <em>Requested</em> shows
+      a resolution, the subscription never came up — re-assign the source or click
+      <strong>Refresh</strong>. If observed resolution is consistently lower than
+      requested, that's usually a bandwidth or entitlement ceiling, not a bug.</li>
+      <li><strong>Confirm the engine is actually running.</strong> Every meeting
+      session launches <code>zoom-runtime\ZoomObsEngine.exe</code> as a child
+      process of OBS — all Zoom SDK access happens there, not in the plugin DLL. If
+      it isn't running (check Task Manager, or "Engine running" in a support
+      bundle's <code>summary.txt</code>), the plugin never receives frames.
+      Antivirus software occasionally quarantines or blocks a freshly-installed
+      <code>ZoomObsEngine.exe</code> — check your antivirus's quarantine/history if
+      it's missing.</li>
+      <li><strong>Bandwidth and entitlements.</strong> Your Zoom account and app
+      entitlements bound both quality and stream count: standard accounts are
+      commonly limited to ~30 Mbps incoming video (roughly 4-6 Mbps per 1080p
+      feed), while Enhanced Media / HBM can raise that to ~100 Mbps. If several
+      1080p feeds are requested at once on a standard account, expect some to
+      negotiate down or fail — see <a href="#requirements">Requirements</a>.</li>
+    </ol>
+
+    <h3 id="signin-loop">Sign-in loop / browser doesn't return to OBS</h3>
+    <p>
+      "Sign in with Zoom" opens your browser to Zoom's consent screen and expects
+      the browser to hand control back to CoreVideo afterward through the
+      <code>corevideo://</code> URL scheme. A few different things can break that
+      handoff:
+    </p>
+    <ul>
+      <li><strong>The <code>corevideo://</code> handler isn't registered yet.</strong>
+      CoreVideo registers it automatically the first time you click <strong>Sign in
+      with Zoom</strong>. If a browser prompt asks which app should open a
+      <code>corevideo://</code> link, choose CoreVideo (and "always allow" it) — if
+      you dismiss or block that prompt, the callback has nowhere to go and the
+      browser tab just sits there after you approve access in Zoom.</li>
+      <li><strong>The callback helper didn't launch.</strong> The last hop is a
+      small helper binary, <code>CoreVideoOAuthCallback.exe</code>, which the OS
+      launches for the <code>corevideo://oauth/callback</code> URL and which
+      forwards it to the plugin's local control server as an
+      <code>oauth_callback</code> command. If antivirus software or SmartScreen
+      blocked that helper from running, sign-in will look like it hung after you
+      approved access in the browser. Retry sign-in, and allow the helper if
+      prompted.</li>
+      <li><strong>Admin-managed Zoom account.</strong> If your organization
+      restricts Marketplace apps, the consent screen shows <strong>Request
+      pre-approval</strong> instead of <strong>Allow</strong> — sign-in cannot
+      complete until a Zoom admin approves CoreVideo. See <a href="#adding">Adding
+      CoreVideo to your Zoom account</a> for the pre-approval steps.</li>
+      <li>Whatever the cause, re-running sign-in from <strong>Tools&nbsp;→&nbsp;Zoom
+      Plugin Settings</strong> is safe and starts a fresh authorization attempt.</li>
+    </ul>
+
+    <h3 id="firewall-prompts">Firewall prompts for TCP 19870 / UDP 19871</h3>
+    <div class="callout info">
+      <div class="callout-title">ℹ️ Both ports are loopback-only</div>
+      The <a href="#control-api">TCP control API</a> and <a href="#osc-api">OSC
+      control API</a> both bind to <code>127.0.0.1</code> only — nothing outside
+      your machine can reach either port, regardless of how you answer a Windows
+      Firewall prompt. Windows may still prompt the first time one of these
+      servers binds, because it can't tell in advance that a listener is
+      loopback-restricted.
+    </div>
+    <p>
+      It's safe to <strong>Allow access</strong> on Private networks if you plan to
+      drive CoreVideo from an external control surface (Companion, a lighting
+      console, a custom script) running on the same machine. If you don't use the
+      TCP/OSC APIs, it's equally safe to <strong>Cancel</strong> or deny the
+      prompt — Zoom capture, sources, and sign-in do not depend on either server;
+      only external control does.
+    </p>
+
+    <h3>Zoom Diagnostics / Zoom Output Manager / other docks missing</h3>
+    <p>
+      Every CoreVideo dock — <strong>Zoom Control</strong>, <strong>Zoom
+      Diagnostics</strong>, <strong>Zoom Output Manager</strong>, and <strong>Zoom
+      ISO Recorder</strong> — can be re-shown from OBS's <strong>Docks</strong>
+      menu once it has appeared at least once. The first time, or if you closed it
+      permanently, use the matching item under the <strong>Tools</strong> menu
+      instead (e.g. <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) — the
+      Tools menu items create and show the dock even if OBS has never registered
+      it in the Docks list before.
+    </p>
+
+    <h3>Plugin not loading</h3>
+    <p>If OBS starts normally but none of the Zoom Control / Diagnostics / Output
+    Manager / ISO Recorder menu items or docks appear at all, the plugin itself
+    likely failed to load:</p>
+    <ul>
+      <li><strong>Confirm OBS Studio is 30 or newer</strong> (Help → About). CoreVideo
+      links against OBS 30's plugin API; older OBS builds cannot load it.</li>
+      <li><strong>Check the OBS log</strong> (Help&nbsp;→&nbsp;Log Files&nbsp;→&nbsp;View
+      Current Log) for a module-load failure mentioning
+      <code>obs-zoom-plugin.dll</code>. A missing-DLL style error there most often
+      means a required file didn't get installed alongside OBS — reinstall with
+      OBS fully closed (the installer refuses to proceed if <code>obs64.exe</code>
+      is still running, but a stuck background process can slip past that check).</li>
+      <li><strong>Missing Visual C++ runtime, in rare cases.</strong> CoreVideo's
+      Qt6 and plugin DLLs are built with the same MSVC toolchain as OBS Studio
+      itself, so if OBS runs at all the runtime is normally already present. On an
+      unusually minimal Windows install, installing the latest
+      <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist" target="_blank" rel="noopener">Microsoft Visual C++ x64 Redistributable</a>
+      is a reasonable thing to try if the log shows a generic DLL load failure.</li>
+    </ul>
+
+    <h3 id="filing-a-bug">Filing a bug</h3>
+    <p>
+      Still stuck? Open the <strong>Zoom Diagnostics</strong> dock
+      (<strong>Docks&nbsp;→&nbsp;Zoom Diagnostics</strong>, or
+      <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) and click <strong>Create
+      Support Bundle</strong>. It writes a redacted bundle — SDK keys, secrets,
+      OAuth tokens, and similar credentials are stripped before anything is written
+      to disk — plus a matching <code>.zip</code> under
+      <code>%AppData%\obs-studio\plugin_config\obs-zoom-plugin\support-bundles\</code>.
+      Attach that <code>.zip</code> when you
+      <a href="https://github.com/iamfatness/CoreVideo/issues/new?template=bug_report.yml">file a bug report</a>,
+      or contact <a href="/support/">CoreVideo Support</a> for anything that isn't
+      a clear bug.
+    </p>
   </section>
 
 

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -1984,53 +1984,6 @@ sequenceDiagram
   </footer>
 </main>
 
-<script>
-  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
-  // v10 — with theme:'dark' they are silently ignored (that was the source of
-  // the unreadable khaki clusters).
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      darkMode: true,
-      fontSize: '16px',
-      background: '#16191b',
-      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
-      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
-      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
-      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
-      edgeLabelBackground: '#0a0b0c',
-      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
-      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
-      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
-      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
-      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
-      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
-      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
-      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    },
-    // useMaxWidth:false renders every diagram at its natural size — text stays
-    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
-    // instead of shrinking to fit the column.
-    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
-    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
-      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
-    state: { useMaxWidth: false },
-    class: { useMaxWidth: false },
-  });
-
-  const sections = document.querySelectorAll('section[id]');
-  const navLinks = document.querySelectorAll('#sidebar a');
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting) {
-        navLinks.forEach(a => a.classList.remove('active'));
-        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
-        if (active) active.classList.add('active');
-      }
-    });
-  }, { rootMargin: '-20% 0px -70% 0px' });
-  sections.forEach(s => observer.observe(s));
-</script>
+<script src="/assets/docs-init.js"></script>
 </body>
 </html>

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -382,6 +382,45 @@
         (details in <a href="#signin">Sign in with Zoom</a> below). That's it — you're ready to use it.</p>
       </div></div>
     </div>
+
+    <h3>Adding CoreVideo to your Zoom account</h3>
+    <p>
+      In Zoom's terms, an app is <strong>added</strong> to your Zoom account the first time you
+      authorize it. There are two equivalent ways to do that:
+    </p>
+    <ul>
+      <li><strong>From OBS (recommended):</strong> click <strong>Sign in with Zoom</strong> in the
+      Zoom Control dock or Tools&nbsp;→&nbsp;Zoom Plugin Settings. Your browser opens Zoom's
+      authorization page; review the requested permissions and click <strong>Allow</strong>.
+      CoreVideo is added to your account automatically and the sign-in completes back in OBS.</li>
+      <li><strong>From the Zoom App Marketplace:</strong> open the
+      <a href="https://marketplace.zoom.us/" target="_blank" rel="noopener">Zoom App Marketplace</a>,
+      search for <strong>CoreVideo</strong>, open the listing, and click <strong>Add</strong>.
+      After you click <strong>Allow</strong> on the permissions screen, install the Windows app
+      (steps above) and sign in — the account authorization is already in place.</li>
+    </ul>
+    <p>
+      Either way, CoreVideo then appears under
+      <a href="https://marketplace.zoom.us/user/installed" target="_blank" rel="noopener">Zoom App Marketplace&nbsp;→&nbsp;Manage&nbsp;→&nbsp;Added Apps</a>,
+      where you can review or <a href="#removing">remove</a> it at any time.
+    </p>
+    <div class="callout info">
+      <div class="callout-title">ℹ️ What you are granting</div>
+      CoreVideo requests only two read-only scopes: <code>user:read:user</code> (your profile /
+      display name) and <code>user:read:token</code> (a short-lived Zoom Access Key used to join
+      meetings as you). It requests no write access, no recording access, and no access to other
+      users' data. Tokens are stored encrypted on your machine — see
+      <a href="#signin">Sign in with Zoom</a>.
+    </div>
+    <div class="callout warning">
+      <div class="callout-title">⚠️ Admin-managed accounts</div>
+      If your organization restricts Marketplace apps, the authorization page may show
+      <strong>Request pre-approval</strong> instead of <strong>Allow</strong>. Send the request (or
+      ask your Zoom admin to approve CoreVideo under
+      <strong>Admin&nbsp;→&nbsp;Advanced&nbsp;→&nbsp;App&nbsp;Marketplace</strong>), then sign in
+      again once it's approved.
+    </div>
+
     <div class="callout info">
       <div class="callout-title">ℹ️ Having trouble?</div>
       See <a href="#troubleshooting">Troubleshooting</a> for installer, dock-not-showing, and sign-in

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -41,18 +41,17 @@
 
     #sidebar {
       position: fixed; top: 52px; left: 0; bottom: 0; width: 260px;
-      background: var(--surface); border-right: 1px solid var(--border);
-      padding: 24px 0; overflow-y: auto; z-index: 100;
+      background: var(--bg); border-right: 1px solid var(--border);
+      padding: 18px 0 32px; overflow-y: auto; z-index: 100;
     }
-    .nav-logo { padding: 0 20px 20px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-    .nav-logo h1 { font-size: 1.1rem; color: var(--accent); font-weight: 700; }
-    .nav-logo p  { font-size: 0.75rem; color: var(--muted); margin-top: 2px; }
     #sidebar a {
-      display: block; padding: 7px 20px; color: var(--muted); text-decoration: none;
-      font-size: 0.95rem; border-left: 2px solid transparent; transition: all 0.15s;
+      display: block; padding: 6px 20px; color: var(--muted); text-decoration: none;
+      font-size: 0.88rem; border-left: 2px solid transparent; transition: color .15s, background .15s, border-color .15s;
     }
-    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.1); }
-    .nav-section { padding: 14px 20px 4px; font-size: 0.78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); }
+    #sidebar a:hover, #sidebar a.active { color: var(--text); border-left-color: var(--accent); background: rgba(34,200,110,.08); }
+    .nav-section { padding: 18px 20px 6px; font-family: "IBM Plex Mono", ui-monospace, monospace;
+      font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: .14em; color: #77828a; }
+    .nav-section-first { padding-top: 4px; }
     main { margin-left: 260px; max-width: 960px; padding: 48px 56px; }
     section[id] { scroll-margin-top: 72px; }
 
@@ -116,12 +115,16 @@
     .card h4 { margin: 0 0 6px; font-size: 0.9rem; }
     .card p { font-size: 0.8rem; color: var(--muted); margin: 0; }
 
+    .diagram-wrap:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     .diagram-wrap {
       background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
-      padding: 28px; margin: 20px 0; overflow-x: auto;
+      padding: 24px; margin: 20px 0; overflow-x: auto;
     }
-    .diagram-wrap .mermaid { display: flex; justify-content: center; }
-    .diagram-caption { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 12px; font-style: italic; }
+    .diagram-wrap .mermaid { display: flex; justify-content: safe center; min-width: min-content; }
+    .diagram-wrap .mermaid svg { max-width: none; }
+    .diagram-wrap > svg.arch { display: block; width: 100%; height: auto; min-width: 720px; }
+    .diagram-caption { font-size: 0.85rem; color: var(--muted); text-align: center; margin-top: 14px;
+      font-family: "IBM Plex Mono", ui-monospace, monospace; }
 
     table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 0.875rem; }
     th { background: #16191b; border: 1px solid var(--border); padding: 10px 14px; text-align: left; font-weight: 600; color: var(--muted); }
@@ -146,9 +149,16 @@
 
     section { scroll-margin-top: 24px; }
 
-    @media (max-width: 768px) {
-      #sidebar { display: none; }
-      main { margin-left: 0; padding: 24px 20px; }
+    @media (max-width: 960px) {
+      /* Sidebar becomes a horizontal on-page index instead of disappearing. */
+      #sidebar { position: static; width: auto; bottom: auto; display: flex; align-items: center;
+        overflow-x: auto; white-space: nowrap; padding: 10px 12px; gap: 2px;
+        border-right: none; border-bottom: 1px solid var(--border); }
+      .nav-section { padding: 0 6px 0 14px; }
+      .nav-section-first { padding-left: 6px; }
+      #sidebar a { padding: 6px 10px; border-left: none; border-radius: 6px; font-size: 0.82rem; }
+      #sidebar a:hover, #sidebar a.active { background: rgba(34,200,110,.12); }
+      main { margin-left: 0; padding: 28px 20px; }
       .site-topbar { flex-direction: column; align-items: flex-start; gap: 10px; }
       .site-topbar .topnav { justify-content: flex-start; }
       main > footer { margin-left: 0 !important; }
@@ -173,12 +183,8 @@
   </nav>
 </header>
 
-<nav id="sidebar">
-  <div class="nav-logo">
-    <h1>📹 CoreVideo</h1>
-    <p>OBS Plugin for Live Zoom Video</p>
-  </div>
-  <div class="nav-section">Overview</div>
+<nav id="sidebar" aria-label="On this page">
+  <div class="nav-section nav-section-first">Overview</div>
   <a href="#overview">Introduction</a>
   <a href="#features">Features</a>
   <div class="nav-section">Get Started</div>
@@ -557,65 +563,89 @@
       which feed they subscribe to: a fixed participant, the active speaker, a
       spotlight slot, or the active screen share.
     </p>
-    <div class="diagram-wrap">
-      <div class="mermaid">
-graph TB
-    subgraph Machine["User's Machine"]
-      subgraph OBS["OBS Studio"]
-        Canvas["Canvas / Output"]
-        VSrc["Zoom Participant\nSource"]
-        Canvas --> VSrc
-      end
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
+      <svg class="arch" viewBox="0 0 1140 600" role="img" aria-labelledby="fig1-t fig1-d" xmlns="http://www.w3.org/2000/svg">
+  <title id="fig1-t">CoreVideo system overview</title>
+  <desc id="fig1-d">Zoom Cloud feeds the ZoomObsEngine child process over HTTPS/WSS. The engine owns all Zoom SDK access and writes I420 video and PCM audio into shared memory, which the obs-zoom-plugin reads and hands to OBS Studio sources. Plugin and engine exchange JSON IPC over a named pipe or Unix socket. External controllers reach the plugin over TCP 19870 and OSC 19871.</desc>
+  <defs>
+    <marker id="ar-g" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#22c86e"/></marker>
+    <marker id="ar-n" markerWidth="9" markerHeight="8" refX="7.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M0,0 L0,6 L8,3 z" fill="#8b949b"/></marker>
+    <marker id="ar-nr" markerWidth="9" markerHeight="8" refX="0.5" refY="3" orient="auto" markerUnits="userSpaceOnUse"><path d="M8,0 L8,6 L0,3 z" fill="#8b949b"/></marker>
+  </defs>
+  <style>
+    .p-title { font: 700 13px "Space Grotesk", sans-serif; letter-spacing: .1em; fill: #e9edef; }
+    .p-tag   { font: 400 9.5px "IBM Plex Mono", monospace; letter-spacing: .06em; fill: #77828a; }
+    .chip    { fill: #1a2025; stroke: #2c343b; }
+    .c-txt   { font: 400 12px "IBM Plex Mono", monospace; fill: #dbe3e8; }
+    .e-lab   { font: 600 11px "IBM Plex Mono", monospace; letter-spacing: .08em; fill: #8b949b; }
+    .e-lab.g { fill: #4fd88f; }
+    .e-sub   { font: 400 10px "IBM Plex Mono", monospace; fill: #6d777d; }
+  </style>
 
-      subgraph Plugin["obs-zoom-plugin  (no SDK dependency)"]
-        ZDock["ZoomDock\n(Control UI · CvStatusDot · CvBanner)"]
-        ZEC["ZoomEngineClient\n★ central singleton"]
-        ZRM["ZoomReconnectManager\n(auto-reconnect)"]
-        ZOAuth["ZoomOAuthManager\n(OAuth broker · ZAK fetch · DPAPI)"]
-        ZS["ZoomSource\n(ShmRegion · AssignmentMode)"]
-        ZOM["ZoomOutputManager"]
-        ZCS["ZoomControlServer :19870"]
-        ZOSC["ZoomOscServer :19871"]
+  <!-- Zoom Cloud -->
+  <rect x="16" y="210" width="160" height="128" rx="12" fill="#10151a" stroke="rgba(188,140,255,.38)" stroke-width="1.5"/>
+  <circle cx="34" cy="234" r="4" fill="#bc8cff"/>
+  <text class="p-title" x="46" y="238">ZOOM CLOUD</text>
+  <text class="p-tag" x="30" y="258">RAW A/V SOURCE</text>
+  <rect class="chip" x="30" y="274" width="132" height="30" rx="7"/>
+  <text class="c-txt" x="42" y="293">Live meeting</text>
 
-        ZDock --> ZEC
-        ZDock --> ZOAuth
-        ZRM --> ZEC
-        ZEC --> ZS
-        ZCS & ZOSC --> ZOM & ZEC
-        ZEC --> ZRM
-        ZOAuth -->|"ZAK + publicAppKey"| ZEC
-      end
+  <!-- Engine -->
+  <rect x="252" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(34,200,110,.5)" stroke-width="1.5"/>
+  <circle cx="270" cy="94" r="4" fill="#22c86e"/>
+  <text class="p-title" x="282" y="98">ZOOMOBSENGINE</text>
+  <text class="p-tag" x="266" y="118">ALL ZOOM SDK ACCESS &#183; CHILD PROCESS</text>
+  <rect class="chip" x="266" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="155">Zoom SDK &#183; auth / meeting / raw</text>
+  <rect class="chip" x="266" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="197">Participant + spotlight tracking</text>
+  <rect class="chip" x="266" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="239">EngineVideo &#8212; I420 &#8594; SHM</text>
+  <rect class="chip" x="266" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="281">EngineAudio &#8212; PCM &#8594; SHM</text>
+  <rect class="chip" x="266" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="323">ISO recorder &#8212; FFmpeg</text>
+  <rect class="chip" x="266" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="278" y="365">IPC loop</text>
 
-      subgraph Engine["ZoomObsEngine  (ALL SDK access)"]
-        ELoop["IPC Loop"]
-        EVid["EngineVideo\n(SHM write)"]
-        EAud["EngineAudio\n(SHM write)"]
-        EPart["Participant &amp; Spotlight\ntracking"]
-        SDK["Zoom SDK\nAuth · Meeting · Webinar · Raw data"]
-        ELoop --> EVid & EAud & EPart --> SDK
-      end
+  <!-- Plugin -->
+  <rect x="632" y="70" width="280" height="400" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="650" cy="94" r="4" fill="#e9edef"/>
+  <text class="p-title" x="662" y="98">OBS-ZOOM-PLUGIN</text>
+  <text class="p-tag" x="646" y="118">OBS MODULE &#183; NO SDK DEPENDENCY</text>
+  <rect class="chip" x="646" y="136" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="155">ZoomEngineClient &#183; singleton</text>
+  <rect class="chip" x="646" y="178" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="197">ZoomSource &#215;N &#8212; SHM read</text>
+  <rect class="chip" x="646" y="220" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="239">ZoomDock &#8212; control UI</text>
+  <rect class="chip" x="646" y="262" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="281">OAuth manager &#8212; PKCE &#183; ZAK</text>
+  <rect class="chip" x="646" y="304" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="323">Output manager &#183; reconnect</text>
+  <rect class="chip" x="646" y="346" width="252" height="30" rx="7"/><text class="c-txt" x="658" y="365">Control APIs &#8212; TCP &#183; OSC</text>
 
-      subgraph ZoomCloud["Zoom Cloud"]
-        Mtg["Live Meeting / Webinar"]
-      end
+  <!-- OBS Studio -->
+  <rect x="972" y="199" width="152" height="150" rx="12" fill="#10151a" stroke="rgba(233,237,239,.22)" stroke-width="1.5"/>
+  <circle cx="990" cy="223" r="4" fill="#e9edef"/>
+  <text class="p-title" x="1002" y="227">OBS STUDIO</text>
+  <rect class="chip" x="986" y="244" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="263">Zoom sources</text>
+  <rect class="chip" x="986" y="286" width="124" height="30" rx="7"/><text class="c-txt" x="998" y="305">Program out</text>
 
-      subgraph External["External Control"]
-        Ctrl["Script / Dashboard"]
-      end
-    end
+  <!-- External control -->
+  <rect x="632" y="506" width="280" height="64" rx="12" fill="#10151a" stroke="rgba(232,164,31,.4)" stroke-width="1.5"/>
+  <circle cx="650" cy="530" r="4" fill="#e8a41f"/>
+  <text class="p-title" x="662" y="534">EXTERNAL CONTROL</text>
+  <text class="p-tag" x="646" y="554">COMPANION &#183; SCRIPTS &#183; CONSOLES</text>
 
-    OBS -->|loads| Plugin
-    VSrc <--> ZS
-    Plugin <-->|"JSON IPC\n(named pipe / Unix socket)"| ELoop
-    EVid & EAud -->|"Named Shared Memory\nI420 frames · PCM audio"| ZS
-    SDK <-->|HTTPS/WSS| Mtg
-    Ctrl <-->|"TCP :19870\nUDP OSC :19871"| ZCS & ZOSC
-    style OBS fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Plugin fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style ZoomCloud fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style External fill:#2d2000,stroke:#d29922,color:#e6edf3
-      </div>
+  <!-- Edges -->
+  <path d="M176,274 L244,274" stroke="#8b949b" stroke-width="2" fill="none" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="210" y="252" text-anchor="middle">HTTPS</text>
+  <text class="e-sub" x="210" y="264" text-anchor="middle">/ WSS</text>
+
+  <path d="M532,250 L624,250" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="582" y="226" text-anchor="middle">SHARED MEMORY</text>
+  <text class="e-sub" x="582" y="240" text-anchor="middle">I420 &#183; PCM</text>
+
+  <path d="M540,340 L624,340" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-lab" x="582" y="316" text-anchor="middle">JSON IPC</text>
+  <text class="e-sub" x="582" y="330" text-anchor="middle">pipe / socket</text>
+
+  <path d="M912,274 L964,274" stroke="#22c86e" stroke-width="3.5" fill="none" marker-end="url(#ar-g)"/>
+  <text class="e-lab g" x="938" y="258" text-anchor="middle">FRAMES</text>
+
+  <path d="M772,498 L772,478" stroke="#8b949b" stroke-width="2" fill="none" marker-start="url(#ar-nr)" marker-end="url(#ar-n)"/>
+  <text class="e-sub" x="786" y="492" text-anchor="start">TCP :19870 &#183; UDP OSC :19871</text>
+</svg>
       <div class="diagram-caption">Fig 1 - All SDK access is in ZoomObsEngine. ZoomOAuthManager handles broker-backed OAuth PKCE, token storage, and ZAK fetches. TCP and OSC provide external control without linking the Zoom SDK into OBS.</div>
     </div>
   </section>
@@ -629,39 +659,26 @@ graph TB
       New additions: <code>ZoomDock</code> (join UI), <code>ZoomReconnectManager</code>
       (auto-reconnect), and <code>HwVideoPipeline</code> (hardware I420→NV12).
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 classDiagram
     class ZoomEngineClient {
         &lt;&lt;Singleton&gt;&gt;
-        +start(auth_token, public_app_key) / stop() / stop_for_reconnect()
-        +join(id, pass, name, kind: MeetingKind)
-        +leave()
-        +subscribe(uuid, pid, isolate_audio)
+        +start() / stop()
+        +join() / leave()
+        +subscribe(uuid, pid)
         +subscribe_spotlight(uuid, slot)
         +subscribe_screenshare(uuid)
-        +unsubscribe(uuid)
-        +state() MeetingState
-        +is_authenticated() bool
-        +active_speaker_id() uint32_t
-        +roster() vector~ParticipantInfo~
+        +state() / roster()
         +register_source(uuid, callbacks)
-        +add_roster_callback(key, cb)
     }
     class ZoomSource {
         +assignment : AssignmentMode
-        +participant_id : atomic~uint32_t~
-        +spotlight_slot : atomic~uint32_t~
-        +failover_participant_id : atomic~uint32_t~
         +resolution : VideoResolution
         +video_loss_mode : VideoLossMode
-        +hw_accel_override : int
-        +speaker_sensitivity_ms, speaker_hold_ms
-        +configure_output_ex(mode, pid, slot, failover, …)
+        +configure_output_ex(...)
         +on_engine_frame(w, h)
-        +on_engine_audio(byte_len)
-        +m_hk_active_on_id, m_hk_active_off_id
-        +m_hw_pipeline : HwVideoPipeline
+        +on_engine_audio(bytes)
     }
     class ZoomOAuthManager {
         &lt;&lt;Singleton&gt;&gt;
@@ -670,29 +687,19 @@ classDiagram
         +register_url_scheme() bool
         +refresh_access_token_blocking() bool
         +fetch_user_zak_blocking(zak) bool
-        -m_pending_state : QString
-        -m_pending_verifier : QString
     }
     class ZoomDock {
         +on_join_clicked()
         +on_leave_clicked()
         +on_cancel_recovery_clicked()
         +update_state_indicator()
-        +update_recovery_panel()
-        +update_credentials_banner()
-        -m_state_dot : CvStatusDot
-        -m_credentials_banner : CvBanner
-        -m_join_token_type : QComboBox
-        -m_output_table : QTableWidget
     }
     class ZoomReconnectManager {
         &lt;&lt;Singleton&gt;&gt;
         +set_policy(policy)
-        +store_session(auth_token, id, pass, name)
-        +trigger(reason: RecoveryReason)
-        +cancel()
-        +on_join_success() / on_join_failed(permanent)
-        +is_recovering() bool
+        +store_session(...)
+        +trigger(reason) / cancel()
+        +on_join_success() / on_join_failed()
         +next_retry_ms() int
     }
     class HwVideoPipeline {
@@ -743,23 +750,17 @@ classDiagram
       All Zoom SDK state (auth, meeting, roster, active speaker) is owned by the
       engine; the client tracks it locally by processing the event stream.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 graph TB
     subgraph Plugin["obs-zoom-plugin process"]
         ZEC["ZoomEngineClient\n★ singleton"]
         Reader["reader_loop()\n(dedicated thread)"]
-        S1["ZoomSource A\n(ShmRegion video+audio)"]
-        S2["ZoomSource B\n(ShmRegion video+audio)"]
+        S1["ZoomSource A"]
+        S2["ZoomSource B"]
         ZEC --> Reader
-        ZEC -->|"on_frame / on_audio callbacks"| S1
-        ZEC -->|"on_frame / on_audio callbacks"| S2
-    end
-
-    subgraph IPC["IPC"]
-        P2E["Plugin → Engine\njson cmds"]
-        E2P["Engine → Plugin\njson events"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        ZEC -->|"frame / audio callbacks"| S1
+        ZEC -->|"frame / audio callbacks"| S2
     end
 
     subgraph Engine["ZoomObsEngine process"]
@@ -768,14 +769,11 @@ graph TB
         SDK3 --- ETrack
     end
 
-    ZEC -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> Engine
-    Engine -- "ready · auth_ok · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> Reader
-    Engine -- "write frames" --> SHM
+    ZEC -- "commands · JSON" --> SDK3
+    SDK3 -- "events · JSON" --> Reader
+    SDK3 -- "frame write" --> SHM["Named shared memory"]
     S1 & S2 -- "mmap read" --> SHM
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 3 — ZoomEngineClient launches the engine, owns IPC channels, and dispatches callbacks to each ZoomSource.</div>
     </div>
@@ -827,35 +825,23 @@ graph TB
       Frame data flows through named shared memory to avoid copying large buffers.
       <code>ZoomEngineClient</code> in the plugin abstracts all IPC details.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-graph LR
+flowchart LR
     subgraph Plugin["obs-zoom-plugin"]
         ZEC2["ZoomEngineClient"]
-        SHM_R["ZoomSource\nShmRegion (mmap read)"]
-    end
-
-    subgraph IPC["IPC Channels"]
-        P2E["Plugin → Engine\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        E2P["Engine → Plugin\nWindows: named pipe\nmacOS/Linux: Unix socket"]
-        SHM["Named Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
+        SHM_R["ZoomSource\nSHM read (mmap)"]
     end
 
     subgraph Engine["ZoomObsEngine"]
-        ELoop["IPC Loop\n+ reader_loop"]
-        EVid["EngineVideo"]
-        EAud["EngineAudio"]
-        SDK2["Zoom SDK\n(all SDK access)"]
-        ELoop --> EVid & EAud --> SDK2
+        ELoop["IPC loop"]
+        EMed["EngineVideo · EngineAudio"]
     end
 
-    ZEC2 -- "init · join · leave · subscribe · unsubscribe · quit" --> P2E --> ELoop
-    ELoop -- "ready · auth_ok · auth_fail · joined · left · frame · audio\nparticipants · active_speaker · error" --> E2P --> ZEC2
-    EVid & EAud -- "write I420 + PCM" --> SHM --> SHM_R
+    ZEC2 -- "commands · JSON" --> ELoop
+    ELoop -- "events · JSON" --> ZEC2
+    EMed -- "I420 + PCM" --> SHM["Named shared memory"] --> SHM_R
 
-    style Plugin fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style Engine fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style IPC fill:#2d1f00,stroke:#d29922,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 4 — Cross-platform IPC: JSON over named pipes (Windows) or Unix sockets (macOS/Linux); frames through shared memory.</div>
     </div>
@@ -868,9 +854,9 @@ graph LR
 
   <section id="arch-video">
     <h2>Architecture: Video Pipeline</h2>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     CAM["Participant\nCamera"] --> ZC["Zoom Cloud"]
     ZC -->|decoded I420| EV["Engine EngineVideo\n(IZoomSDKRenderer)"]
     EV -->|"write I420 to\nShmRegion"| SHM2["Shared Memory\nZoomObsPlugin_&lt;uuid&gt;"]
@@ -879,14 +865,6 @@ flowchart LR
     ZS5 -->|"VideoLossMode:\nLastFrame / Black"| LOSS["Loss handling"]
     LOSS -->|"I420 planar\nPreviewCallback ≤5fps"| OBS_V["OBS Video\nobs_source_output_video()"]
 
-    style CAM fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EV fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM2 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC3 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZS5 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style LOSS fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style OBS_V fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 5 — Video path: engine writes I420 to shared memory; ZoomSource reads via ShmRegion and forwards to OBS.</div>
     </div>
@@ -910,7 +888,7 @@ flowchart LR
       pushes it to OBS. Stereo sources use an internal <code>m_stereo_buf</code> to
       interleave channels before output.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart TB
     SDK4["Zoom SDK\n(inside engine)"]
@@ -923,10 +901,6 @@ flowchart TB
 
     ZS6 -->|"Mono: direct S16\nStereo: interleaved"| OBS_A["OBS Audio\nobs_source_output_audio()"]
 
-    style SDK4 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EAud2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM3 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZS6 fill:#0d2137,stroke:#22c86e,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 6 — Audio pipeline: engine mixes/isolates audio in-process and delivers chunks through shared memory.</div>
     </div>
@@ -950,9 +924,9 @@ flowchart TB
       <code>frame</code> events on the share source UUID and forwards them to OBS
       exactly like participant video.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
-flowchart LR
+flowchart TB
     SC2["Screen Share\nIn Meeting"] --> ZC3["Zoom Cloud"]
     ZC3 -->|onSharingStatus| EShare["Engine\nShareDelegate\n(inside ZoomObsEngine)"]
     EShare -->|subscribe share renderer| Rnd["IZoomSDKRenderer"]
@@ -960,12 +934,6 @@ flowchart LR
     SHM4 -->|"frame event"| ZEC4["ZoomEngineClient\n→ ZoomSource (share)"]
     ZEC4 -->|obs_source_output_video| OBS_SS["OBS Zoom\nShare Source"]
 
-    style SC2 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style ZC3 fill:#2d1a2d,stroke:#bc8cff,color:#e6edf3
-    style EShare fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
-    style SHM4 fill:#2d1f00,stroke:#d29922,color:#e6edf3
-    style ZEC4 fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style OBS_SS fill:#1a2137,stroke:#388bfd,color:#e6edf3
       </div>
       <div class="diagram-caption">Fig 7 — Screen share: engine-side delegate writes I420 to shared memory; plugin receives via ZoomEngineClient frame callback.</div>
     </div>
@@ -982,7 +950,7 @@ flowchart LR
       the helper with <code>AuthContext.publicAppKey</code>. The engine is not
       started on module load; it is launched the first time a join is requested.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant OBS as OBS Studio
@@ -998,7 +966,7 @@ sequenceDiagram
     PM->>ZOA2: load OAuth tokens and broker URL
     PM->>ZoomControlServer: start(control_server_port)
     PM->>ZoomOscServer: start(osc_server_port)
-    PM->>ZDock: ensure_zoom_dock() [after OBS_FRONTEND_EVENT_FINISHED_LOADING]
+    PM->>ZDock: ensure_zoom_dock() after frontend loaded
 
     Note over ZDock: User clicks Join or API sends join cmd
 
@@ -1068,7 +1036,7 @@ sequenceDiagram
     </div>
 
     <h3>Authorization Flow</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant User
@@ -1086,17 +1054,17 @@ sequenceDiagram
     ZOA->>Browser: QDesktopServices::openUrl(/oauth/start?state=…)
     Browser->>Broker2: GET /oauth/start
     Broker2->>Broker2: generate PKCE verifier/challenge
-    Broker2->>ZoomCloud2: redirect to /v2/authorize?client_id=…&code_challenge=…
+    Broker2->>ZoomCloud2: redirect → /v2/authorize (PKCE)
     ZoomCloud2-->>Browser: consent screen
     User->>Browser: approve
     ZoomCloud2-->>Broker2: redirect to /oauth/callback?code=…&state=…
-    Broker2-->>Browser: redirect to corevideo://oauth/callback?broker_token=…&state=…
-    Browser->>Helper: launch CoreVideoOAuthCallback (Windows: .exe / macOS: .app)
-    Helper->>ZCS2: POST {"cmd":"oauth_callback","url":"corevideo://oauth/callback?broker_token=…&state=…"}
+    Broker2-->>Browser: redirect → corevideo://oauth/callback
+    Browser->>Helper: launch CoreVideoOAuthCallback helper
+    Helper->>ZCS2: POST {"cmd":"oauth_callback", url}
     ZCS2->>ZOA: handle_redirect_url(url)
     ZOA->>ZOA: verify state matches m_pending_state
     ZOA->>Broker2: POST /oauth/redeem broker_token=…
-    Broker2->>ZoomCloud2: POST /oauth/token client_id + code_verifier, no secret
+    Broker2->>ZoomCloud2: POST /oauth/token (PKCE, no secret)
     Broker2-->>ZOA: {access_token, refresh_token, expires_in}
     ZOA->>ZOA: store tokens (DPAPI on Windows)
     Note over ZOA: Ready to fetch ZAK on next join
@@ -1105,7 +1073,7 @@ sequenceDiagram
     </div>
 
     <h3>ZAK Fetch and publicAppKey SDK Auth (before each join)</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZDock4 as ZoomDock
@@ -1115,12 +1083,12 @@ sequenceDiagram
     participant ZEC8 as ZoomEngineClient
 
     ZDock4->>ZOA2: fetch_user_zak_blocking(zak)
-    ZOA2->>ZOA2: check token expiry\nrefresh_access_token_blocking() if expired
-    ZOA2->>ZoomAPI: GET /v2/users/me/token?type=zak\nAuthorization: Bearer {access_token}
+    ZOA2->>ZOA2: refresh access token if expired
+    ZOA2->>ZoomAPI: GET /users/me/token?type=zak
     ZoomAPI-->>ZOA2: signed-in user ZAK
     ZOA2-->>ZDock4: zak string
-    ZDock4->>ZEC8: start(public_app_key), then join(id, pass, name, kind, zak)
-    ZEC8->>Engine: {"cmd":"init","public_app_key":"…"} then {"cmd":"join","meeting_id":"…","user_zak":"…"}
+    ZDock4->>ZEC8: start(publicAppKey) → join(…, zak)
+    ZEC8->>Engine: {"cmd":"init"} then {"cmd":"join"}
       </div>
       <div class="diagram-caption">Fig 8c - A user ZAK is fetched before each join using the stored OAuth access token; token refresh is automatic when expired.</div>
     </div>
@@ -1150,7 +1118,7 @@ sequenceDiagram
       Joining is centralized in <code>ZoomDock</code> (or the TCP/OSC control APIs) —
       not in individual sources. Sources subscribe to the already-joined meeting.
     </p>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant U as User / Control API
@@ -1160,23 +1128,23 @@ sequenceDiagram
     participant ZS3 as ZoomSource
     participant Engine as ZoomObsEngine
 
-    U->>ZDock2: click Join (meeting_id, passcode, display_name, [webinar])
+    U->>ZDock2: click Join
     ZDock2->>ZRM2: store_session(auth_token, id, pass, name)
-    ZDock2->>ZEC6: start(public_app_key) [launches engine if not running]
+    ZDock2->>ZEC6: start() — launch engine if needed
     ZDock2->>ZEC6: join(id, pass, name, kind=Meeting|Webinar)
-    ZEC6->>Engine: {"cmd":"join","meeting_id":"…","kind":"meeting|webinar"}
+    ZEC6->>Engine: {"cmd":"join", kind}
     Engine-->>ZEC6: {"cmd":"joined"}
     ZEC6-->>ZRM2: on_join_success()
 
     Note over ZS3: ZoomSource.activate() when OBS activates source
 
-    ZS3->>ZEC6: subscribe(uuid, pid, isolate) OR subscribe_spotlight(uuid, slot)
-    ZEC6->>Engine: {"cmd":"subscribe","source_uuid":"…","participant_id":N}
+    ZS3->>ZEC6: subscribe() / subscribe_spotlight()
+    ZEC6->>Engine: {"cmd":"subscribe", uuid, pid}
 
     loop Live capture
         Engine-->>ZEC6: {"cmd":"frame","uuid":"…","w":W,"h":H}
         ZEC6-->>ZS3: on_engine_frame(w, h)
-        ZS3->>ZS3: read I420 from video shm, process with HwVideoPipeline if enabled
+        ZS3->>ZS3: read I420 from SHM (+HW pipeline)
         ZS3->>OBS: obs_source_output_video()
         Engine-->>ZEC6: {"cmd":"audio","uuid":"…","byte_len":B}
         ZEC6-->>ZS3: on_engine_audio(byte_len)
@@ -1260,7 +1228,7 @@ sequenceDiagram
       This mirrors the ZoomISO "Spotlight 1/2/3" output model.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 flowchart LR
     subgraph Source["ZoomSource (AssignmentMode)"]
@@ -1277,9 +1245,6 @@ flowchart LR
 
     ZEC7 -->|JSON IPC| Engine2["ZoomObsEngine\n(resolves → SDK renderer)"]
 
-    style Source fill:#0d2137,stroke:#22c86e,color:#e6edf3
-    style ZEC7 fill:#1a2332,stroke:#388bfd,color:#e6edf3
-    style Engine2 fill:#1a2d1a,stroke:#3fb950,color:#e6edf3
       </div>
       <div class="diagram-caption">Assignment modes map to different ZoomEngineClient subscribe calls; the engine resolves each to the correct SDK renderer.</div>
     </div>
@@ -1329,7 +1294,7 @@ flowchart LR
       <code>obs_queue_task(OBS_TASK_UI, …)</code> to re-evaluate on the OBS UI thread.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 stateDiagram-v2
     [*] --> Idle : active_speaker_mode = off
@@ -1361,7 +1326,7 @@ stateDiagram-v2
     </div>
 
     <h3>Switch Sequence</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <div class="mermaid">
 sequenceDiagram
     participant ZP as ZoomEngineClient\n(roster_callback)
@@ -1370,8 +1335,8 @@ sequenceDiagram
     participant UI as OBS UI Thread
     participant VD as VideoDelegate
 
-    ZP-->>ZS4: roster callback\n(active_speaker_id from engine event = X)
-    ZS4->>ZS4: on_active_speaker_changed()\npending = X, candidate_since = now
+    ZP-->>ZS4: roster callback: active_speaker = X
+    ZS4->>ZS4: pending = X, start hold timer
 
     alt delay == 0
         ZS4->>ZS4: do_speaker_switch(X)
@@ -1530,7 +1495,7 @@ sequenceDiagram
       position in OBS. It is the primary UI for meeting management.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-obs-workspace.svg" alt="CoreVideo OBS workspace with Zoom Control dock" style="max-width:100%;height:auto;">
       <div class="diagram-caption">CoreVideo runs as normal OBS UI: the Zoom Control dock manages meeting state and raw media while Zoom Participant sources render inside OBS scenes.</div>
     </div>
@@ -1732,7 +1697,7 @@ sequenceDiagram
       <tr><td><code>ZoomOutputProfile::remove(name)</code></td><td>Deletes profile JSON file</td></tr>
     </table>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-output-manager.svg" alt="CoreVideo Output Manager with participant and output mapping" style="max-width:100%;height:auto;">
       <div class="diagram-caption">The Output Manager mirrors the dock assignment controls and remains useful for named profile save/load workflows.</div>
     </div>
@@ -1821,7 +1786,7 @@ sequenceDiagram
     </table>
 
     <h3>Zoom Participant Source Properties</h3>
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/corevideo-source-properties.svg" alt="CoreVideo Zoom Participant source properties" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Each Zoom Participant source keeps its own assignment mode, audio routing, requested resolution, and failover behavior.</div>
     </div>
@@ -1888,7 +1853,7 @@ sequenceDiagram
       state in the panel and TCP status payload.
     </p>
 
-    <div class="diagram-wrap">
+    <div class="diagram-wrap" tabindex="0" role="group" aria-label="Architecture diagram (scrollable)">
       <img src="/core-plugin/images/iso-recording-flow.svg" alt="CoreVideo ISO recording flow" style="max-width:100%;height:auto;">
       <div class="diagram-caption">Assignments resolve the participant IDs. Each assigned Zoom source can feed an FFmpeg writer for video/audio ISO files while OBS continues to own the program output.</div>
     </div>
@@ -1981,27 +1946,38 @@ sequenceDiagram
 </main>
 
 <script>
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
   mermaid.initialize({
     startOnLoad: true,
-    theme: 'dark',
+    theme: 'base',
     themeVariables: {
       darkMode: true,
-      background: '#0d1117',
-      mainBkg: '#1e2a35', primaryColor: '#1e2a35', primaryTextColor: '#eaf2f6',
-      primaryBorderColor: '#2fd07f', nodeBorder: '#2fd07f',
-      secondaryColor: '#26313c', tertiaryColor: '#1a222b',
-      lineColor: '#aeb7bf', textColor: '#eaf2f6', nodeTextColor: '#eaf2f6',
-      edgeLabelBackground: '#0d1117', clusterBkg: '#161d25', clusterBorder: '#3a4650', titleColor: '#eaf2f6',
-      actorBkg: '#1e2a35', actorBorder: '#2fd07f', actorTextColor: '#ffffff',
-      actorLineColor: '#aeb7bf', signalColor: '#aeb7bf', signalTextColor: '#eaf2f6',
-      noteBkgColor: '#2a3742', noteTextColor: '#eaf2f6', noteBorderColor: '#4a5762',
-      activationBorderColor: '#2fd07f', activationBkgColor: '#183a2a',
-      sequenceNumberColor: '#0d1117', labelBoxBkgColor: '#1e2a35',
-      labelBoxBorderColor: '#4a5762', labelTextColor: '#eaf2f6', loopTextColor: '#eaf2f6',
-      fontFamily: 'Space Grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     },
-    flowchart: { curve: 'basis', htmlLabels: true },
-    sequence: { actorMargin: 60, messageMargin: 30 },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
   });
 
   const sections = document.querySelectorAll('section[id]');

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -233,6 +233,18 @@
       and TCP/OSC control APIs for full broadcast automation.
     </p>
     <div class="callout warning" style="margin-top:18px;">
+      <div class="callout-title">🧪 Beta status</div>
+      CoreVideo is in <strong>public beta</strong>. The supported platform is
+      <strong>Windows x64</strong> (installer or ZIP) — see
+      <a href="https://github.com/iamfatness/CoreVideo/blob/main/docs/ROADMAP.md">the Roadmap</a> for known limitations and what's
+      planned next. To report a problem, use
+      <a href="https://github.com/iamfatness/CoreVideo/issues/new/choose">GitHub Issues</a>
+      (the bug report template walks you through attaching a redacted
+      <a href="#troubleshooting">support bundle</a>). New releases are announced
+      through a dismissible in-app update banner in the Zoom Control dock and on the
+      <a href="https://github.com/iamfatness/CoreVideo/releases">GitHub Releases</a> page.
+    </div>
+    <div class="callout warning" style="margin-top:18px;">
       <div class="callout-title">Zoom Raw Data Bandwidth Planning</div>
       CoreVideo uses Zoom Meeting SDK raw data APIs. Raw data access does not require Enhanced Media by itself,
       but quality and stream count follow Zoom account and app entitlements. Standard accounts are commonly
@@ -240,6 +252,7 @@
       100 Mbps. Plan around 4-6 Mbps per standard 1080p feed.
     </div>
     <div class="hero-badges" style="margin-top:16px;">
+      <span class="badge orange">Public beta</span>
       <span class="badge green">Free</span>
       <span class="badge green">OBS Studio 30+</span>
       <span class="badge orange">Windows installer</span>
@@ -570,16 +583,183 @@
   <!-- ── Troubleshooting ────────────────────────────────────────── -->
   <section id="troubleshooting">
     <h2>Troubleshooting</h2>
+    <div class="callout warning">
+      <div class="callout-title">⚠️ Public beta</div>
+      CoreVideo is in public beta. The Windows installer is not yet code-signed, and
+      the issues below are the ones we expect to see most from new installs. If
+      something isn't covered here, see <a href="#filing-a-bug">Filing a bug</a> below.
+    </div>
     <table>
       <tr><th>Symptom</th><th>Fix</th></tr>
-      <tr><td>Zoom Control dock not visible after install</td><td>Enable it from OBS <strong>Docks&nbsp;→&nbsp;Zoom Control</strong>. Confirm OBS is version 30+ and was fully closed during install.</td></tr>
-      <tr><td>"Sign in with Zoom" doesn't complete</td><td>Finish the browser consent and allow the <code>corevideo://</code> link to open CoreVideo. Re-run sign-in from Tools&nbsp;→&nbsp;Zoom Plugin Settings.</td></tr>
-      <tr><td>Joined, but no video</td><td>Confirm the host admitted "OBS" from the waiting room, the participant has their camera on, and your Zoom account/app entitlements allow raw video (see Requirements).</td></tr>
+      <tr><td>Zoom Control dock not visible after install</td><td>Enable it from OBS <strong>Docks&nbsp;→&nbsp;Zoom Control</strong> (or <strong>Tools&nbsp;→&nbsp;Zoom Control</strong>, which creates and shows it even if you've never opened it before). Confirm OBS is version 30+ and was fully closed during install.</td></tr>
+      <tr><td>"Sign in with Zoom" doesn't complete</td><td>Finish the browser consent and allow the <code>corevideo://</code> link to open CoreVideo. Re-run sign-in from Tools&nbsp;→&nbsp;Zoom Plugin Settings. See <a href="#signin-loop">Sign-in loop</a> below for more.</td></tr>
+      <tr><td>Joined, but no video</td><td>Work through the <a href="#no-video-frames">No video frames</a> checklist below.</td></tr>
       <tr><td>Source shows color bars</td><td>The source isn't subscribed yet — assign a participant or slot in the source properties or the Output Manager.</td></tr>
       <tr><td>Choppy or low-resolution feeds</td><td>Reduce the number of concurrent 1080p feeds or the requested resolution, and check available bandwidth (~4-6 Mbps per 1080p feed).</td></tr>
+      <tr><td>Windows warns "Windows protected your PC" during install</td><td>Expected for the unsigned beta installer — see <a href="#smartscreen">SmartScreen</a> below.</td></tr>
+      <tr><td>Windows Firewall prompts for CoreVideo or ZoomObsEngine</td><td>Both control ports are loopback-only — see <a href="#firewall-prompts">Firewall prompts</a> below.</td></tr>
     </table>
-    <p>Still stuck? Export a redacted support bundle from the <strong>Zoom Diagnostics</strong> dock
-    and contact <a href="/support/">CoreVideo Support</a>.</p>
+
+    <h3 id="smartscreen">Installer blocked by Windows SmartScreen</h3>
+    <p>
+      CoreVideo's beta installer (<code>CoreVideo-Setup.exe</code>) is not yet
+      code-signed, so Windows SmartScreen will show <strong>"Windows protected your
+      PC"</strong> the first time you run it. This is expected during the beta —
+      it does not mean the download is unsafe, but you should still confirm you got
+      the file from <a href="https://corevideo.io/download">corevideo.io/download</a>
+      or the official <a href="https://github.com/iamfatness/CoreVideo/releases">GitHub Releases</a> page.
+    </p>
+    <div class="steps">
+      <div class="step"><div class="step-body">
+        <h4>1. Click "More info"</h4>
+        <p>On the SmartScreen dialog, click <strong>More info</strong>, then
+        <strong>Run anyway</strong>. If you don't see a "More info" link, your
+        organization's policy may be blocking unsigned installers entirely — check
+        with your IT administrator.</p>
+      </div></div>
+      <div class="step"><div class="step-body">
+        <h4>2. (Optional but recommended) Verify the checksum</h4>
+        <p>Every release publishes a matching <code>.sha256</code> file next to the
+        installer and ZIP. Compare it against a local hash before running the
+        installer:</p>
+        <pre tabindex="0"><code>certutil -hashfile CoreVideo-Setup.exe SHA256</code></pre>
+        <p>or, in PowerShell:</p>
+        <pre tabindex="0"><code>Get-FileHash .\CoreVideo-Setup.exe -Algorithm SHA256</code></pre>
+        <p>The result should match the contents of the corresponding
+        <code>.sha256</code> file from the same release.</p>
+      </div></div>
+    </div>
+
+    <h3 id="no-video-frames">"No video frames" checklist</h3>
+    <p>Work through these in order — each one rules out a different stage of the pipeline.</p>
+    <ol>
+      <li><strong>Assignment mode is set.</strong> A newly added Zoom Participant /
+      Spotlight / Screen Share source isn't subscribed to anything until you assign
+      it — in the source properties or the <strong>Zoom Output Manager</strong>
+      dock. An unassigned source shows the color-bar placeholder, not black.</li>
+      <li><strong>The participant actually has their camera on</strong> and has been
+      admitted from the waiting room (or the meeting allows guests). CoreVideo can
+      only capture video a participant is sending.</li>
+      <li><strong>Check requested vs. observed resolution in the Zoom Diagnostics
+      dock.</strong> Open <strong>Docks&nbsp;→&nbsp;Zoom Diagnostics</strong> (or
+      <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) and look at the Outputs
+      table. If <em>Observed</em> stays blank or 0×0 while <em>Requested</em> shows
+      a resolution, the subscription never came up — re-assign the source or click
+      <strong>Refresh</strong>. If observed resolution is consistently lower than
+      requested, that's usually a bandwidth or entitlement ceiling, not a bug.</li>
+      <li><strong>Confirm the engine is actually running.</strong> Every meeting
+      session launches <code>zoom-runtime\ZoomObsEngine.exe</code> as a child
+      process of OBS — all Zoom SDK access happens there, not in the plugin DLL. If
+      it isn't running (check Task Manager, or "Engine running" in a support
+      bundle's <code>summary.txt</code>), the plugin never receives frames.
+      Antivirus software occasionally quarantines or blocks a freshly-installed
+      <code>ZoomObsEngine.exe</code> — check your antivirus's quarantine/history if
+      it's missing.</li>
+      <li><strong>Bandwidth and entitlements.</strong> Your Zoom account and app
+      entitlements bound both quality and stream count: standard accounts are
+      commonly limited to ~30 Mbps incoming video (roughly 4-6 Mbps per 1080p
+      feed), while Enhanced Media / HBM can raise that to ~100 Mbps. If several
+      1080p feeds are requested at once on a standard account, expect some to
+      negotiate down or fail — see <a href="#requirements">Requirements</a>.</li>
+    </ol>
+
+    <h3 id="signin-loop">Sign-in loop / browser doesn't return to OBS</h3>
+    <p>
+      "Sign in with Zoom" opens your browser to Zoom's consent screen and expects
+      the browser to hand control back to CoreVideo afterward through the
+      <code>corevideo://</code> URL scheme. A few different things can break that
+      handoff:
+    </p>
+    <ul>
+      <li><strong>The <code>corevideo://</code> handler isn't registered yet.</strong>
+      CoreVideo registers it automatically the first time you click <strong>Sign in
+      with Zoom</strong>. If a browser prompt asks which app should open a
+      <code>corevideo://</code> link, choose CoreVideo (and "always allow" it) — if
+      you dismiss or block that prompt, the callback has nowhere to go and the
+      browser tab just sits there after you approve access in Zoom.</li>
+      <li><strong>The callback helper didn't launch.</strong> The last hop is a
+      small helper binary, <code>CoreVideoOAuthCallback.exe</code>, which the OS
+      launches for the <code>corevideo://oauth/callback</code> URL and which
+      forwards it to the plugin's local control server as an
+      <code>oauth_callback</code> command. If antivirus software or SmartScreen
+      blocked that helper from running, sign-in will look like it hung after you
+      approved access in the browser. Retry sign-in, and allow the helper if
+      prompted.</li>
+      <li><strong>Admin-managed Zoom account.</strong> If your organization
+      restricts Marketplace apps, the consent screen shows <strong>Request
+      pre-approval</strong> instead of <strong>Allow</strong> — sign-in cannot
+      complete until a Zoom admin approves CoreVideo. See <a href="#adding">Adding
+      CoreVideo to your Zoom account</a> for the pre-approval steps.</li>
+      <li>Whatever the cause, re-running sign-in from <strong>Tools&nbsp;→&nbsp;Zoom
+      Plugin Settings</strong> is safe and starts a fresh authorization attempt.</li>
+    </ul>
+
+    <h3 id="firewall-prompts">Firewall prompts for TCP 19870 / UDP 19871</h3>
+    <div class="callout info">
+      <div class="callout-title">ℹ️ Both ports are loopback-only</div>
+      The <a href="#control-api">TCP control API</a> and <a href="#osc-api">OSC
+      control API</a> both bind to <code>127.0.0.1</code> only — nothing outside
+      your machine can reach either port, regardless of how you answer a Windows
+      Firewall prompt. Windows may still prompt the first time one of these
+      servers binds, because it can't tell in advance that a listener is
+      loopback-restricted.
+    </div>
+    <p>
+      It's safe to <strong>Allow access</strong> on Private networks if you plan to
+      drive CoreVideo from an external control surface (Companion, a lighting
+      console, a custom script) running on the same machine. If you don't use the
+      TCP/OSC APIs, it's equally safe to <strong>Cancel</strong> or deny the
+      prompt — Zoom capture, sources, and sign-in do not depend on either server;
+      only external control does.
+    </p>
+
+    <h3>Zoom Diagnostics / Zoom Output Manager / other docks missing</h3>
+    <p>
+      Every CoreVideo dock — <strong>Zoom Control</strong>, <strong>Zoom
+      Diagnostics</strong>, <strong>Zoom Output Manager</strong>, and <strong>Zoom
+      ISO Recorder</strong> — can be re-shown from OBS's <strong>Docks</strong>
+      menu once it has appeared at least once. The first time, or if you closed it
+      permanently, use the matching item under the <strong>Tools</strong> menu
+      instead (e.g. <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) — the
+      Tools menu items create and show the dock even if OBS has never registered
+      it in the Docks list before.
+    </p>
+
+    <h3>Plugin not loading</h3>
+    <p>If OBS starts normally but none of the Zoom Control / Diagnostics / Output
+    Manager / ISO Recorder menu items or docks appear at all, the plugin itself
+    likely failed to load:</p>
+    <ul>
+      <li><strong>Confirm OBS Studio is 30 or newer</strong> (Help → About). CoreVideo
+      links against OBS 30's plugin API; older OBS builds cannot load it.</li>
+      <li><strong>Check the OBS log</strong> (Help&nbsp;→&nbsp;Log Files&nbsp;→&nbsp;View
+      Current Log) for a module-load failure mentioning
+      <code>obs-zoom-plugin.dll</code>. A missing-DLL style error there most often
+      means a required file didn't get installed alongside OBS — reinstall with
+      OBS fully closed (the installer refuses to proceed if <code>obs64.exe</code>
+      is still running, but a stuck background process can slip past that check).</li>
+      <li><strong>Missing Visual C++ runtime, in rare cases.</strong> CoreVideo's
+      Qt6 and plugin DLLs are built with the same MSVC toolchain as OBS Studio
+      itself, so if OBS runs at all the runtime is normally already present. On an
+      unusually minimal Windows install, installing the latest
+      <a href="https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist" target="_blank" rel="noopener">Microsoft Visual C++ x64 Redistributable</a>
+      is a reasonable thing to try if the log shows a generic DLL load failure.</li>
+    </ul>
+
+    <h3 id="filing-a-bug">Filing a bug</h3>
+    <p>
+      Still stuck? Open the <strong>Zoom Diagnostics</strong> dock
+      (<strong>Docks&nbsp;→&nbsp;Zoom Diagnostics</strong>, or
+      <strong>Tools&nbsp;→&nbsp;Zoom Diagnostics</strong>) and click <strong>Create
+      Support Bundle</strong>. It writes a redacted bundle — SDK keys, secrets,
+      OAuth tokens, and similar credentials are stripped before anything is written
+      to disk — plus a matching <code>.zip</code> under
+      <code>%AppData%\obs-studio\plugin_config\obs-zoom-plugin\support-bundles\</code>.
+      Attach that <code>.zip</code> when you
+      <a href="https://github.com/iamfatness/CoreVideo/issues/new?template=bug_report.yml">file a bug report</a>,
+      or contact <a href="/support/">CoreVideo Support</a> for anything that isn't
+      a clear bug.
+    </p>
   </section>
 
 

--- a/scripts/New-DelayImportLib.ps1
+++ b/scripts/New-DelayImportLib.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+Regenerates an MSVC short-format import library from a DLL's export table.
+
+The prebuilt FFmpeg import libraries (C:\ffmpeg\lib\*.lib) are dlltool-style
+long-format archives. MSVC's /DELAYLOAD cannot attribute imports from those
+to their DLL (LNK4199 "no imports found"), which silently leaves the imports
+static. Short-format libraries produced by lib.exe /def work with /DELAYLOAD.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$DllPath,
+    [Parameter(Mandatory = $true)][string]$DumpbinExe,
+    [Parameter(Mandatory = $true)][string]$LibExe,
+    [Parameter(Mandatory = $true)][string]$OutLib
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $DllPath)) { throw "DLL not found: $DllPath" }
+$dllName = Split-Path -Leaf $DllPath
+
+$exports = & $DumpbinExe /NOLOGO /EXPORTS $DllPath
+if ($LASTEXITCODE -ne 0) { throw "dumpbin failed on $DllPath (exit $LASTEXITCODE)" }
+
+# Export rows look like: "  ordinal  hint  RVA       name [= forwarder]"
+$names = @()
+$inTable = $false
+foreach ($line in $exports) {
+    if ($line -match '^\s+ordinal\s+hint\s+RVA\s+name') { $inTable = $true; continue }
+    if (-not $inTable) { continue }
+    if ($line -match '^\s*Summary') { break }
+    if ($line -match '^\s*\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]{8}\s+(\S+)') {
+        $names += $Matches[1]
+    }
+}
+if ($names.Count -eq 0) { throw "No exports parsed from $DllPath" }
+
+$defPath = [System.IO.Path]::ChangeExtension($OutLib, ".def")
+$defLines = @("LIBRARY $dllName", "EXPORTS") + $names
+Set-Content -LiteralPath $defPath -Value $defLines -Encoding ascii
+
+& $LibExe /NOLOGO "/DEF:$defPath" /MACHINE:X64 "/OUT:$OutLib"
+if ($LASTEXITCODE -ne 0) { throw "lib.exe failed for $OutLib (exit $LASTEXITCODE)" }
+
+Write-Host "Generated $OutLib ($($names.Count) exports from $dllName)"

--- a/scripts/New-PrivateFfmpeg.ps1
+++ b/scripts/New-PrivateFfmpeg.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+Produces a collision-proof private copy of the FFmpeg shared runtime by
+renaming every DLL to a cv-prefixed name and patching the PE name strings.
+
+OBS bundles FFmpeg under the standard DLL names, and the Windows loader
+dedups loaded modules by base name — so a plugin can never keep its own
+same-named FFmpeg family isolated from OBS's inside one process. Renaming
+gives our runtime globally unique names (the same effect as building FFmpeg
+with --build-suffix, without maintaining a source build).
+
+Each family name is renamed by replacing its first two characters with "cv"
+(avutil-60.dll → cvutil-60.dll, swscale-9.dll → cvscale-9.dll, ...), which
+keeps every string the same length so the import/export tables and their
+string references can be patched in place. Exported function names are not
+touched. The DLLs are unsigned, so no signature is invalidated.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$FfmpegBinDir,
+    [Parameter(Mandatory = $true)][string]$OutDir
+)
+
+$ErrorActionPreference = "Stop"
+
+$families = "avcodec", "avdevice", "avfilter", "avformat", "avutil",
+            "swresample", "swscale"
+$familyPattern = "^(" + ($families -join "|") + ")-\d+\.dll$"
+
+$dlls = @(Get-ChildItem -LiteralPath $FfmpegBinDir -File |
+    Where-Object { $_.Name -match $familyPattern })
+if ($dlls.Count -eq 0) { throw "No FFmpeg family DLLs found in $FfmpegBinDir" }
+
+# Old name -> new name, e.g. avfilter-11.dll -> cvfilter-11.dll (same length).
+$renames = @{}
+foreach ($dll in $dlls) {
+    $renames[$dll.Name] = "cv" + $dll.Name.Substring(2)
+}
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+# Latin-1 round-trips all 256 byte values, so string replacement on the
+# decoded bytes is an exact same-length binary patch.
+$latin1 = [System.Text.Encoding]::GetEncoding(28591)
+
+foreach ($dll in $dlls) {
+    $bytes = [System.IO.File]::ReadAllBytes($dll.FullName)
+    $text = $latin1.GetString($bytes)
+    $patched = 0
+    foreach ($pair in $renames.GetEnumerator()) {
+        $before = $text.Length
+        $text = $text.Replace($pair.Key, $pair.Value)
+        if ($text.Length -ne $before) { throw "Length changed patching $($dll.Name)" }
+        if ($text.Contains($pair.Value)) { $patched++ }
+    }
+    if (-not $text.Contains($renames[$dll.Name])) {
+        throw "Patch failed: $($dll.Name) does not reference its own new name"
+    }
+    $outPath = Join-Path $OutDir $renames[$dll.Name]
+    [System.IO.File]::WriteAllBytes($outPath, $latin1.GetBytes($text))
+    Write-Host "Patched $($dll.Name) -> $($renames[$dll.Name])"
+}
+
+# Sanity: the renamed runtime must actually load, and its dependencies must
+# resolve inside $OutDir (not to any av*-named module). A load failure here
+# means the patch is wrong — fail the build, not the user's OBS.
+$avfilterNew = $renames.Keys | Where-Object { $_ -like "avfilter-*" } |
+    ForEach-Object { $renames[$_] } | Select-Object -First 1
+Add-Type -Namespace CvNative -Name Loader -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("kernel32", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+public static extern System.IntPtr LoadLibraryExW(string path, System.IntPtr file, uint flags);
+[System.Runtime.InteropServices.DllImport("kernel32", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+public static extern System.IntPtr GetModuleHandleW(string name);
+'@
+$LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x100
+$LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x1000
+$handle = [CvNative.Loader]::LoadLibraryExW(
+    (Join-Path $OutDir $avfilterNew), [IntPtr]::Zero,
+    $LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR -bor $LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+if ($handle -eq [IntPtr]::Zero) {
+    throw "Renamed runtime failed to load: $avfilterNew (error $([System.Runtime.InteropServices.Marshal]::GetLastWin32Error()))"
+}
+foreach ($old in $renames.Keys) {
+    if ([CvNative.Loader]::GetModuleHandleW($old) -ne [IntPtr]::Zero) {
+        throw "Isolation broken: original-named module $old got loaded"
+    }
+}
+Write-Host "Load check passed: $avfilterNew loads with no av*/sw*-named modules resident"
+
+$license = Join-Path (Split-Path -Parent $FfmpegBinDir) "LICENSE.txt"
+if (Test-Path -LiteralPath $license) {
+    Copy-Item -LiteralPath $license (Join-Path $OutDir "FFMPEG-LICENSE.txt") -Force
+}
+
+Write-Host "Private FFmpeg runtime ready in $OutDir"

--- a/scripts/Test-CoreVideoPackage.ps1
+++ b/scripts/Test-CoreVideoPackage.ps1
@@ -101,8 +101,18 @@ $ffmpegDlls = @(
     "swresample-6.dll",
     "swscale-9.dll"
 )
+
+# The FFmpeg runtime must never sit loose in obs-plugins\64bit: OBS 32.2+
+# bundles FFmpeg 8 under identical DLL names, and loose copies there stop
+# OBS's own obs-ffmpeg module from loading (breaks OBS outright).
+$looseFfmpeg = @(Get-ChildItem -LiteralPath (Join-Path $root "obs-plugins\64bit") -File -ErrorAction Stop |
+    Where-Object { $_.Name -match '^(avcodec|avdevice|avfilter|avformat|avutil|swresample|swscale)-\d+\.dll$' })
+if ($looseFfmpeg.Count -gt 0) {
+    throw "Release package validation failed. FFmpeg DLLs must live in obs-plugins\64bit\corevideo-ffmpeg, not loose in obs-plugins\64bit: $($looseFfmpeg.Name -join ', ')"
+}
+
 $ffmpegPresent = $ffmpegDlls | Where-Object {
-    Test-Path -LiteralPath (Join-Path $root "obs-plugins\64bit\$_")
+    Test-Path -LiteralPath (Join-Path $root "obs-plugins\64bit\corevideo-ffmpeg\$_")
 }
 if ($ffmpegPresent.Count -gt 0 -and $ffmpegPresent.Count -ne $ffmpegDlls.Count) {
     throw "Release package has a partial FFmpeg runtime. Present: $($ffmpegPresent -join ', ')"

--- a/scripts/Test-CoreVideoPackage.ps1
+++ b/scripts/Test-CoreVideoPackage.ps1
@@ -92,23 +92,31 @@ foreach ($forbidden in @($ForbiddenBinaryText | Where-Object { $_ })) {
     }
 }
 
+# The runtime ships renamed (cv* — see New-PrivateFfmpeg.ps1) so it can
+# never collide with the FFmpeg OBS bundles under the standard names.
 $ffmpegDlls = @(
-    "avcodec-62.dll",
-    "avdevice-62.dll",
-    "avfilter-11.dll",
-    "avformat-62.dll",
-    "avutil-60.dll",
-    "swresample-6.dll",
-    "swscale-9.dll"
+    "cvcodec-62.dll",
+    "cvdevice-62.dll",
+    "cvfilter-11.dll",
+    "cvformat-62.dll",
+    "cvutil-60.dll",
+    "cvresample-6.dll",
+    "cvscale-9.dll"
 )
 
-# The FFmpeg runtime must never sit loose in obs-plugins\64bit: OBS 32.2+
-# bundles FFmpeg 8 under identical DLL names, and loose copies there stop
-# OBS's own obs-ffmpeg module from loading (breaks OBS outright).
+# No FFmpeg runtime may sit loose in obs-plugins\64bit: OBS 32.2+ bundles
+# FFmpeg 8 under the standard names, and loose copies there stop OBS's own
+# obs-ffmpeg module from loading (breaks OBS outright). Original-named DLLs
+# must not appear anywhere in the package at all.
 $looseFfmpeg = @(Get-ChildItem -LiteralPath (Join-Path $root "obs-plugins\64bit") -File -ErrorAction Stop |
-    Where-Object { $_.Name -match '^(avcodec|avdevice|avfilter|avformat|avutil|swresample|swscale)-\d+\.dll$' })
+    Where-Object { $_.Name -match '^(avcodec|avdevice|avfilter|avformat|avutil|swresample|swscale|cvcodec|cvdevice|cvfilter|cvformat|cvutil|cvresample|cvscale)-\d+\.dll$' })
 if ($looseFfmpeg.Count -gt 0) {
     throw "Release package validation failed. FFmpeg DLLs must live in obs-plugins\64bit\corevideo-ffmpeg, not loose in obs-plugins\64bit: $($looseFfmpeg.Name -join ', ')"
+}
+$originalNamed = @(Get-ChildItem -LiteralPath (Join-Path $root "obs-plugins\64bit") -Recurse -File -ErrorAction Stop |
+    Where-Object { $_.Name -match '^(avcodec|avdevice|avfilter|avformat|avutil|swresample|swscale)-\d+\.dll$' })
+if ($originalNamed.Count -gt 0) {
+    throw "Release package validation failed. Original-named FFmpeg DLLs found (must be cv*-renamed): $($originalNamed.FullName -join ', ')"
 }
 
 $ffmpegPresent = $ffmpegDlls | Where-Object {

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -740,6 +740,7 @@ const docsHtml = fs.readFileSync(path.join(docsDir, "index.html"), "utf8")
     : "CoreVideo documentation")
   .replaceAll("https://iamfatness.github.io/CoreVideo/", "/documentation/")
   .replaceAll('href="ZOOM_MARKETPLACE_OAUTH.md"', 'href="https://github.com/iamfatness/CoreVideo/blob/main/docs/ZOOM_MARKETPLACE_OAUTH.md"')
+  .replaceAll('href="ROADMAP.md"', 'href="https://github.com/iamfatness/CoreVideo/blob/main/docs/ROADMAP.md"')
   .replaceAll("<pre>", '<pre tabindex="0">')
   .replace(
     "</head>",

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -753,6 +753,15 @@ writeText(
   fs.readFileSync(path.join(siteAssetsDir, "site.css"), "utf8"),
 );
 
+// Docs-page script (mermaid theme init + sidebar highlighting). Must be an
+// external self-hosted file: the worker's CSP has script-src 'self' + jsdelivr
+// with no 'unsafe-inline', so inline scripts are silently blocked in
+// production (that is how the mermaid theme config never applied for months).
+writeText(
+  "assets/docs-init.js",
+  fs.readFileSync(path.join(siteAssetsDir, "docs-init.js"), "utf8"),
+);
+
 // Bundled application fonts (Space Grotesk + IBM Plex Mono), self-hosted so
 // the CSP font-src 'self' policy allows them.
 const fontsSource = path.join(siteAssetsDir, "fonts");
@@ -777,5 +786,25 @@ writeText("_redirects", `/terms-of-use /terms/ 301
 /oauth/ /documentation/#flow-oauth 301
 `);
 writeText("CNAME", "corevideo.io\n");
+
+// Guard: the production CSP blocks inline scripts, so any inline <script> in
+// built HTML is a page that will silently misbehave in production only.
+// Fail the build loudly instead.
+function findHtmlFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(dir, e.name);
+    return e.isDirectory() ? findHtmlFiles(p) : e.name.endsWith(".html") ? [p] : [];
+  });
+}
+const inlineOffenders = findHtmlFiles(outDir).filter((f) =>
+  /<script(?![^>]*src=)[^>]*>/i.test(fs.readFileSync(f, "utf8")),
+);
+if (inlineOffenders.length) {
+  const list = inlineOffenders.map((f) => path.relative(outDir, f)).join(", ");
+  throw new Error(
+    `Inline <script> blocked by the production CSP found in: ${list}. ` +
+      "Move the code into an external file under assets/ instead.",
+  );
+}
 
 console.log(`Built CoreVideo site in ${path.relative(root, outDir)}`);

--- a/scripts/make-macos-bundle.sh
+++ b/scripts/make-macos-bundle.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Assemble the loadable macOS OBS plugin bundle.
+#
+# The repo's install() rules produce the Windows layout (obs-plugins/64bit +
+# data/obs-plugins/...), which macOS OBS cannot load: it wants a .plugin bundle
+# whose Contents/MacOS holds the module. This script builds that bundle, and is
+# the single place that knows the macOS-specific runtime fixups. Assembling it
+# by hand is how the Qt double-load and missing-TLS-backend problems kept
+# reappearing.
+#
+# Usage:
+#   scripts/make-macos-bundle.sh --build-dir build [options]
+#
+#   --build-dir DIR   CMake build directory (required)
+#   --out DIR         Where to write the .plugin (default: <build-dir>)
+#   --qt-prefix DIR   Qt prefix supplying the TLS backends (default: auto)
+#   --obs-app PATH    OBS.app to resolve Qt against (default: /Applications/OBS.app)
+#   --install         Also copy into ~/Library/Application Support/obs-studio/plugins
+#   --sign IDENTITY   codesign identity (default: "-", ad-hoc)
+#
+# Ad-hoc signing is fine for local runs. A distributable build needs a Developer
+# ID identity plus notarization, which this script does not do.
+
+set -euo pipefail
+
+BUNDLE_NAME="obs-zoom-plugin.plugin"
+BUILD_DIR=""
+OUT_DIR=""
+QT_PREFIX=""
+OBS_APP="/Applications/OBS.app"
+DO_INSTALL=0
+SIGN_ID="-"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        --out)       OUT_DIR="$2";   shift 2 ;;
+        --qt-prefix) QT_PREFIX="$2"; shift 2 ;;
+        --obs-app)   OBS_APP="$2";   shift 2 ;;
+        --sign)      SIGN_ID="$2";   shift 2 ;;
+        --install)   DO_INSTALL=1;   shift ;;
+        -h|--help)   sed -n '2,25p' "$0"; exit 0 ;;
+        *) echo "error: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$BUILD_DIR" ] || { echo "error: --build-dir is required" >&2; exit 2; }
+[ -d "$BUILD_DIR" ] || { echo "error: build dir '$BUILD_DIR' does not exist" >&2; exit 2; }
+OUT_DIR="${OUT_DIR:-$BUILD_DIR}"
+SRC_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+MODULE="$BUILD_DIR/obs-zoom-plugin.so"
+[ -f "$MODULE" ] || { echo "error: $MODULE not found; build first" >&2; exit 1; }
+
+OBS_FRAMEWORKS="$OBS_APP/Contents/Frameworks"
+[ -d "$OBS_FRAMEWORKS" ] || {
+    echo "error: $OBS_FRAMEWORKS not found; pass --obs-app" >&2; exit 1; }
+
+# Qt prefix: only needed for the TLS backends. Derive it from the module's own
+# rpath when not given, since that is the Qt this build linked against.
+if [ -z "$QT_PREFIX" ]; then
+    for rp in $(otool -l "$MODULE" | awk '/LC_RPATH/{f=1} f&&/path /{print $2; f=0}'); do
+        if [ -d "$rp/../plugins/tls" ]; then QT_PREFIX="$(cd "$rp/.." && pwd)"; break; fi
+    done
+fi
+
+BUNDLE="$OUT_DIR/$BUNDLE_NAME"
+rm -rf "$BUNDLE"
+mkdir -p "$BUNDLE/Contents/MacOS" "$BUNDLE/Contents/Resources"
+
+VERSION="$(sed -n 's/^#define[[:space:]]*OBS_ZOOM_PLUGIN_VERSION[[:space:]]*"\([^"]*\)".*/\1/p' \
+    "$BUILD_DIR/obs-zoom-version.h" 2>/dev/null | head -1)"
+VERSION="${VERSION:-0.0.0}"
+
+cat > "$BUNDLE/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key><string>en</string>
+    <key>CFBundleExecutable</key><string>obs-zoom-plugin</string>
+    <key>CFBundleIdentifier</key><string>us.iamfatness.corevideo.obs-zoom-plugin</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>obs-zoom-plugin</string>
+    <key>CFBundlePackageType</key><string>BNDL</string>
+    <key>CFBundleShortVersionString</key><string>$VERSION</string>
+    <key>CFBundleVersion</key><string>$VERSION</string>
+    <key>LSMinimumSystemVersion</key><string>12.0</string>
+</dict>
+</plist>
+PLIST
+
+cp "$MODULE" "$BUNDLE/Contents/MacOS/obs-zoom-plugin"
+[ -d "$SRC_DIR/data/locale" ] && cp -R "$SRC_DIR/data/locale" "$BUNDLE/Contents/Resources/"
+
+# The engine and the OAuth helper must sit BESIDE the module: both are resolved
+# relative to the loaded module (dladdr) at runtime.
+[ -f "$BUILD_DIR/ZoomObsEngine" ] && \
+    cp "$BUILD_DIR/ZoomObsEngine" "$BUNDLE/Contents/MacOS/ZoomObsEngine"
+[ -d "$BUILD_DIR/CoreVideoOAuthCallback.app" ] && \
+    ditto "$BUILD_DIR/CoreVideoOAuthCallback.app" \
+          "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app"
+
+# Qt TLS backends. OBS.app bundles Qt but ships no TLS backend at all, so
+# without these every https request fails with "TLS initialization failed".
+# plugin-main.cpp adds Contents/MacOS/plugins to the Qt library paths.
+if [ -n "$QT_PREFIX" ] && [ -d "$QT_PREFIX/plugins/tls" ]; then
+    mkdir -p "$BUNDLE/Contents/MacOS/plugins/tls"
+    for lib in libqsecuretransportbackend.dylib libqcertonlybackend.dylib; do
+        if [ -f "$QT_PREFIX/plugins/tls/$lib" ]; then
+            cp "$QT_PREFIX/plugins/tls/$lib" "$BUNDLE/Contents/MacOS/plugins/tls/"
+        else
+            echo "warning: Qt TLS backend $lib not found; https will fail at runtime" >&2
+        fi
+    done
+else
+    echo "warning: no Qt plugins/tls dir found; https will fail at runtime" >&2
+fi
+
+# Repoint every Qt-linking binary at OBS's own frameworks. Left alone they point
+# at the build machine's Qt, which would load a SECOND Qt runtime into a process
+# that already has OBS's -- duplicate QApplication/meta-object state, i.e. a
+# crash. Replace each existing rpath rather than adding one, so the build Qt is
+# not merely deprioritised but unreachable.
+#
+# Strip every existing rpath and add exactly one. Replacing entries in place is
+# not deterministic when a binary carries several Qt rpaths -- the load-command
+# list shifts under you and you end up with duplicates. Both targets here (the
+# module and the Qt TLS backends) use rpath solely to find Qt, so removing all of
+# them is safe; do not reuse this on a binary that resolves anything else that
+# way.
+repoint_rpaths() {
+    local target="$1" rp
+    while :; do
+        rp="$(otool -l "$target" | awk '/LC_RPATH/{f=1} f&&/path /{print $2; exit}')"
+        [ -n "$rp" ] || break
+        install_name_tool -delete_rpath "$rp" "$target" 2>/dev/null || break
+    done
+    install_name_tool -add_rpath "$OBS_FRAMEWORKS" "$target"
+}
+
+repoint_rpaths "$BUNDLE/Contents/MacOS/obs-zoom-plugin"
+for f in "$BUNDLE/Contents/MacOS/plugins/tls/"*.dylib; do
+    [ -f "$f" ] && repoint_rpaths "$f"
+done
+
+# Sign nested code BEFORE the enclosing bundle: signing the outer bundle seals
+# its contents, so signing anything inside afterwards invalidates that seal.
+for f in "$BUNDLE/Contents/MacOS/plugins/tls/"*.dylib; do
+    [ -f "$f" ] && codesign --force --sign "$SIGN_ID" "$f"
+done
+[ -f "$BUNDLE/Contents/MacOS/ZoomObsEngine" ] && \
+    codesign --force --sign "$SIGN_ID" "$BUNDLE/Contents/MacOS/ZoomObsEngine"
+[ -d "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app" ] && \
+    codesign --force --sign "$SIGN_ID" "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app"
+codesign --force --sign "$SIGN_ID" "$BUNDLE"
+codesign --verify --strict "$BUNDLE"
+
+echo "built: $BUNDLE (version $VERSION)"
+
+if [ "$DO_INSTALL" -eq 1 ]; then
+    DEST="$HOME/Library/Application Support/obs-studio/plugins"
+    if pgrep -x OBS >/dev/null 2>&1; then
+        echo "warning: OBS is running; it will not load the new build until restarted" >&2
+    fi
+    mkdir -p "$DEST"
+    rm -rf "${DEST:?}/$BUNDLE_NAME"
+    ditto "$BUNDLE" "$DEST/$BUNDLE_NAME"
+    echo "installed: $DEST/$BUNDLE_NAME"
+fi

--- a/scripts/make-macos-bundle.sh
+++ b/scripts/make-macos-bundle.sh
@@ -15,6 +15,10 @@
 #   --out DIR         Where to write the .plugin (default: <build-dir>)
 #   --qt-prefix DIR   Qt prefix supplying the TLS backends (default: auto)
 #   --obs-app PATH    OBS.app to resolve Qt against (default: /Applications/OBS.app)
+#   --zoom-sdk DIR    Zoom macOS SDK runtime (default: $ZOOM_SDK_DIR, then
+#                     ~/Developer/zoom-sdk-macos)
+#   --link-sdk        Symlink the SDK into the engine app instead of copying it.
+#                     Fast for local iteration; NOT distributable.
 #   --install         Also copy into ~/Library/Application Support/obs-studio/plugins
 #   --sign IDENTITY   codesign identity (default: "-", ad-hoc)
 #
@@ -28,6 +32,8 @@ BUILD_DIR=""
 OUT_DIR=""
 QT_PREFIX=""
 OBS_APP="/Applications/OBS.app"
+ZOOM_SDK="${ZOOM_SDK_DIR:-$HOME/Developer/zoom-sdk-macos}"
+LINK_SDK=0
 DO_INSTALL=0
 SIGN_ID="-"
 
@@ -37,9 +43,11 @@ while [ $# -gt 0 ]; do
         --out)       OUT_DIR="$2";   shift 2 ;;
         --qt-prefix) QT_PREFIX="$2"; shift 2 ;;
         --obs-app)   OBS_APP="$2";   shift 2 ;;
+        --zoom-sdk)  ZOOM_SDK="$2";  shift 2 ;;
         --sign)      SIGN_ID="$2";   shift 2 ;;
+        --link-sdk)  LINK_SDK=1;     shift ;;
         --install)   DO_INSTALL=1;   shift ;;
-        -h|--help)   sed -n '2,25p' "$0"; exit 0 ;;
+        -h|--help)   sed -n '2,31p' "$0"; exit 0 ;;
         *) echo "error: unknown argument '$1'" >&2; exit 2 ;;
     esac
 done
@@ -95,8 +103,67 @@ cp "$MODULE" "$BUNDLE/Contents/MacOS/obs-zoom-plugin"
 
 # The engine and the OAuth helper must sit BESIDE the module: both are resolved
 # relative to the loaded module (dladdr) at runtime.
-[ -f "$BUILD_DIR/ZoomObsEngine" ] && \
-    cp "$BUILD_DIR/ZoomObsEngine" "$BUNDLE/Contents/MacOS/ZoomObsEngine"
+#
+# The engine ships as an .app, not a loose executable. That is a hard runtime
+# requirement, not tidiness: the macOS Zoom SDK loads its runtime bundles
+# (ssb_sdk, zNet, zPTUIEx, ...) through the MAIN BUNDLE's Frameworks directory.
+# Run the engine as a bare binary and initSDKWithParams still reports success
+# while sdkAuth then fails synchronously with no delegate callback and no
+# explanation. See engine/src/main-macos.mm.
+ENGINE_APP="$BUNDLE/Contents/MacOS/ZoomObsEngine.app"
+if [ -f "$BUILD_DIR/ZoomObsEngine" ]; then
+    mkdir -p "$ENGINE_APP/Contents/MacOS"
+    cp "$BUILD_DIR/ZoomObsEngine" "$ENGINE_APP/Contents/MacOS/ZoomObsEngine"
+    cat > "$ENGINE_APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key><string>en</string>
+    <key>CFBundleExecutable</key><string>ZoomObsEngine</string>
+    <key>CFBundleIdentifier</key><string>us.iamfatness.corevideo.ZoomObsEngine</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>ZoomObsEngine</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleShortVersionString</key><string>$VERSION</string>
+    <key>CFBundleVersion</key><string>$VERSION</string>
+    <key>LSMinimumSystemVersion</key><string>12.0</string>
+    <key>LSUIElement</key><true/>
+    <key>NSCameraUsageDescription</key><string>CoreVideo captures Zoom meeting video for OBS.</string>
+    <key>NSMicrophoneUsageDescription</key><string>CoreVideo captures Zoom meeting audio for OBS.</string>
+</dict>
+</plist>
+PLIST
+
+    if [ -d "$ZOOM_SDK/ZoomSDK.framework" ]; then
+        if [ "$LINK_SDK" -eq 1 ]; then
+            ln -s "$ZOOM_SDK" "$ENGINE_APP/Contents/Frameworks"
+            echo "note: engine SDK is a symlink to $ZOOM_SDK (dev only, not distributable)"
+        else
+            ditto "$ZOOM_SDK" "$ENGINE_APP/Contents/Frameworks"
+        fi
+    else
+        echo "warning: no ZoomSDK.framework under '$ZOOM_SDK'; the engine will" >&2
+        echo "         report sdk_runtime_missing and cannot authenticate." >&2
+        echo "         Pass --zoom-sdk DIR or set ZOOM_SDK_DIR." >&2
+    fi
+
+    # The build tree binary carries an absolute rpath to the developer's SDK
+    # checkout. Leave it in place and the shipped engine silently prefers that
+    # machine-specific path over its own bundled copy, so the bundle would be
+    # untested on every machine but this one.
+    if [ ! -L "$ENGINE_APP/Contents/Frameworks" ]; then
+        while :; do
+            rp="$(otool -l "$ENGINE_APP/Contents/MacOS/ZoomObsEngine" \
+                  | awk '/LC_RPATH/{f=1} f&&/path /{print $2; exit}')"
+            [ -n "$rp" ] || break
+            install_name_tool -delete_rpath "$rp" \
+                "$ENGINE_APP/Contents/MacOS/ZoomObsEngine" 2>/dev/null || break
+        done
+        install_name_tool -add_rpath "@executable_path/../Frameworks" \
+            "$ENGINE_APP/Contents/MacOS/ZoomObsEngine"
+    fi
+fi
 [ -d "$BUILD_DIR/CoreVideoOAuthCallback.app" ] && \
     ditto "$BUILD_DIR/CoreVideoOAuthCallback.app" \
           "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app"
@@ -149,12 +216,18 @@ done
 for f in "$BUNDLE/Contents/MacOS/plugins/tls/"*.dylib; do
     [ -f "$f" ] && codesign --force --sign "$SIGN_ID" "$f"
 done
-[ -f "$BUNDLE/Contents/MacOS/ZoomObsEngine" ] && \
-    codesign --force --sign "$SIGN_ID" "$BUNDLE/Contents/MacOS/ZoomObsEngine"
+[ -d "$ENGINE_APP" ] && \
+    codesign --force --sign "$SIGN_ID" "$ENGINE_APP"
 [ -d "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app" ] && \
     codesign --force --sign "$SIGN_ID" "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app"
 codesign --force --sign "$SIGN_ID" "$BUNDLE"
-codesign --verify --strict "$BUNDLE"
+# A symlinked SDK is deliberately unsealable, so --strict would fail on exactly
+# the builds we know are dev-only. Verify the real thing; say so for the other.
+if [ "$LINK_SDK" -eq 1 ]; then
+    echo "note: skipping codesign --verify --strict (--link-sdk bundle is not sealable)"
+else
+    codesign --verify --strict "$BUNDLE"
+fi
 
 echo "built: $BUNDLE (version $VERSION)"
 

--- a/scripts/make-macos-bundle.sh
+++ b/scripts/make-macos-bundle.sh
@@ -128,7 +128,6 @@ if [ -f "$BUILD_DIR/ZoomObsEngine" ]; then
     <key>CFBundleShortVersionString</key><string>$VERSION</string>
     <key>CFBundleVersion</key><string>$VERSION</string>
     <key>LSMinimumSystemVersion</key><string>12.0</string>
-    <key>LSUIElement</key><true/>
     <key>NSCameraUsageDescription</key><string>CoreVideo captures Zoom meeting video for OBS.</string>
     <key>NSMicrophoneUsageDescription</key><string>CoreVideo captures Zoom meeting audio for OBS.</string>
 </dict>

--- a/scripts/release-local.ps1
+++ b/scripts/release-local.ps1
@@ -369,6 +369,15 @@ try {
         if (-not (Test-Path -LiteralPath $ObsInstallPath)) {
             throw "OBS install path does not exist: $ObsInstallPath"
         }
+        # Pre-v0.1.30 installs left the FFmpeg runtime loose in obs-plugins\64bit,
+        # which collides with OBS 32.2+'s same-named FFmpeg 8 DLLs and stops
+        # OBS's own obs-ffmpeg module from loading. Sweep before copying.
+        $legacyDir = Join-Path $ObsInstallPath "obs-plugins\64bit"
+        if (Test-Path -LiteralPath $legacyDir) {
+            Get-ChildItem -LiteralPath $legacyDir -File |
+                Where-Object { $_.Name -match '^(avcodec|avdevice|avfilter|avformat|avutil|swresample|swscale)-\d+\.dll$' } |
+                Remove-Item -Force
+        }
         Copy-Item -Path (Join-Path $installPath "*") -Destination $ObsInstallPath -Recurse -Force
         & (Join-Path $PSScriptRoot "Test-CoreVideoPackage.ps1") `
             -PackageRoot $ObsInstallPath `

--- a/site-assets/docs-init.js
+++ b/site-assets/docs-init.js
@@ -1,0 +1,46 @@
+  // NOTE: custom themeVariables are only honored with theme:'base' in Mermaid
+  // v10 — with theme:'dark' they are silently ignored (that was the source of
+  // the unreadable khaki clusters).
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      darkMode: true,
+      fontSize: '16px',
+      background: '#16191b',
+      mainBkg: '#1d2327', primaryColor: '#1d2327', primaryTextColor: '#e9edef',
+      primaryBorderColor: '#39434b', nodeBorder: '#39434b',
+      secondaryColor: '#232a2f', tertiaryColor: '#12161a',
+      lineColor: '#8b949b', textColor: '#e9edef', nodeTextColor: '#e9edef',
+      edgeLabelBackground: '#0a0b0c',
+      clusterBkg: '#111518', clusterBorder: '#2b3339', titleColor: '#e9edef',
+      actorBkg: '#1d2327', actorBorder: '#22c86e', actorTextColor: '#e9edef',
+      actorLineColor: '#5a646b', signalColor: '#aeb7bf', signalTextColor: '#e9edef',
+      noteBkgColor: '#20282d', noteTextColor: '#cdd9e5', noteBorderColor: '#39434b',
+      activationBorderColor: '#22c86e', activationBkgColor: '#12271b',
+      sequenceNumberColor: '#0a0b0c', labelBoxBkgColor: '#1d2327',
+      labelBoxBorderColor: '#39434b', labelTextColor: '#e9edef', loopTextColor: '#e9edef',
+      fontFamily: '"Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    },
+    // useMaxWidth:false renders every diagram at its natural size — text stays
+    // at the configured 16px and wide diagrams scroll inside .diagram-wrap
+    // instead of shrinking to fit the column.
+    flowchart: { curve: 'basis', htmlLabels: true, useMaxWidth: false, nodeSpacing: 55, rankSpacing: 60, padding: 12 },
+    sequence: { useMaxWidth: false, actorMargin: 55, messageMargin: 28, width: 160,
+      actorFontSize: 15, actorFontWeight: 600, messageFontSize: 14, noteFontSize: 13 },
+    state: { useMaxWidth: false },
+    class: { useMaxWidth: false },
+  });
+
+  const sections = document.querySelectorAll('section[id]');
+  const navLinks = document.querySelectorAll('#sidebar a');
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        navLinks.forEach(a => a.classList.remove('active'));
+        const active = document.querySelector(`#sidebar a[href="#${e.target.id}"]`);
+        if (active) active.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  sections.forEach(s => observer.observe(s));

--- a/src/cv-ffmpeg-loader.cpp
+++ b/src/cv-ffmpeg-loader.cpp
@@ -9,23 +9,21 @@
 
 #include <string>
 
-// OBS 32.2+ bundles FFmpeg 8 under the same DLL names we ship (avfilter-11,
-// avutil-60, ...). Loose copies of those names in obs-plugins/64bit made
-// OBS's own obs-ffmpeg module bind our build and fail to load, breaking OBS
-// outright (and our plugin with it). The runtime therefore lives in the
-// private corevideo-ffmpeg/ subdirectory and resolves through the delay-load
-// hook below:
-//   - if the process already holds avfilter/avutil (OBS 32.2+), bind those —
-//     the Windows loader dedups modules by base name, so a second same-named
-//     copy can never be kept isolated from the first;
-//   - otherwise (OBS <= 32.1 ships avcodec-61-era names, no overlap) load our
-//     bundled runtime by absolute path so nothing else resolves into it.
+// OBS bundles FFmpeg under the standard DLL names, and the Windows loader
+// dedups modules by base name — a same-named private runtime can never be
+// kept isolated from OBS's inside one process (that collision is exactly how
+// OBS 32.2 broke pre-v0.1.30 installs). Our runtime is therefore renamed to
+// cv-prefixed DLLs (cvfilter-11.dll, cvutil-60.dll, ... — see
+// scripts/New-PrivateFfmpeg.ps1), shipped in the private corevideo-ffmpeg/
+// subdirectory, and delay-loaded by absolute path through the hook below.
+// Unique names mean the full-featured build (scale_cuda/vpp_qsv) is always
+// ours, on every OBS version, and OBS's own FFmpeg never sees it.
 
 #ifndef COREVIDEO_AVFILTER_DLL
-#define COREVIDEO_AVFILTER_DLL "avfilter-11.dll"
+#define COREVIDEO_AVFILTER_DLL "cvfilter-11.dll"
 #endif
 #ifndef COREVIDEO_AVUTIL_DLL
-#define COREVIDEO_AVUTIL_DLL "avutil-60.dll"
+#define COREVIDEO_AVUTIL_DLL "cvutil-60.dll"
 #endif
 
 static CvFfmpegRuntime g_runtime = CvFfmpegRuntime::Unavailable;
@@ -60,8 +58,8 @@ static std::wstring plugin_directory()
 
 static bool is_delayed_ffmpeg_dll(const char *name)
 {
-    return _strnicmp(name, "avfilter", 8) == 0 ||
-           _strnicmp(name, "avutil", 6) == 0;
+    return _strnicmp(name, "cvfilter", 8) == 0 ||
+           _strnicmp(name, "cvutil", 6) == 0;
 }
 
 static FARPROC WINAPI cv_delayload_hook(unsigned event, DelayLoadInfo *info)
@@ -138,35 +136,25 @@ CvFfmpegRuntime cv_ffmpeg_loader_init()
              "installer (or delete av*-*.dll / sw*-*.dll from "
              "obs-plugins\\64bit) to fix this.");
 
-    bool filter_loaded = GetModuleHandleA(COREVIDEO_AVFILTER_DLL) != nullptr;
-    bool util_loaded = GetModuleHandleA(COREVIDEO_AVUTIL_DLL) != nullptr;
-
-    if (filter_loaded && util_loaded) {
+    // cv* names are globally unique, so a resident copy can only be one we
+    // (or a second CoreVideo init) loaded earlier — reuse it.
+    if (GetModuleHandleA(COREVIDEO_AVFILTER_DLL) &&
+        GetModuleHandleA(COREVIDEO_AVUTIL_DLL)) {
         g_runtime = CvFfmpegRuntime::ProcessCopies;
-    } else if (filter_loaded != util_loaded) {
-        // One half of the pair is mapped without the other (e.g. obs-ffmpeg
-        // failed mid-load). Binding across builds is how crashes start —
-        // refuse and stay on the CPU path.
-        blog(LOG_ERROR,
-             "[obs-zoom-plugin] Inconsistent FFmpeg runtime in process "
-             "(%s loaded, %s not) — hardware acceleration disabled",
-             filter_loaded ? COREVIDEO_AVFILTER_DLL : COREVIDEO_AVUTIL_DLL,
-             filter_loaded ? COREVIDEO_AVUTIL_DLL : COREVIDEO_AVFILTER_DLL);
-        g_runtime = CvFfmpegRuntime::Unavailable;
+        return g_runtime;
+    }
+
+    g_private_dir = plugin_dir + L"corevideo-ffmpeg\\";
+    DWORD attrs = GetFileAttributesW(
+        (g_private_dir + widen(COREVIDEO_AVFILTER_DLL)).c_str());
+    if (attrs != INVALID_FILE_ATTRIBUTES) {
+        g_runtime = CvFfmpegRuntime::PrivateCopies;
     } else {
-        g_private_dir = plugin_dir + L"corevideo-ffmpeg\\";
-        DWORD attrs =
-            GetFileAttributesW((g_private_dir + widen(COREVIDEO_AVFILTER_DLL))
-                                   .c_str());
-        if (attrs != INVALID_FILE_ATTRIBUTES) {
-            g_runtime = CvFfmpegRuntime::PrivateCopies;
-        } else {
-            blog(LOG_ERROR,
-                 "[obs-zoom-plugin] Bundled FFmpeg runtime missing at "
-                 "corevideo-ffmpeg\\%s — hardware acceleration disabled",
-                 COREVIDEO_AVFILTER_DLL);
-            g_runtime = CvFfmpegRuntime::Unavailable;
-        }
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Bundled FFmpeg runtime missing at "
+             "corevideo-ffmpeg\\%s — hardware acceleration disabled",
+             COREVIDEO_AVFILTER_DLL);
+        g_runtime = CvFfmpegRuntime::Unavailable;
     }
     return g_runtime;
 }
@@ -181,7 +169,7 @@ const char *cv_ffmpeg_runtime_describe()
 {
     switch (g_runtime) {
     case CvFfmpegRuntime::ProcessCopies:
-        return "using FFmpeg runtime already loaded by OBS (OBS 32.2+)";
+        return "using bundled FFmpeg runtime (already resident)";
     case CvFfmpegRuntime::PrivateCopies:
         return "using bundled FFmpeg runtime from corevideo-ffmpeg/";
     case CvFfmpegRuntime::SystemLinked:

--- a/src/cv-ffmpeg-loader.cpp
+++ b/src/cv-ffmpeg-loader.cpp
@@ -1,0 +1,219 @@
+#include "cv-ffmpeg-loader.h"
+
+#include <obs-module.h>
+
+#if defined(_WIN32) && defined(COREVIDEO_HW_ACCEL)
+
+#include <windows.h>
+#include <delayimp.h>
+
+#include <string>
+
+// OBS 32.2+ bundles FFmpeg 8 under the same DLL names we ship (avfilter-11,
+// avutil-60, ...). Loose copies of those names in obs-plugins/64bit made
+// OBS's own obs-ffmpeg module bind our build and fail to load, breaking OBS
+// outright (and our plugin with it). The runtime therefore lives in the
+// private corevideo-ffmpeg/ subdirectory and resolves through the delay-load
+// hook below:
+//   - if the process already holds avfilter/avutil (OBS 32.2+), bind those —
+//     the Windows loader dedups modules by base name, so a second same-named
+//     copy can never be kept isolated from the first;
+//   - otherwise (OBS <= 32.1 ships avcodec-61-era names, no overlap) load our
+//     bundled runtime by absolute path so nothing else resolves into it.
+
+#ifndef COREVIDEO_AVFILTER_DLL
+#define COREVIDEO_AVFILTER_DLL "avfilter-11.dll"
+#endif
+#ifndef COREVIDEO_AVUTIL_DLL
+#define COREVIDEO_AVUTIL_DLL "avutil-60.dll"
+#endif
+
+static CvFfmpegRuntime g_runtime = CvFfmpegRuntime::Unavailable;
+static std::wstring g_private_dir;
+
+static std::wstring widen(const char *narrow)
+{
+    std::wstring wide;
+    for (const char *p = narrow; *p; ++p)
+        wide.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*p)));
+    return wide;
+}
+
+static std::wstring plugin_directory()
+{
+    HMODULE self = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            reinterpret_cast<LPCWSTR>(&plugin_directory),
+                            &self))
+        return {};
+    wchar_t path[MAX_PATH];
+    DWORD len = GetModuleFileNameW(self, path, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH)
+        return {};
+    std::wstring dir(path, len);
+    size_t slash = dir.find_last_of(L"\\/");
+    if (slash == std::wstring::npos)
+        return {};
+    return dir.substr(0, slash + 1);
+}
+
+static bool is_delayed_ffmpeg_dll(const char *name)
+{
+    return _strnicmp(name, "avfilter", 8) == 0 ||
+           _strnicmp(name, "avutil", 6) == 0;
+}
+
+static FARPROC WINAPI cv_delayload_hook(unsigned event, DelayLoadInfo *info)
+{
+    if (event != dliNotePreLoadLibrary || !info || !info->szDll)
+        return nullptr;
+    if (!is_delayed_ffmpeg_dll(info->szDll))
+        return nullptr;
+
+    // A same-named module already in the process always wins; the loader
+    // would dedup to it on any name-based load anyway.
+    if (HMODULE loaded = GetModuleHandleA(info->szDll))
+        return reinterpret_cast<FARPROC>(loaded);
+
+    if (g_runtime != CvFfmpegRuntime::PrivateCopies || g_private_dir.empty())
+        return nullptr; // fall through to default search; init() already warned
+
+    std::wstring path = g_private_dir + widen(info->szDll);
+    // DLL_LOAD_DIR makes avfilter's own imports (avcodec/swscale/...) resolve
+    // from corevideo-ffmpeg/ first instead of OBS's bin directory.
+    HMODULE mod = LoadLibraryExW(path.c_str(), nullptr,
+                                 LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+                                     LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    if (!mod) {
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Failed to load private FFmpeg runtime '%s' "
+             "(error %lu) — hardware acceleration will fail over to CPU",
+             info->szDll, GetLastError());
+        return nullptr;
+    }
+    blog(LOG_INFO, "[obs-zoom-plugin] Loaded private FFmpeg runtime '%s'",
+         info->szDll);
+    return reinterpret_cast<FARPROC>(mod);
+}
+
+extern "C" const PfnDliHook __pfnDliNotifyHook2 = cv_delayload_hook;
+
+static bool legacy_loose_dlls_present(const std::wstring &plugin_dir)
+{
+    static const wchar_t *families[] = {L"avcodec-*.dll",  L"avdevice-*.dll",
+                                        L"avfilter-*.dll", L"avformat-*.dll",
+                                        L"avutil-*.dll",   L"swresample-*.dll",
+                                        L"swscale-*.dll"};
+    for (const wchar_t *pattern : families) {
+        WIN32_FIND_DATAW fd;
+        HANDLE find = FindFirstFileW((plugin_dir + pattern).c_str(), &fd);
+        if (find != INVALID_HANDLE_VALUE) {
+            FindClose(find);
+            return true;
+        }
+    }
+    return false;
+}
+
+CvFfmpegRuntime cv_ffmpeg_loader_init()
+{
+    std::wstring plugin_dir = plugin_directory();
+    if (plugin_dir.empty()) {
+        blog(LOG_ERROR, "[obs-zoom-plugin] Could not locate plugin directory; "
+                        "hardware acceleration disabled");
+        g_runtime = CvFfmpegRuntime::Unavailable;
+        return g_runtime;
+    }
+
+    // Pre-v0.1.30 installs left the FFmpeg runtime loose in obs-plugins/64bit,
+    // which collides with OBS 32.2+'s own FFmpeg 8 and stops obs-ffmpeg.dll
+    // from loading. We cannot delete them from here (no elevation, possibly
+    // already mapped) — shout so support bundles show the cause.
+    if (legacy_loose_dlls_present(plugin_dir))
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Legacy FFmpeg DLLs found loose in the OBS "
+             "plugin directory. On OBS 32.2+ these prevent OBS's own "
+             "obs-ffmpeg module from loading. Run the CoreVideo v0.1.30+ "
+             "installer (or delete av*-*.dll / sw*-*.dll from "
+             "obs-plugins\\64bit) to fix this.");
+
+    bool filter_loaded = GetModuleHandleA(COREVIDEO_AVFILTER_DLL) != nullptr;
+    bool util_loaded = GetModuleHandleA(COREVIDEO_AVUTIL_DLL) != nullptr;
+
+    if (filter_loaded && util_loaded) {
+        g_runtime = CvFfmpegRuntime::ProcessCopies;
+    } else if (filter_loaded != util_loaded) {
+        // One half of the pair is mapped without the other (e.g. obs-ffmpeg
+        // failed mid-load). Binding across builds is how crashes start —
+        // refuse and stay on the CPU path.
+        blog(LOG_ERROR,
+             "[obs-zoom-plugin] Inconsistent FFmpeg runtime in process "
+             "(%s loaded, %s not) — hardware acceleration disabled",
+             filter_loaded ? COREVIDEO_AVFILTER_DLL : COREVIDEO_AVUTIL_DLL,
+             filter_loaded ? COREVIDEO_AVUTIL_DLL : COREVIDEO_AVFILTER_DLL);
+        g_runtime = CvFfmpegRuntime::Unavailable;
+    } else {
+        g_private_dir = plugin_dir + L"corevideo-ffmpeg\\";
+        DWORD attrs =
+            GetFileAttributesW((g_private_dir + widen(COREVIDEO_AVFILTER_DLL))
+                                   .c_str());
+        if (attrs != INVALID_FILE_ATTRIBUTES) {
+            g_runtime = CvFfmpegRuntime::PrivateCopies;
+        } else {
+            blog(LOG_ERROR,
+                 "[obs-zoom-plugin] Bundled FFmpeg runtime missing at "
+                 "corevideo-ffmpeg\\%s — hardware acceleration disabled",
+                 COREVIDEO_AVFILTER_DLL);
+            g_runtime = CvFfmpegRuntime::Unavailable;
+        }
+    }
+    return g_runtime;
+}
+
+bool cv_ffmpeg_available()
+{
+    return g_runtime == CvFfmpegRuntime::ProcessCopies ||
+           g_runtime == CvFfmpegRuntime::PrivateCopies;
+}
+
+const char *cv_ffmpeg_runtime_describe()
+{
+    switch (g_runtime) {
+    case CvFfmpegRuntime::ProcessCopies:
+        return "using FFmpeg runtime already loaded by OBS (OBS 32.2+)";
+    case CvFfmpegRuntime::PrivateCopies:
+        return "using bundled FFmpeg runtime from corevideo-ffmpeg/";
+    case CvFfmpegRuntime::SystemLinked:
+        return "using system-linked FFmpeg";
+    default:
+        return "no usable FFmpeg runtime — hardware acceleration disabled";
+    }
+}
+
+#else // !_WIN32 || !COREVIDEO_HW_ACCEL
+
+#ifdef COREVIDEO_HW_ACCEL
+static CvFfmpegRuntime g_runtime = CvFfmpegRuntime::SystemLinked;
+#else
+static CvFfmpegRuntime g_runtime = CvFfmpegRuntime::Unavailable;
+#endif
+
+CvFfmpegRuntime cv_ffmpeg_loader_init()
+{
+    return g_runtime;
+}
+
+bool cv_ffmpeg_available()
+{
+    return g_runtime == CvFfmpegRuntime::SystemLinked;
+}
+
+const char *cv_ffmpeg_runtime_describe()
+{
+    return g_runtime == CvFfmpegRuntime::SystemLinked
+               ? "using system-linked FFmpeg"
+               : "built without FFmpeg hardware acceleration";
+}
+
+#endif

--- a/src/cv-ffmpeg-loader.h
+++ b/src/cv-ffmpeg-loader.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Decides where the plugin's FFmpeg runtime (avfilter/avutil) comes from and,
+// on Windows, installs the delay-load resolver that enforces the decision.
+// Must run before the first HwVideoPipeline use. See cv-ffmpeg-loader.cpp.
+enum class CvFfmpegRuntime {
+    SystemLinked,  // non-Windows: normal dynamic linking, nothing to resolve
+    ProcessCopies, // binding the avfilter/avutil OBS already loaded (OBS 32.2+)
+    PrivateCopies, // loading our bundled runtime from corevideo-ffmpeg/
+    Unavailable,   // no usable runtime: hardware acceleration must stay off
+};
+
+CvFfmpegRuntime cv_ffmpeg_loader_init();
+
+// True once init() found a usable runtime. HwVideoPipeline::init() checks this
+// before touching any FFmpeg symbol so a missing runtime degrades to the CPU
+// path instead of raising a delay-load exception.
+bool cv_ffmpeg_available();
+
+const char *cv_ffmpeg_runtime_describe();

--- a/src/cv-ffmpeg-loader.h
+++ b/src/cv-ffmpeg-loader.h
@@ -5,7 +5,7 @@
 // Must run before the first HwVideoPipeline use. See cv-ffmpeg-loader.cpp.
 enum class CvFfmpegRuntime {
     SystemLinked,  // non-Windows: normal dynamic linking, nothing to resolve
-    ProcessCopies, // binding the avfilter/avutil OBS already loaded (OBS 32.2+)
+    ProcessCopies, // our cv*-named runtime is already resident in the process
     PrivateCopies, // loading our bundled runtime from corevideo-ffmpeg/
     Unavailable,   // no usable runtime: hardware acceleration must stay off
 };

--- a/src/cv-style.h
+++ b/src/cv-style.h
@@ -149,6 +149,7 @@ QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal { width: 0; }
 /* ─── Named Widgets ─────────────────────────────────────────────────────────── */
 QLabel#speakerValue { color: #999999; font-style: italic; }
 QLabel#errorLabel   { color: #ee5555; font-size: 11px; }
+QLabel[role="muted"] { color: #8a8a8a; font-size: 11px; }
 
 QFrame#recoveryPanel {
     background-color: rgba(240,160,0,0.10);

--- a/src/engine-ipc.h
+++ b/src/engine-ipc.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cerrno>
+#include <cstdio>
 
 // ── IPC command / event tokens ────────────────────────────────────────────────
 #define IPC_CMD_INIT        "init"
@@ -173,10 +174,44 @@ struct ShmAudioHeader {
        r.owner = false;
    }
 
+   // Map a caller's logical region name onto the actual POSIX object name.
+   //
+   // macOS caps shared-memory names at PSHMNAMLEN (31) characters INCLUDING the
+   // leading '/', and shm_open fails with ENAMETOOLONG past that. The logical
+   // names callers build -- IPC_SHM_PREFIX + source uuid, plus an optional
+   // "_audio" suffix -- run ~37-43 characters, so on macOS EVERY region fails to
+   // open and no frame can ever be delivered. Note that shortening the uuid alone
+   // cannot fix this: the "ZoomObsPlugin_" prefix eats 14 of the 31 by itself,
+   // leaving 16 for the uuid and the suffix combined.
+   //
+   // So on Apple collapse the whole logical name to a fixed 20-char form:
+   // '/' + "ZOP" + 16 hex digits of an FNV-1a 64 hash. It is deterministic and
+   // applied inside shm_region_create/shm_region_open_read, so the plugin and the
+   // engine derive byte-identical names from the same logical name without either
+   // side knowing -- a call site cannot forget to apply it, and the two cannot
+   // drift apart. Linux (NAME_MAX 255) and Windows keep their existing names
+   // untouched, so their wire behavior is unchanged.
+   inline std::string shm_platform_name(const std::string &logical)
+   {
+#  if defined(__APPLE__)
+       uint64_t hash = 1469598103934665603ULL;   // FNV-1a 64 offset basis
+       for (unsigned char c : logical) {
+           hash ^= static_cast<uint64_t>(c);
+           hash *= 1099511628211ULL;             // FNV-1a 64 prime
+       }
+       char buf[24];
+       std::snprintf(buf, sizeof(buf), "/ZOP%016llx",
+                     static_cast<unsigned long long>(hash));
+       return std::string(buf);
+#  else
+       return "/" + logical;                     // shm_open requires a leading '/'
+#  endif
+   }
+
    inline bool shm_region_create(ShmRegion &r, const std::string &name, size_t size)
    {
        shm_region_destroy(r);
-       r.name = "/" + name; // shm_open requires a leading '/'
+       r.name = shm_platform_name(name);
        r.owner = true;
        r.fd   = shm_open(r.name.c_str(), O_CREAT | O_RDWR, 0600);
        if (r.fd < 0) return false;
@@ -190,7 +225,7 @@ struct ShmAudioHeader {
    inline bool shm_region_open_read(ShmRegion &r, const std::string &name, size_t size)
    {
        shm_region_destroy(r);
-       r.name = "/" + name;
+       r.name = shm_platform_name(name);
        r.owner = false;
        r.fd = shm_open(r.name.c_str(), O_RDONLY, 0600);
        if (r.fd < 0) return false;

--- a/src/engine-ipc.h
+++ b/src/engine-ipc.h
@@ -213,6 +213,29 @@ struct ShmAudioHeader {
        shm_region_destroy(r);
        r.name = shm_platform_name(name);
        r.owner = true;
+
+       // A POSIX shm object can be sized exactly once: ftruncate on an object
+       // that already exists fails with EINVAL on macOS (verified empirically --
+       // fresh object ftruncate succeeds, reopening the same object and
+       // ftruncating to a new size does not, and unlinking first makes it work
+       // again). So an object left behind by a previous run -- an engine that
+       // crashed or was killed before shm_region_destroy could unlink it -- can
+       // never be resized, and every create against that name fails until
+       // something removes it.
+       //
+       // That bit for real: the first frame after a resolution change (or after
+       // an engine restart) failed with "could not allocate shared memory", the
+       // failure path unlinked the region as it tore down, and the NEXT frame
+       // then succeeded -- a self-healing error that still raised an operator
+       // alert mid-show. Unlink first so the create is against a fresh object
+       // every time and the transient never happens.
+       //
+       // Harmless on Linux (which allows repeated ftruncate): unlinking a name
+       // the caller is about to recreate is a no-op there. The read side is
+       // unaffected either way -- an existing mapping stays valid against the
+       // old object until the shm_gen bump tells the plugin to remap.
+       shm_unlink(r.name.c_str());
+
        r.fd   = shm_open(r.name.c_str(), O_CREAT | O_RDWR, 0600);
        if (r.fd < 0) return false;
        if (ftruncate(r.fd, static_cast<off_t>(size)) < 0) { shm_region_destroy(r); return false; }

--- a/src/hw-video-pipeline.cpp
+++ b/src/hw-video-pipeline.cpp
@@ -1,4 +1,5 @@
 #include "hw-video-pipeline.h"
+#include "cv-ffmpeg-loader.h"
 #ifdef COREVIDEO_HW_ACCEL
 
 extern "C" {
@@ -60,6 +61,14 @@ bool HwVideoPipeline::init(HwAccelMode mode)
     shutdown();
     if (mode == HwAccelMode::None)
         return false;
+
+    // Without a usable runtime the first avfilter call would raise a
+    // delay-load exception instead of failing over to the CPU path.
+    if (!cv_ffmpeg_available()) {
+        blog(LOG_WARNING, "[obs-zoom-plugin] HW accel: %s",
+             cv_ffmpeg_runtime_describe());
+        return false;
+    }
 
     if (mode == HwAccelMode::Auto) {
         const auto it = std::find_if(std::begin(kBackends), std::end(kBackends),

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -28,6 +28,9 @@ extern "C" IMAGE_DOS_HEADER __ImageBase;
 #if !defined(WIN32)
 #include <csignal>
 #endif
+#if defined(__APPLE__)
+#include <dlfcn.h> // dladdr: locate the loaded plugin bundle for Qt plugin paths
+#endif
 
 static QPointer<ZoomDock> g_dock;
 static QPointer<ZoomIsoPanel> g_iso_panel;
@@ -103,6 +106,32 @@ static void configure_qt_plugin_paths()
     for (const QString &path : candidates) {
         if (QFileInfo::exists(path))
             QCoreApplication::addLibraryPath(path);
+    }
+
+    blog(LOG_INFO, "[obs-zoom-plugin] Qt library paths: %s",
+         QCoreApplication::libraryPaths().join(";").toUtf8().constData());
+#elif defined(__APPLE__)
+    // OBS.app bundles Qt but ships NO Qt TLS backend plugin (there is no
+    // PlugIns/tls directory), so QtNetwork inside the OBS process has no TLS
+    // provider at all and every https request dies with "TLS initialization
+    // failed" -- which broke the OAuth broker redeem. The Windows package
+    // already ships qcertonlybackend/qschannelbackend for exactly this reason;
+    // this is the macOS half of that same fix, pointing Qt at the
+    // securetransport backend we ship inside the plugin bundle.
+    Dl_info info{};
+    if (dladdr(reinterpret_cast<const void *>(&configure_qt_plugin_paths), &info) &&
+        info.dli_fname) {
+        const QFileInfo plugin_info(QString::fromUtf8(info.dli_fname));
+        const QDir plugin_dir = plugin_info.dir(); // <bundle>/Contents/MacOS
+        const QStringList candidates = {
+            plugin_dir.absoluteFilePath("plugins"),
+            plugin_dir.absoluteFilePath("../PlugIns"),
+            plugin_dir.absoluteFilePath("../Resources/qt/plugins"),
+        };
+        for (const QString &path : candidates) {
+            if (QFileInfo::exists(path))
+                QCoreApplication::addLibraryPath(path);
+        }
     }
 
     blog(LOG_INFO, "[obs-zoom-plugin] Qt library paths: %s",

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -14,6 +14,7 @@
 #include "zoom-iso-panel.h"
 #include "zoom-control-server.h"
 #include "zoom-osc-server.h"
+#include "cv-ffmpeg-loader.h"
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
@@ -349,7 +350,9 @@ bool obs_module_load(void)
 {
     blog(LOG_INFO, "[obs-zoom-plugin] Loading plugin v%s", OBS_ZOOM_PLUGIN_VERSION);
 #ifdef COREVIDEO_HW_ACCEL
-    blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: enabled at build (FFmpeg)");
+    cv_ffmpeg_loader_init();
+    blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: %s",
+         cv_ffmpeg_runtime_describe());
 #else
     blog(LOG_INFO, "[obs-zoom-plugin] Hardware video acceleration: disabled (built without ENABLE_FFMPEG_HW_ACCEL - CPU path only)");
 #endif

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -599,20 +599,23 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
         const QString display_name = req.value("display_name").toString("OBS");
 
         // Accept either a numeric ID or a full Zoom URL in meeting_id.
-        const auto parsed = zoom_join_utils::parse_join_input(meeting_id.toStdString());
-        if (parsed.meeting_id.empty()) {
+        // Named distinctly from the outer `parsed` (the ParsedControlRequest
+        // for this whole dispatch call) -- they are different types and
+        // reusing the name shadowed the outer variable (cppcheck shadowVariable).
+        const auto join_input = zoom_join_utils::parse_join_input(meeting_id.toStdString());
+        if (join_input.meeting_id.empty()) {
             write_response(socket, {{"ok", false}, {"error", "invalid_meeting_id"}});
             return;
         }
         std::string passcode = passcode_in.toStdString();
-        if (passcode.empty()) passcode = parsed.passcode;
+        if (passcode.empty()) passcode = join_input.passcode;
         ZoomJoinAuthTokens tokens;
         tokens.on_behalf_token = req.value("on_behalf_token").toString(
-            QString::fromStdString(parsed.on_behalf_token)).toStdString();
+            QString::fromStdString(join_input.on_behalf_token)).toStdString();
         tokens.user_zak = req.value("user_zak").toString(
-            QString::fromStdString(parsed.user_zak)).toStdString();
+            QString::fromStdString(join_input.user_zak)).toStdString();
         tokens.app_privilege_token = req.value("app_privilege_token").toString(
-            QString::fromStdString(parsed.app_privilege_token)).toStdString();
+            QString::fromStdString(join_input.app_privilege_token)).toStdString();
         ZoomPluginSettings settings = ZoomPluginSettings::load();
         const bool needs_oauth_zak =
             tokens.user_zak.empty() &&
@@ -630,7 +633,7 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
 
             std::string zak;
             QString zak_error;
-            if (!ZoomOAuthManager::instance().fetch_zak_blocking(zak, parsed.meeting_id, &zak_error)) {
+            if (!ZoomOAuthManager::instance().fetch_zak_blocking(zak, join_input.meeting_id, &zak_error)) {
                 blog(LOG_WARNING, "[obs-zoom-plugin] Control join OAuth ZAK fetch failed: %s",
                      zak_error.toUtf8().constData());
                 write_response(socket, {
@@ -673,7 +676,7 @@ void ZoomControlServer::handle_line(QTcpSocket *socket, const QByteArray &line)
              settings.use_broker_sdk_jwt() ? 1 : 0);
         const bool ok =
             ZoomEngineClient::instance().start(jwt, public_app_key) &&
-            ZoomEngineClient::instance().join(parsed.meeting_id, passcode,
+            ZoomEngineClient::instance().join(join_input.meeting_id, passcode,
                                               display_name.toStdString(),
                                               MeetingKind::Meeting, tokens);
         write_response(socket, {{"ok", ok}});

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -448,6 +448,12 @@ void ZoomEngineClient::leave()
     if (!m_running.load(std::memory_order_acquire)) return;
     m_user_leaving.store(true, std::memory_order_release);
     ZoomReconnectManager::instance().cancel(); // suppress any in-progress recovery
+    // Explicit user leave is a deliberate end of participation: drop the stored
+    // recovery session so sensitive join credentials (ZAK / on-behalf /
+    // app-privilege tokens) are wiped from memory rather than lingering until
+    // the next join() or stop(). Mirrors stop(); a subsequent rejoin re-stores
+    // a fresh session via join().
+    ZoomReconnectManager::instance().clear_session();
     m_state.store(MeetingState::Leaving, std::memory_order_release);
     {
         std::lock_guard<std::mutex> lk(m_mtx);

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -181,7 +181,23 @@ static std::string engine_executable_path()
         const size_t slash = module_path.find_last_of('/');
         if (slash != std::string::npos) {
             const std::string module_dir = module_path.substr(0, slash + 1);
+#if defined(__APPLE__)
+            // Preferred macOS layout, and the only one where authentication can
+            // work: the engine ships as an .app whose Contents/Frameworks holds
+            // the Zoom SDK runtime, because the SDK loads its runtime bundles
+            // through the main bundle rather than through rpath. A bare
+            // executable beside the module still launches and still authenticates
+            // *nothing* -- see engine/src/main-macos.mm. Checked first so a stale
+            // loose binary from an older install cannot win.
+            std::string candidate =
+                module_dir + "ZoomObsEngine.app/Contents/MacOS/ZoomObsEngine";
+            if (access(candidate.c_str(), X_OK) == 0)
+                return candidate;
+
+            candidate = module_dir + "zoom-runtime/ZoomObsEngine";
+#else
             std::string candidate = module_dir + "zoom-runtime/ZoomObsEngine";
+#endif
             if (access(candidate.c_str(), X_OK) == 0)
                 return candidate;
 

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -126,12 +126,14 @@ static std::string zoom_error_message(const QJsonObject &obj)
 #if defined(WIN32)
 #include <windows.h>
 #else
+#include <dlfcn.h>
 #include <signal.h>
 #include <spawn.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cstring>
 extern char **environ;
 #endif
 
@@ -166,6 +168,38 @@ static std::string engine_executable_path()
         return candidate;
     return "ZoomObsEngine.exe";
 #else
+    // Resolve the engine next to the loaded plugin binary, mirroring the Windows
+    // branch above. Returning a bare "ZoomObsEngine" is not sufficient: the
+    // launcher uses posix_spawnp, which for a name containing no slash performs
+    // a PATH search, and the engine ships inside the plugin bundle
+    // (Contents/MacOS on macOS) which is never on PATH -- so the spawn failed
+    // with ENOENT and the plugin could never start a meeting.
+    Dl_info info{};
+    if (dladdr(reinterpret_cast<const void *>(&engine_executable_path), &info) &&
+        info.dli_fname) {
+        const std::string module_path(info.dli_fname);
+        const size_t slash = module_path.find_last_of('/');
+        if (slash != std::string::npos) {
+            const std::string module_dir = module_path.substr(0, slash + 1);
+            std::string candidate = module_dir + "zoom-runtime/ZoomObsEngine";
+            if (access(candidate.c_str(), X_OK) == 0)
+                return candidate;
+
+            candidate = module_dir + "ZoomObsEngine";
+            if (access(candidate.c_str(), X_OK) == 0)
+                return candidate;
+        }
+    }
+
+    char *obs_path = obs_module_file("ZoomObsEngine");
+    if (obs_path) {
+        const std::string candidate(obs_path);
+        bfree(obs_path);
+        if (access(candidate.c_str(), X_OK) == 0)
+            return candidate;
+    }
+    // Last resort: let posix_spawnp search PATH, so a developer build with the
+    // engine on PATH still works rather than failing outright.
     return "ZoomObsEngine";
 #endif
 }
@@ -552,11 +586,18 @@ bool ZoomEngineClient::launch_engine()
     return true;
 #else
     const std::string path = engine_executable_path();
+    blog(LOG_INFO, "[obs-zoom-plugin] Launching ZoomObsEngine: %s", path.c_str());
     char *const argv[] = {const_cast<char *>(path.c_str()), nullptr};
     pid_t pid = -1;
+    // posix_spawnp returns the error number directly; it does not set errno.
     const int rc = posix_spawnp(&pid, path.c_str(), nullptr, nullptr, argv, environ);
     if (rc != 0) {
-        set_last_error("Failed to launch ZoomObsEngine process.");
+        // Name the path and the reason: "failed to launch" alone gives no way to
+        // tell a missing engine from a non-executable one.
+        const std::string message = "Failed to launch ZoomObsEngine at '" + path +
+                                    "': " + strerror(rc);
+        set_last_error(message);
+        blog(LOG_ERROR, "[obs-zoom-plugin] %s", message.c_str());
         return false;
     }
     m_pid = pid;

--- a/src/zoom-iso-panel.cpp
+++ b/src/zoom-iso-panel.cpp
@@ -274,8 +274,12 @@ static qint64 estimated_iso_bytes_per_second(
     const std::vector<ZoomOutputInfo> &outputs, bool record_program)
 {
     qint64 bytes_per_second = 0;
+    // Accumulation is conditional (filtered by is_iso_eligible_output), so
+    // std::accumulate would need an equivalent-or-more-convoluted lambda
+    // here with no readability gain over the plain loop.
     for (const auto &output : outputs) {
         if (is_iso_eligible_output(output))
+            // cppcheck-suppress useStlAlgorithm
             bytes_per_second += estimated_output_bytes_per_second(output);
     }
     if (record_program)

--- a/src/zoom-output-dialog.cpp
+++ b/src/zoom-output-dialog.cpp
@@ -677,9 +677,8 @@ void ZoomOutputDialog::refresh()
                 audio_role->currentData(),
             };
         }
+        m_table->setUpdatesEnabled(false);
     }
-
-    if (m_table) m_table->setUpdatesEnabled(false);
     if (m_participant_table) m_participant_table->setUpdatesEnabled(false);
 
     refresh_participants();

--- a/src/zoom-output-health.h
+++ b/src/zoom-output-health.h
@@ -50,11 +50,18 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
     };
 
     for (auto &out : outputs) {
+        // Assignment "None" (Participant mode, participant id 0, not
+        // active-speaker) expects no media: it must not be graded as
+        // waiting/stale or offered recovery actions.
+        const bool unassigned =
+            out.assignment == AssignmentMode::Participant &&
+            out.participant_id == 0 && !out.active_speaker;
         const bool wants_media =
-            out.assignment == AssignmentMode::Participant ||
-            out.assignment == AssignmentMode::ActiveSpeaker ||
-            out.assignment == AssignmentMode::SpotlightIndex ||
-            out.assignment == AssignmentMode::ScreenShare;
+            !unassigned &&
+            (out.assignment == AssignmentMode::Participant ||
+             out.assignment == AssignmentMode::ActiveSpeaker ||
+             out.assignment == AssignmentMode::SpotlightIndex ||
+             out.assignment == AssignmentMode::ScreenShare);
         if (!raw_media_active) {
             out.health_reason = wants_media
                 ? ZoomOutputHealthReason::RawMediaNotReady
@@ -91,6 +98,8 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
         }
 
         if (out.health_reason != ZoomOutputHealthReason::Ok)
+            continue;
+        if (unassigned)
             continue;
         if (out.video_stale) {
             out.health_reason = ZoomOutputHealthReason::StaleFrame;

--- a/src/zoom-output-health.h
+++ b/src/zoom-output-health.h
@@ -9,21 +9,25 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
                                 const std::vector<ParticipantInfo> &roster,
                                 bool raw_media_active)
 {
+    // Loop variables are named `out` rather than `output` because a test
+    // translation unit that includes this header (tests/output-health-test.cpp)
+    // defines a file-static helper function named `output()`; a local
+    // `output` here shadowed it (cppcheck shadowFunction).
     std::unordered_map<uint32_t, size_t> assigned_counts;
-    for (const auto &output : outputs) {
-        if (output.assignment == AssignmentMode::Participant &&
-            output.participant_id != 0) {
-            ++assigned_counts[output.participant_id];
+    for (const auto &out : outputs) {
+        if (out.assignment == AssignmentMode::Participant &&
+            out.participant_id != 0) {
+            ++assigned_counts[out.participant_id];
         }
     }
 
-    for (auto &output : outputs) {
-        output.duplicate_participant_assignment = false;
-        output.health_reason = ZoomOutputHealthReason::Ok;
-        if (output.assignment == AssignmentMode::Participant &&
-            output.participant_id != 0) {
-            output.duplicate_participant_assignment =
-                assigned_counts[output.participant_id] > 1;
+    for (auto &out : outputs) {
+        out.duplicate_participant_assignment = false;
+        out.health_reason = ZoomOutputHealthReason::Ok;
+        if (out.assignment == AssignmentMode::Participant &&
+            out.participant_id != 0) {
+            out.duplicate_participant_assignment =
+                assigned_counts[out.participant_id] > 1;
         }
     }
 
@@ -45,55 +49,55 @@ inline void apply_output_health(std::vector<ZoomOutputInfo> &outputs,
             });
     };
 
-    for (auto &output : outputs) {
+    for (auto &out : outputs) {
         const bool wants_media =
-            output.assignment == AssignmentMode::Participant ||
-            output.assignment == AssignmentMode::ActiveSpeaker ||
-            output.assignment == AssignmentMode::SpotlightIndex ||
-            output.assignment == AssignmentMode::ScreenShare;
+            out.assignment == AssignmentMode::Participant ||
+            out.assignment == AssignmentMode::ActiveSpeaker ||
+            out.assignment == AssignmentMode::SpotlightIndex ||
+            out.assignment == AssignmentMode::ScreenShare;
         if (!raw_media_active) {
-            output.health_reason = wants_media
+            out.health_reason = wants_media
                 ? ZoomOutputHealthReason::RawMediaNotReady
                 : ZoomOutputHealthReason::Ok;
-        } else if (output.duplicate_participant_assignment) {
-            output.health_reason = ZoomOutputHealthReason::DuplicateAssignment;
-        } else if (output.assignment == AssignmentMode::ScreenShare &&
+        } else if (out.duplicate_participant_assignment) {
+            out.health_reason = ZoomOutputHealthReason::DuplicateAssignment;
+        } else if (out.assignment == AssignmentMode::ScreenShare &&
                    !screen_share_available) {
-            output.health_reason = ZoomOutputHealthReason::ScreenShareUnavailable;
-        } else if (output.assignment == AssignmentMode::ActiveSpeaker &&
-                   output.participant_id == 0 &&
+            out.health_reason = ZoomOutputHealthReason::ScreenShareUnavailable;
+        } else if (out.assignment == AssignmentMode::ActiveSpeaker &&
+                   out.participant_id == 0 &&
                    !active_video_speaker_available) {
-            output.health_reason = ZoomOutputHealthReason::ActiveSpeakerUnavailable;
-        } else if (output.assignment == AssignmentMode::SpotlightIndex &&
-                   output.spotlight_slot > 0) {
+            out.health_reason = ZoomOutputHealthReason::ActiveSpeakerUnavailable;
+        } else if (out.assignment == AssignmentMode::SpotlightIndex &&
+                   out.spotlight_slot > 0) {
             const auto spotlight_it = std::find_if(
                 roster.begin(), roster.end(),
-                [&output](const ParticipantInfo &participant) {
-                    return participant.spotlight_index == output.spotlight_slot;
+                [&out](const ParticipantInfo &participant) {
+                    return participant.spotlight_index == out.spotlight_slot;
                 });
             if (spotlight_it == roster.end()) {
-                output.health_reason = ZoomOutputHealthReason::SpotlightUnavailable;
+                out.health_reason = ZoomOutputHealthReason::SpotlightUnavailable;
             } else if (!spotlight_it->has_video) {
-                output.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
+                out.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
             }
-        } else if (output.assignment == AssignmentMode::Participant &&
-                   output.participant_id != 0) {
-            const auto participant_it = find_participant(output.participant_id);
+        } else if (out.assignment == AssignmentMode::Participant &&
+                   out.participant_id != 0) {
+            const auto participant_it = find_participant(out.participant_id);
             if (participant_it == roster.end()) {
-                output.health_reason = ZoomOutputHealthReason::ParticipantMissing;
+                out.health_reason = ZoomOutputHealthReason::ParticipantMissing;
             } else if (!participant_it->has_video) {
-                output.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
+                out.health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
             }
         }
 
-        if (output.health_reason != ZoomOutputHealthReason::Ok)
+        if (out.health_reason != ZoomOutputHealthReason::Ok)
             continue;
-        if (output.video_stale) {
-            output.health_reason = ZoomOutputHealthReason::StaleFrame;
-        } else if (output.observed_width == 0 || output.observed_height == 0) {
-            output.health_reason = ZoomOutputHealthReason::WaitingForFirstFrame;
-        } else if (output_signal_below_requested(output)) {
-            output.health_reason = ZoomOutputHealthReason::ZoomDeliveredLowerResolution;
+        if (out.video_stale) {
+            out.health_reason = ZoomOutputHealthReason::StaleFrame;
+        } else if (out.observed_width == 0 || out.observed_height == 0) {
+            out.health_reason = ZoomOutputHealthReason::WaitingForFirstFrame;
+        } else if (output_signal_below_requested(out)) {
+            out.health_reason = ZoomOutputHealthReason::ZoomDeliveredLowerResolution;
         }
     }
 }

--- a/src/zoom-settings-dialog.cpp
+++ b/src/zoom-settings-dialog.cpp
@@ -20,6 +20,9 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QScrollArea>
 
 ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     : QDialog(parent)
@@ -192,16 +195,45 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     version_label->setAlignment(Qt::AlignRight);
     version_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
+    // The six sections stacked directly in the dialog made it taller than the
+    // screen, so the buttons below them were pushed off-screen and the dialog
+    // could not be saved or cancelled. Put the sections in a scroll area and
+    // keep the version label and the button box outside it, so Save/Cancel stay
+    // visible no matter how many sections there are or how large the user's
+    // font is.
+    auto *content = new QWidget;
+    auto *content_layout = new QVBoxLayout(content);
+    content_layout->setContentsMargins(0, 0, 0, 0);
+    content_layout->setSpacing(8);
+    content_layout->addWidget(oauth_group);
+    content_layout->addWidget(ctrl_group);
+    content_layout->addWidget(osc_group);
+    content_layout->addWidget(hw_group);
+    content_layout->addWidget(updates_group);
+    content_layout->addWidget(rc_group);
+    content_layout->addStretch();
+
+    auto *scroll = new QScrollArea(this);
+    scroll->setWidget(content);
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+    // Sections are form layouts that wrap poorly; scroll vertically only.
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
     auto *layout = new QVBoxLayout(this);
     layout->setSpacing(8);
-    layout->addWidget(oauth_group);
-    layout->addWidget(ctrl_group);
-    layout->addWidget(osc_group);
-    layout->addWidget(hw_group);
-    layout->addWidget(updates_group);
-    layout->addWidget(rc_group);
+    layout->addWidget(scroll, 1);
     layout->addWidget(version_label);
     layout->addWidget(buttons);
+
+    // Open at a comfortable size rather than the full natural height of the
+    // content, and never exceed the usable screen area (menu bar / Dock
+    // excluded) on a small display.
+    const QScreen *scr = screen() ? screen() : QGuiApplication::primaryScreen();
+    const QRect avail = scr ? scr->availableGeometry() : QRect(0, 0, 1280, 800);
+    resize(qMin(620, avail.width() - 80),
+           qMin(660, avail.height() - 80));
+    setSizeGripEnabled(true);
 
     // Apply stylesheet last so all widget properties are already set
     setStyleSheet(cv_stylesheet());

--- a/src/zoom-settings-dialog.cpp
+++ b/src/zoom-settings-dialog.cpp
@@ -1,5 +1,6 @@
 #include "zoom-settings-dialog.h"
 #include "cv-style.h"
+#include "obs-zoom-version.h"
 #include "zoom-settings.h"
 #include "zoom-control-server.h"
 #include "zoom-oauth.h"
@@ -185,6 +186,12 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     if (auto *save_btn = buttons->button(QDialogButtonBox::Save))
         save_btn->setProperty("role", "primary");
 
+    auto *version_label =
+        new QLabel(QString("CoreVideo v%1").arg(OBS_ZOOM_PLUGIN_VERSION), this);
+    version_label->setProperty("role", "muted");
+    version_label->setAlignment(Qt::AlignRight);
+    version_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
     auto *layout = new QVBoxLayout(this);
     layout->setSpacing(8);
     layout->addWidget(oauth_group);
@@ -193,6 +200,7 @@ ZoomSettingsDialog::ZoomSettingsDialog(QWidget *parent)
     layout->addWidget(hw_group);
     layout->addWidget(updates_group);
     layout->addWidget(rc_group);
+    layout->addWidget(version_label);
     layout->addWidget(buttons);
 
     // Apply stylesheet last so all widget properties are already set

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -744,6 +744,25 @@ void ZoomSource::subscribe()
                 [&](const ParticipantInfo &p) { return p.user_id == target; });
             if (!primary_present) target = failover;
         }
+        if (target == 0 && !use_active_speaker) {
+            // Assignment cleared ("None"). Tear down any previous engine
+            // subscription: skipping this left the old feed streaming into
+            // shared memory while the UI showed None, and flipping
+            // m_subscribed below made unsubscribe() a permanent no-op, so
+            // the leaked subscription could never be cleaned up.
+            const bool had_subscription =
+                m_subscribed.load(std::memory_order_acquire) ||
+                m_current_subscription_id.load(std::memory_order_acquire) != 0;
+            if (had_subscription) {
+                blog(LOG_INFO,
+                     "[obs-zoom-plugin] Assignment cleared; unsubscribing Zoom source: source=%s uuid=%s",
+                     output_name().c_str(), source_uuid.c_str());
+                clear_subscription_state();
+            }
+            m_subscribed = false;
+            m_current_subscription_id = 0;
+            return;
+        }
         if (target != 0)
             ZoomEngineClient::instance().subscribe(source_uuid, target,
                                                    isolate_audio, audience_audio,
@@ -768,6 +787,11 @@ void ZoomSource::subscribe()
 void ZoomSource::unsubscribe()
 {
     if (!m_subscribed) return;
+    clear_subscription_state();
+}
+
+void ZoomSource::clear_subscription_state()
+{
     ZoomEngineClient::instance().unsubscribe(source_uuid);
     if (!m_director_preview_uuid.empty())
         ZoomEngineClient::instance().unsubscribe(m_director_preview_uuid);

--- a/src/zoom-source.h
+++ b/src/zoom-source.h
@@ -73,6 +73,10 @@ struct ZoomSource {
                              bool new_audience_audio = false);
     void subscribe();
     void unsubscribe();
+    // Sends the engine unsubscribe and resets latched signal state without
+    // consulting m_subscribed — used when an assignment is cleared, where the
+    // subscribed flag may already be false but an engine feed still exists.
+    void clear_subscription_state();
     bool recover_stale_video(uint64_t now_ns, bool force = false);
     bool upgrade_low_quality_video(uint64_t now_ns, bool force = false);
     void activate();

--- a/tests/ffmpeg-runtime-test.cpp
+++ b/tests/ffmpeg-runtime-test.cpp
@@ -1,0 +1,74 @@
+// Verifies the renamed private FFmpeg runtime (see New-PrivateFfmpeg.ps1):
+//  - cvfilter loads from corevideo-ffmpeg/ with its whole dependency chain,
+//  - the full-featured build is intact (scale_cuda present),
+//  - no original-named (av*/sw*) module enters the process, which is the
+//    collision that broke OBS 32.2 (issue #165 / PR #162 history).
+#include <windows.h>
+#include <cstdio>
+#include <string>
+
+typedef const void *(*avfilter_get_by_name_fn)(const char *);
+
+static int fail(const char *msg)
+{
+    std::fprintf(stderr, "FAIL: %s (last error %lu)\n", msg, GetLastError());
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    std::wstring dir;
+    if (argc > 1) {
+        std::string narrow(argv[1]);
+        dir.assign(narrow.begin(), narrow.end());
+    } else {
+        wchar_t path[MAX_PATH];
+        DWORD len = GetModuleFileNameW(nullptr, path, MAX_PATH);
+        if (len == 0 || len >= MAX_PATH)
+            return fail("GetModuleFileNameW");
+        std::wstring exe(path, len);
+        dir = exe.substr(0, exe.find_last_of(L"\\/") + 1) +
+              L"corevideo-ffmpeg";
+    }
+
+    WIN32_FIND_DATAW fd;
+    HANDLE find = FindFirstFileW((dir + L"\\cvfilter-*.dll").c_str(), &fd);
+    if (find == INVALID_HANDLE_VALUE)
+        return fail("no cvfilter-*.dll in corevideo-ffmpeg directory");
+    FindClose(find);
+
+    std::wstring cvfilter = dir + L"\\" + fd.cFileName;
+    HMODULE mod = LoadLibraryExW(cvfilter.c_str(), nullptr,
+                                 LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+                                     LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    if (!mod)
+        return fail("LoadLibraryExW(cvfilter) failed");
+
+    auto get_by_name = reinterpret_cast<avfilter_get_by_name_fn>(
+        GetProcAddress(mod, "avfilter_get_by_name"));
+    if (!get_by_name)
+        return fail("avfilter_get_by_name not exported");
+
+    if (!get_by_name("scale_cuda"))
+        return fail("scale_cuda filter missing from bundled avfilter");
+    std::printf("scale_cuda: present\n");
+    std::printf("vpp_qsv: %s\n",
+                get_by_name("vpp_qsv") ? "present" : "absent (informational)");
+
+    static const wchar_t *originals[] = {
+        L"avcodec-62.dll",  L"avdevice-62.dll", L"avfilter-11.dll",
+        L"avformat-62.dll", L"avutil-60.dll",   L"swresample-6.dll",
+        L"swscale-9.dll"};
+    for (const wchar_t *name : originals) {
+        if (GetModuleHandleW(name)) {
+            std::fwprintf(stderr,
+                          L"FAIL: original-named module %s leaked into the "
+                          L"process\n",
+                          name);
+            return 1;
+        }
+    }
+
+    std::printf("PASS: private FFmpeg runtime loads fully isolated\n");
+    return 0;
+}

--- a/tests/ipc-hardening-test.cpp
+++ b/tests/ipc-hardening-test.cpp
@@ -11,12 +11,15 @@
 
 static int g_failures = 0;
 
-static void check(bool ok, const char *what)
+// Returns the result so a caller can skip dependent assertions when a
+// precondition (e.g. creating the region) already failed.
+static bool check(bool ok, const char *what)
 {
     if (!ok) {
         std::cerr << "FAIL: " << what << "\n";
         ++g_failures;
     }
+    return ok;
 }
 
 // ── Heartbeat timeout decision (used by ZoomEngineClient::monitor_loop) ──────
@@ -151,11 +154,56 @@ static void test_win_invalid_fd()
 }
 #endif // WIN32
 
+#if !defined(WIN32)
+// ── POSIX SHM object naming ──────────────────────────────────────────────────
+// Regression guard for the macOS PSHMNAMLEN limit: shm_open rejects names longer
+// than 31 characters INCLUDING the leading '/', which is shorter than every
+// logical name the plugin and engine build. If this regresses, no SHM region can
+// be opened on macOS and no frame is ever delivered.
+static void test_shm_platform_name()
+{
+    // A realistic logical name: IPC_SHM_PREFIX + make_source_uuid() output.
+    const std::string video = IPC_SHM_PREFIX "source_1234567890123456_0";
+    const std::string audio = video + "_audio";
+
+    const std::string video_name = shm_platform_name(video);
+    const std::string audio_name = shm_platform_name(audio);
+
+    check(video_name.size() <= 31, "video SHM name fits POSIX limit (31 incl '/')");
+    check(audio_name.size() <= 31, "audio SHM name fits POSIX limit (31 incl '/')");
+    check(!video_name.empty() && video_name[0] == '/', "SHM name has leading '/'");
+    check(!audio_name.empty() && audio_name[0] == '/', "audio SHM name has leading '/'");
+
+    // Deterministic: both sides derive the name independently and must agree.
+    check(shm_platform_name(video) == video_name, "SHM name is deterministic");
+
+    // Distinct logical names must not collide onto one region, or the audio and
+    // video paths would trample each other.
+    check(video_name != audio_name, "video and audio names stay distinct");
+    check(shm_platform_name(IPC_SHM_PREFIX "source_1234567890123456_1") != video_name,
+          "different source uuids stay distinct");
+
+    // End-to-end: the name must actually be accepted by the kernel, and the
+    // read side must resolve the same region the write side created.
+    ShmRegion writer;
+    if (check(shm_region_create(writer, video, 4096), "shm_region_create succeeds")) {
+        ShmRegion reader;
+        check(shm_region_open_read(reader, video, 4096),
+              "shm_region_open_read resolves the same region");
+        shm_region_destroy(reader);
+    }
+    shm_region_destroy(writer);
+}
+#endif // !WIN32
+
 int main()
 {
     test_heartbeat_expiry();
     test_shm_mapping_stale();
     test_shm_source_cap();
+#if !defined(WIN32)
+    test_shm_platform_name();
+#endif
 #if defined(WIN32)
     test_win_line_io();
     test_win_broken_pipe();

--- a/tests/ipc-hardening-test.cpp
+++ b/tests/ipc-hardening-test.cpp
@@ -193,6 +193,28 @@ static void test_shm_platform_name()
         shm_region_destroy(reader);
     }
     shm_region_destroy(writer);
+
+    // Regression: a POSIX shm object can be sized exactly once, so a region left
+    // behind by a crashed engine could never be resized and every subsequent
+    // create against that name failed (macOS ftruncate -> EINVAL). Simulate the
+    // leak by creating a region and dropping the handle WITHOUT unlinking, the
+    // way a killed process does, then create again at a larger size.
+    {
+        ShmRegion leaked;
+        if (check(shm_region_create(leaked, video, 4096),
+                  "leak simulation: first create succeeds")) {
+            // Abandon the name exactly as a killed process would: close and
+            // unmap, but never shm_unlink.
+            if (leaked.ptr) munmap(leaked.ptr, leaked.size);
+            if (leaked.fd >= 0) close(leaked.fd);
+            leaked = ShmRegion{};
+        }
+
+        ShmRegion grown;
+        check(shm_region_create(grown, video, 65536),
+              "create over a leaked region succeeds at a larger size");
+        shm_region_destroy(grown);
+    }
 }
 #endif // !WIN32
 

--- a/tests/output-health-test.cpp
+++ b/tests/output-health-test.cpp
@@ -234,6 +234,30 @@ int main()
                        ZoomOutputHealthReason::RawMediaNotReady))
         return 1;
 
+    // Unassigned outputs ("None": participant mode, id 0, not active-speaker)
+    // expect no media and must never be graded waiting/stale or offered
+    // recovery — regression test for None rows showing phantom warnings.
+    ZoomOutputInfo unassigned;
+    unassigned.assignment = AssignmentMode::Participant;
+    unassigned.participant_id = 0;
+    unassigned.active_speaker = false;
+    unassigned.observed_width = 0;
+    unassigned.observed_height = 0;
+    if (!expect_reason("unassigned with no frames is Ok", unassigned,
+                       {participant(1)}, true, ZoomOutputHealthReason::Ok))
+        return 1;
+    unassigned.observed_width = 1920;
+    unassigned.observed_height = 1080;
+    unassigned.video_stale = true;
+    if (!expect_reason("unassigned with latched stale stats is Ok", unassigned,
+                       {participant(1)}, true, ZoomOutputHealthReason::Ok))
+        return 1;
+    // Raw media inactive must also not flag an unassigned output.
+    unassigned.video_stale = false;
+    if (!expect_reason("unassigned ignores raw media inactive", unassigned,
+                       {participant(1)}, false, ZoomOutputHealthReason::Ok))
+        return 1;
+
     // Duplicate + participant missing combination (duplicate should win in current logic order)
     std::vector<ZoomOutputInfo> dup_missing = {output(88), output(88)};
     dup_missing[0].participant_id = 88;

--- a/tests/output-health-test.cpp
+++ b/tests/output-health-test.cpp
@@ -37,7 +37,7 @@ static ZoomOutputInfo output(uint32_t participant_id = 1)
 
 static bool expect_reason(const char *name,
                           ZoomOutputInfo output_info,
-                          std::vector<ParticipantInfo> roster,
+                          const std::vector<ParticipantInfo> &roster,
                           bool raw_media_active,
                           ZoomOutputHealthReason expected)
 {

--- a/tests/zoom-control-parse-test.cpp
+++ b/tests/zoom-control-parse-test.cpp
@@ -135,7 +135,12 @@ static void test_known_commands()
     expect("unknown command is rejected", !is_known_control_command("totally_bogus_cmd"));
     expect("empty command is rejected", !is_known_control_command(""));
     expect("known commands are case sensitive", !is_known_control_command("HELP"));
+    // Intentional regression guard -- known_control_commands() is a fixed
+    // literal list, so cppcheck correctly proves the count is 19 today.
+    // That's the point of this assertion: it forces this test to be updated
+    // whenever a command is added or removed.
     expect("known command list has no duplicates and no gaps",
+           // cppcheck-suppress knownConditionTrueFalse
            known_control_commands().size() == 19);
 }
 

--- a/tests/zoom-osc-wire-test.cpp
+++ b/tests/zoom-osc-wire-test.cpp
@@ -25,11 +25,19 @@ static QByteArray raw_osc_string(const std::string &s)
 
 int main()
 {
-    // pad4 boundary values.
+    // pad4 boundary values. osc_pad4() is a pure function of a literal
+    // argument, so cppcheck's value-flow analysis correctly proves each of
+    // these comparisons is always true -- that is exactly what a regression
+    // assertion on a pure function's known output is supposed to do.
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(0) == 0", osc_pad4(0) == 0);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(1) == 4", osc_pad4(1) == 4);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(3) == 4", osc_pad4(3) == 4);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(4) == 4", osc_pad4(4) == 4);
+    // cppcheck-suppress knownConditionTrueFalse
     expect("pad4(5) == 8", osc_pad4(5) == 8);
 
     // ── Address matching / no-type-tag messages ─────────────────────────
@@ -130,9 +138,6 @@ int main()
     // ── Unsupported type tags ────────────────────────────────────────────
     {
         // 'd' (double) is not a supported tag in this implementation.
-        std::vector<OscArg> in(1);
-        in[0].type = OscArg::Int32;
-        in[0].i = 7;
         // Hand-build so the unsupported tag doesn't trip up osc_build_message
         // (which only knows how to encode 'i' and 's').
         QByteArray pkt = raw_osc_string("/zoom/bad") + raw_osc_string(",id");

--- a/tests/zoom-reconnect-backoff-test.cpp
+++ b/tests/zoom-reconnect-backoff-test.cpp
@@ -1,5 +1,6 @@
 #include "zoom-reconnect-backoff.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 
@@ -58,6 +59,44 @@ int main()
     // backoff policy) still follows the same formula.
     expect_near("multiplier 1.5, attempt 2",
                 compute_backoff_delay_ms(2, 1000, 1.5, 60000, 1.0), 2250);
+
+    // Bounds invariant: for every jitter factor the production RNG can draw
+    // (std::uniform_real_distribution<double>(0.8, 1.2)), the delay must stay
+    // within [0.8 * capped, 1.2 * capped] AND never exceed max_delay_ms. Sweep
+    // the [0.8, 1.2] range across several attempts (both below and at the cap)
+    // to assert the clamp-then-jitter-then-clamp contract holds at the edges.
+    {
+        const double base = 2000, mult = 2.0, cap = 30000;
+        for (int attempt = 0; attempt <= 8; ++attempt) {
+            const double unjittered =
+                compute_backoff_delay_ms(attempt, base, mult, cap, 1.0);
+            for (int k = 0; k <= 40; ++k) {
+                const double jf = 0.8 + (0.4 * k) / 40.0; // walk 0.8 -> 1.2
+                const double d = compute_backoff_delay_ms(attempt, base, mult, cap, jf);
+                if (d < 0.8 * unjittered - 1e-6) {
+                    std::cerr << "jitter bounds: attempt " << attempt
+                              << " factor " << jf << " -> " << d
+                              << " below 0.8x floor " << (0.8 * unjittered) << "\n";
+                    ++g_failures;
+                }
+                // Upper bound is the tighter of (1.2 * pre-jitter delay) and the
+                // cap, since the second clamp re-applies max_delay_ms.
+                const double upper = std::min(1.2 * unjittered, cap);
+                if (d > upper + 1e-6) {
+                    std::cerr << "jitter bounds: attempt " << attempt
+                              << " factor " << jf << " -> " << d
+                              << " above upper bound " << upper << "\n";
+                    ++g_failures;
+                }
+                if (d > cap + 1e-6) {
+                    std::cerr << "jitter bounds: attempt " << attempt
+                              << " factor " << jf << " -> " << d
+                              << " exceeds cap " << cap << "\n";
+                    ++g_failures;
+                }
+            }
+        }
+    }
 
     return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Brings the macOS engine from build-only to live-verified against real meetings:

- **Auth**: Zoom SDK ships inside `ZoomObsEngine.app/Contents/Frameworks` (the framework loads sibling bundles via the main bundle, not rpath); OAuth broker flow verified end to end.
- **Join / roster / active speaker**: full delegate coverage (every meeting-delegate method is `@required`), heartbeat so the plugin can tell a quiet engine from a dead one, join-rejection surfaces as a terminal event.
- **Raw media**: video + audio into shared memory, verified 1920x1080 @ ~33 fps with 48 kHz audio; POSIX shm name length and resize-after-crash fixes.
- **Screen share**: single renderer follows the viewable share across sharer switches; frames keyed by sharing participant; odd window dimensions cropped to even (the SHM I420 layout cannot express odd chroma planes).
- **SDK crash containment**, all live-verified failure modes:
  - `destroyRender:` fires `onRendererBeDestroyed` synchronously on the calling thread — teardown paths detach the delegate first (was a permanent main-thread deadlock).
  - Never subscribe to the local user's own share (never viewable, ≤1 frame, crashed the SDK ~16 s after `SelfEnd`).
  - Frame callbacks `try_lock` and drop rather than block SDK threads; roster rebuilds run outside the share mutex.
  - Heartbeat pings route through the main queue, so a hung main thread trips the plugin's 10 s watchdog instead of zombieing.

## Testing

- 17/17 host tests pass; CI macOS job builds with the same staged OBS headers.
- Live-verified in real meetings: auth → join → roster → active speaker → participant video/audio → remote screen share (2560x1440), self-share ignored cleanly, SDK UI + return video via OBS Virtual Camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)