### PR TITLE
Fix vacuously-green Windows CI and empty OBS import libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,22 @@ jobs:
           Copy-Item "C:\obs-source\libobs\*"                               "$sdk\include\obs\" -Recurse -Force
           Copy-Item "C:\obs-source\UI\obs-frontend-api\obs-frontend-api.h" "$sdk\include\obs\"
 
-          # Import libs from DLL export tables
+          # Import libs from DLL export tables. Read the PE export directory
+          # with pefile instead of scraping dumpbin text: a runner-image
+          # update changed the output enough that the old regex matched
+          # nothing, and lib.exe happily built EMPTY import libraries (~1.5KB)
+          # that made every obs_* symbol come up unresolved at link.
+          python -m pip install --quiet pefile
+          $py = @'
+          import sys, pefile
+          pe = pefile.PE(sys.argv[1], fast_load=True)
+          pe.parse_data_directories(directories=[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_EXPORT']])
+          print('\n'.join(e.name.decode() for e in pe.DIRECTORY_ENTRY_EXPORT.symbols if e.name))
+          '@
+          # The here-string keeps the YAML block's indentation; python cares.
+          $py = ($py -split "`n" | ForEach-Object { $_.TrimStart() }) -join "`n"
+          Set-Content -Path "$sdk\export-names.py" -Value $py -Encoding ASCII
+
           New-Item -Force -ItemType Directory "$sdk\lib" | Out-Null
           foreach ($name in @("obs", "obs-frontend-api")) {
               $dll = "$obs\bin\64bit\$name.dll"
@@ -71,14 +86,15 @@ jobs:
               $def = "$sdk\lib\$name.def"
               $lib = "$sdk\lib\$name.lib"
 
-              $exports = @("EXPORTS")
-              (dumpbin /nologo /exports $dll) | ForEach-Object {
-                  if ($_ -match "^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)\s*$") {
-                      $exports += "  $($Matches[1])"
-                  }
+              $names = @(python "$sdk\export-names.py" $dll)
+              if ($LASTEXITCODE -ne 0) { throw "pefile export parse failed for $dll" }
+              Write-Host "$name.dll exports: $($names.Count)"
+              if ($names.Count -lt 10) {
+                  throw "Only $($names.Count) exports parsed from $dll - refusing to build an empty import library."
               }
-              $exports | Set-Content $def -Encoding ASCII
+              @("EXPORTS") + ($names | ForEach-Object { "  $_" }) | Set-Content $def -Encoding ASCII
               lib /nologo /def:$def /out:$lib /machine:x64
+              if ($LASTEXITCODE -ne 0) { throw "lib.exe failed for $def" }
           }
 
           # CMake config files (always generated; never use the zip's copies)
@@ -123,7 +139,17 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
-          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          # Filter in PowerShell, not --jq: embedded \" quoting broke when the
+          # runner image changed native-argument tokenization, and the lookup
+          # failed as "accepts 1 arg(s), received 3" - which this step then
+          # treated as "no SDK", making the whole job green while never
+          # compiling the plugin at all.
+          $releases = gh api "repos/$env:GITHUB_REPOSITORY/releases" | ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0) { throw "gh api releases failed" }
+          $assetId = $releases | Where-Object { $_.draft } |
+              ForEach-Object { $_.assets } |
+              Where-Object { $_.name -eq $assetName } |
+              Select-Object -First 1 -ExpandProperty id
           if (-not $assetId) {
               "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
               "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -134,8 +160,14 @@ jobs:
           curl.exe -sSfL -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/octet-stream" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$assetId" -o zoom-sdk.zip
           if ((Get-Item zoom-sdk.zip).Length -lt 100MB) { throw "Downloaded SDK archive is implausibly small." }
           Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted
-          $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
-          Move-Item $inner.FullName third_party/zoom-sdk
+          # Find the directory that actually holds the SDK rather than trusting
+          # archive nesting: "first directory" broke when extraction layout
+          # shifted and CMake then quietly skipped the engine.
+          $sdkRoot = Get-ChildItem third_party/zoom-sdk-extracted -Directory -Recurse -Depth 3 |
+              Where-Object { Test-Path (Join-Path $_.FullName "h\zoom_sdk.h") } |
+              Select-Object -First 1
+          if (-not $sdkRoot) { throw "h/zoom_sdk.h not found anywhere in $assetName" }
+          Move-Item $sdkRoot.FullName third_party/zoom-sdk
           "COREVIDEO_HAS_ZOOM_RUNTIME=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "has_zoom_runtime=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -61,6 +61,20 @@ jobs:
           Copy-Item "C:\obs-source\libobs\*" "$sdk\include\obs\" -Recurse -Force
           Copy-Item "C:\obs-source\UI\obs-frontend-api\obs-frontend-api.h" "$sdk\include\obs\"
 
+          # Import libs from the PE export directory via pefile, not dumpbin
+          # text scraping - a runner-image update changed dumpbin's output
+          # enough that the regex matched nothing and lib.exe built EMPTY
+          # import libraries; every obs_* symbol then failed to resolve.
+          python -m pip install --quiet pefile
+          $py = @'
+          import sys, pefile
+          pe = pefile.PE(sys.argv[1], fast_load=True)
+          pe.parse_data_directories(directories=[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_EXPORT']])
+          print('\n'.join(e.name.decode() for e in pe.DIRECTORY_ENTRY_EXPORT.symbols if e.name))
+          '@
+          $py = ($py -split "`n" | ForEach-Object { $_.TrimStart() }) -join "`n"
+          Set-Content -Path "$sdk\export-names.py" -Value $py -Encoding ASCII
+
           New-Item -Force -ItemType Directory "$sdk\lib" | Out-Null
           foreach ($name in @("obs", "obs-frontend-api")) {
             $dll = "$obs\bin\64bit\$name.dll"
@@ -70,14 +84,15 @@ jobs:
 
             $def = "$sdk\lib\$name.def"
             $lib = "$sdk\lib\$name.lib"
-            $exports = @("EXPORTS")
-            (dumpbin /nologo /exports $dll) | ForEach-Object {
-              if ($_ -match "^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)\s*$") {
-                $exports += "  $($Matches[1])"
-              }
+            $names = @(python "$sdk\export-names.py" $dll)
+            if ($LASTEXITCODE -ne 0) { throw "pefile export parse failed for $dll" }
+            Write-Host "$name.dll exports: $($names.Count)"
+            if ($names.Count -lt 10) {
+              throw "Only $($names.Count) exports parsed from $dll - refusing to build an empty import library."
             }
-            $exports | Set-Content $def -Encoding ASCII
+            @("EXPORTS") + ($names | ForEach-Object { "  $_" }) | Set-Content $def -Encoding ASCII
             lib /nologo /def:$def /out:$lib /machine:x64
+            if ($LASTEXITCODE -ne 0) { throw "lib.exe failed for $def" }
           }
 
           $sdkFwd = $sdk -replace '\\', '/'
@@ -133,14 +148,19 @@ jobs:
           curl.exe -sSfL -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/octet-stream" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$assetId" -o zoom-sdk.zip
           if ((Get-Item zoom-sdk.zip).Length -lt 100MB) { throw "Downloaded SDK archive is implausibly small." }
           Expand-Archive zoom-sdk.zip third_party/zoom-sdk-extracted -Force
-          $inner = Get-ChildItem third_party/zoom-sdk-extracted -Directory | Select-Object -First 1
-          if (-not $inner) {
-            throw "Zoom SDK archive did not contain an extracted SDK directory."
+          # Find the directory that actually holds the SDK rather than trusting
+          # archive nesting: "first directory" broke when extraction layout
+          # shifted and CMake then quietly skipped the engine.
+          $sdkRoot = Get-ChildItem third_party/zoom-sdk-extracted -Directory -Recurse -Depth 3 |
+            Where-Object { Test-Path (Join-Path $_.FullName "h\zoom_sdk.h") } |
+            Select-Object -First 1
+          if (-not $sdkRoot) {
+            throw "h/zoom_sdk.h not found anywhere in $assetName"
           }
           if (Test-Path third_party/zoom-sdk) {
             Remove-Item third_party/zoom-sdk -Recurse -Force
           }
-          Move-Item $inner.FullName third_party/zoom-sdk
+          Move-Item $sdkRoot.FullName third_party/zoom-sdk
           "COREVIDEO_HAS_ZOOM_RUNTIME=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "has_zoom_runtime=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 


### PR DESCRIPTION
Two runner-image casualties, both failing soft:

1. The `gh api --jq` SDK lookup broke ("accepts 1 arg(s), received 3"), which build.yml treated as "no SDK available" — so Windows CI has been green without ever compiling the plugin. Same PowerShell-side JSON filtering fix as #174, now applied to CI.
2. dumpbin's output format shifted enough that the export-parsing regex matched nothing, producing ~1.5KB **empty** import libraries; the first genuine link (release re-run) failed with every obs_* symbol unresolved. Exports now come from the PE export directory via `pefile`, with a hard failure below 10 exports, on `lib.exe` errors, and when `h/zoom_sdk.h` can't be located in the SDK archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)