### PR TITLE
Pin third-party release actions to commit SHAs

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -202,7 +202,7 @@ jobs:
           cd .. && shasum -a 256 "CoreVideo-${TAG}-macOS-arm64.zip"
 
       - name: Publish release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           name: ${{ steps.release.outputs.name }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -26,7 +26,7 @@ jobs:
           ref: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref }}"
 
       - name: Set up MSVC tools
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: x64
 
@@ -271,7 +271,7 @@ jobs:
 
       - name: Publish GitHub Release
         if: env.COREVIDEO_HAS_ZOOM_RUNTIME == 'true'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           name: ${{ steps.release.outputs.name }}


### PR DESCRIPTION
Flagged by security review of the new macOS release workflow; applied to the Windows one too. Mutable tags on third-party actions running with `contents: write` are a supply-chain risk; both are now SHA-pinned with the version noted in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)