### PR TITLE
Fix Windows release SDK lookup broken by runner PowerShell quoting change

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -113,7 +113,16 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
-          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          # Filter in PowerShell, not --jq: embedded \" quoting in a native-
+          # command argument tokenizes differently across PowerShell versions,
+          # and a runner-image update turned the jq expression into three args
+          # ("accepts 1 arg(s), received 3"), silently skipping the SDK.
+          $releases = gh api "repos/$env:GITHUB_REPOSITORY/releases" | ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0) { throw "gh api releases failed" }
+          $assetId = $releases | Where-Object { $_.draft } |
+            ForEach-Object { $_.assets } |
+            Where-Object { $_.name -eq $assetName } |
+            Select-Object -First 1 -ExpandProperty id
           if (-not $assetId) {
             "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append


### PR DESCRIPTION
The `gh api --jq` call with embedded `\"` escapes tokenized differently after a runner image update, so the Windows SDK draft asset was never found and the beta release's Windows package failed validation. Filter the releases JSON in PowerShell instead, and throw if the API call fails rather than silently degrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)