### PR TITLE
macOS release workflow + 0.1.32-beta.1 changelog

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,212 @@
+name: Release (macOS)
+
+# Builds the distributable macOS plugin bundle and attaches it to the GitHub
+# release for the pushed tag. Runs alongside release-windows.yml on the same
+# tag; softprops adds assets to the existing release rather than clobbering it.
+#
+# The bundle is ad-hoc signed: there is no Developer ID identity or
+# notarization yet, so testers must clear the quarantine attribute once after
+# unzipping (instructions ship inside the zip). Tags containing '-' (e.g.
+# v0.1.32-beta.1) are marked as pre-releases.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to publish, for example v0.1.32-beta.1"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    name: macOS arm64 release bundle
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Resolve release tag
+        id: release
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${INPUT_VERSION}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+          if ! [[ "$tag" =~ ^v[0-9A-Za-z.-]+$ ]]; then
+            echo "::error::Refusing suspicious tag '$tag'"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "name=CoreVideo $tag" >> "$GITHUB_OUTPUT"
+          if [[ "$tag" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        run: brew install cmake qt@6
+
+      # Same header-only OBS staging as build.yml: the plugin links with
+      # -undefined dynamic_lookup, so headers are all that is needed at build
+      # time.
+      - name: Get OBS headers
+        run: |
+          OBS_VER=30.2.2
+          curl -fL \
+              "https://github.com/obsproject/obs-studio/archive/refs/tags/${OBS_VER}.tar.gz" \
+              -o obs-source.tar.gz
+          mkdir -p /tmp/obs-source
+          tar -xzf obs-source.tar.gz --strip-components=1 \
+              -C /tmp/obs-source \
+              "obs-studio-${OBS_VER}/libobs" \
+              "obs-studio-${OBS_VER}/UI/obs-frontend-api"
+
+          mkdir -p /tmp/obs-sdk/include/obs \
+                   /tmp/obs-sdk/cmake/LibObs \
+                   /tmp/obs-sdk/cmake/obs-frontend-api
+
+          cp -R /tmp/obs-source/libobs/*                            /tmp/obs-sdk/include/obs/
+          cp /tmp/obs-source/UI/obs-frontend-api/obs-frontend-api.h /tmp/obs-sdk/include/obs/
+
+          printf '%s\n' \
+              'add_library(OBS::libobs INTERFACE IMPORTED GLOBAL)' \
+              'set_target_properties(OBS::libobs PROPERTIES' \
+              '    INTERFACE_INCLUDE_DIRECTORIES "/tmp/obs-sdk/include/obs")' \
+              'set(LibObs_FOUND TRUE)' \
+              > /tmp/obs-sdk/cmake/LibObs/LibObsConfig.cmake
+
+          printf '%s\n' \
+              'add_library(OBS::obs-frontend-api INTERFACE IMPORTED GLOBAL)' \
+              'set_target_properties(OBS::obs-frontend-api PROPERTIES' \
+              '    INTERFACE_INCLUDE_DIRECTORIES "/tmp/obs-sdk/include/obs")' \
+              'set(obs-frontend-api_FOUND TRUE)' \
+              > /tmp/obs-sdk/cmake/obs-frontend-api/obs-frontend-apiConfig.cmake
+
+      # The bundle script resolves the plugin's Qt against a real OBS.app so
+      # the shipped bundle binds OBS's own Qt at load time. Runners have no
+      # OBS installed; use the same app version the port was live-tested with.
+      - name: Download OBS.app
+        run: |
+          OBS_APP_VER=32.0.4
+          curl -fL \
+              "https://github.com/obsproject/obs-studio/releases/download/${OBS_APP_VER}/OBS-Studio-${OBS_APP_VER}-macOS-Apple.dmg" \
+              -o obs.dmg
+          MOUNT_DIR="$(hdiutil attach -nobrowse -readonly obs.dmg | awk -F'\t' '/\/Volumes\//{print $NF}' | tail -1)"
+          echo "Mounted at: ${MOUNT_DIR}"
+          test -d "${MOUNT_DIR}/OBS.app/Contents/Frameworks"
+          echo "OBS_APP=${MOUNT_DIR}/OBS.app" >> "$GITHUB_ENV"
+
+      # The macOS Zoom Meeting SDK lives as a private draft-release asset
+      # (never commit it; never publish that draft release). Unlike build.yml
+      # this is a hard requirement: a release bundle without the engine would
+      # be a plugin that cannot join meetings.
+      - name: Download Zoom macOS SDK (private draft-release asset)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          asset_name="zoom-sdk-macos-7.1.5.84750.zip"
+          asset_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
+              --jq ".[] | select(.draft) | .assets[] | select(.name==\"${asset_name}\") | .id" \
+              | head -1)"
+          if [ -z "${asset_id}" ]; then
+              echo "::error::${asset_name} not found on any draft release; cannot build a release bundle."
+              exit 1
+          fi
+          gh api -H "Accept: application/octet-stream" \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > zoom-sdk.zip
+          mkdir -p third_party/zoom-sdk-extracted
+          unzip -q zoom-sdk.zip -d third_party/zoom-sdk-extracted
+          sdk_root="$(find third_party/zoom-sdk-extracted -maxdepth 3 -type d -name ZoomSDK \
+              -exec test -d '{}/ZoomSDK.framework' ';' -print | head -1)"
+          if [ -z "${sdk_root}" ]; then
+              echo "::error::Could not locate ZoomSDK/ZoomSDK.framework in the SDK archive."
+              exit 1
+          fi
+          rm -rf third_party/zoom-sdk
+          mv "${sdk_root}" third_party/zoom-sdk
+          rm -rf third_party/zoom-sdk-extracted zoom-sdk.zip
+
+      - name: Configure
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          QT_PREFIX="$(brew --prefix qt@6)"
+          cmake -B build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_OSX_ARCHITECTURES=arm64 \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+              -DCOREVIDEO_BUILD_PLUGIN=ON \
+              -DCOREVIDEO_BUILD_ENGINE=ON \
+              -DZOOM_SDK_DIR=third_party/zoom-sdk \
+              "-DCOREVIDEO_RELEASE_VERSION=${RELEASE_TAG}" \
+              "-DCMAKE_PREFIX_PATH=/tmp/obs-sdk;$QT_PREFIX" \
+              "-DLibObs_DIR=/tmp/obs-sdk/cmake/LibObs" \
+              "-Dobs-frontend-api_DIR=/tmp/obs-sdk/cmake/obs-frontend-api" \
+              "-DZOOM_EMBED_SDK_KEY=${{ secrets.ZOOM_EMBED_SDK_KEY }}" \
+              "-DZOOM_EMBED_SDK_SECRET=${{ secrets.ZOOM_EMBED_SDK_SECRET }}" \
+              "-DZOOM_EMBED_JWT_TOKEN=${{ secrets.ZOOM_EMBED_JWT_TOKEN }}" \
+              "-DZOOM_EMBED_OAUTH_CLIENT_ID=y6sIWSwiTZe1JygMx4C9EQ" \
+              "-DZOOM_EMBED_OAUTH_AUTHORIZATION_URL=${{ secrets.ZOOM_EMBED_OAUTH_AUTHORIZATION_URL }}" \
+              "-DZOOM_EMBED_MEETING_SDK_PUBLIC_APP_KEY=y6sIWSwiTZe1JygMx4C9EQ"
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Assemble plugin bundle
+        run: |
+          scripts/make-macos-bundle.sh \
+              --build-dir build \
+              --zoom-sdk third_party/zoom-sdk \
+              --obs-app "$OBS_APP" \
+              --qt-prefix "$(brew --prefix qt@6)"
+
+      - name: Package as ZIP
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          STAGE=package/CoreVideo-macOS
+          mkdir -p "$STAGE"
+          cp -R build/obs-zoom-plugin.plugin "$STAGE/"
+          cat > "$STAGE/INSTALL.txt" <<'EOF'
+          CoreVideo for OBS - macOS (Apple Silicon) BETA
+
+          1. Quit OBS.
+          2. Copy obs-zoom-plugin.plugin into:
+               ~/Library/Application Support/obs-studio/plugins/
+             (create the plugins folder if it does not exist)
+          3. This beta is not yet notarized, so macOS will quarantine it.
+             Clear the flag once, in Terminal:
+               xattr -dr com.apple.quarantine \
+                 ~/Library/Application\ Support/obs-studio/plugins/obs-zoom-plugin.plugin
+          4. Start OBS. CoreVideo appears as "Zoom Control" (View > Docks)
+             and as the CoreVideo source types.
+
+          Requires OBS Studio 30.2+ for Apple Silicon. On first join, macOS
+          will ask for camera/microphone permissions for ZoomObsEngine.
+          EOF
+          cd package && zip -ry "../CoreVideo-${TAG}-macOS-arm64.zip" CoreVideo-macOS
+          cd .. && shasum -a 256 "CoreVideo-${TAG}-macOS-arm64.zip"
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: ${{ steps.release.outputs.name }}
+          prerelease: ${{ steps.release.outputs.prerelease }}
+          fail_on_unmatched_files: true
+          files: |
+            CoreVideo-${{ steps.release.outputs.tag }}-macOS-arm64.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+## [0.1.32-beta.1] - 2026-08-01
+
+### Added
+- **macOS (Apple Silicon) beta.** First distributable macOS build of the OBS
+  plugin, live-verified against real meetings: OAuth sign-in, join, roster,
+  active speaker, participant video (1080p) and audio into OBS sources, and
+  remote screen share (up to 1440p verified). Return video reaches the
+  meeting through the OBS Virtual Camera selected in the Zoom SDK window.
+  Known limitations: the bundle is not yet notarized (testers must clear the
+  quarantine attribute once — see INSTALL.txt in the zip), it is arm64-only,
+  and capturing your own screen should use OBS's native macOS Screen Capture
+  source — the CoreVideo share source carries *other participants'* shares.
+
+### Fixed
+- A video subscription failure no longer flips a healthy session to
+  "Connection failed", and a source bound to a participant who has not
+  (re)joined waits quietly instead of raising repeated error dialogs.
+- The dock no longer shows a previous attempt's failure banner after a
+  successful join.
+
 ## [0.1.31] - 2026-08-01
 
 ### Fixed


### PR DESCRIPTION
Adds `release-macos.yml` (mirror of the Windows release flow) so `v*` tags publish a distributable macOS arm64 plugin bundle — SDK copied into the engine app, ad-hoc signed, INSTALL.txt with the quarantine workaround — and the 0.1.32-beta.1 changelog entry covering the macOS beta and tonight's session-state fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)