### PR TITLE
Home page: latest-release link + macOS beta guide row

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -23,7 +23,8 @@ Welcome to the CoreVideo wiki - an OBS Studio plugin for live Zoom meeting video
 | Documentation site | https://corevideo.io/documentation/ |
 | Core plugin guide | https://corevideo.io/core-plugin/ |
 | OAuth / Marketplace setup | https://corevideo.io/oauth/ |
-| Latest Windows release | https://github.com/iamfatness/CoreVideo/releases/tag/v0.1.18 |
+| Latest Windows release | https://github.com/iamfatness/CoreVideo/releases/latest |
+| macOS beta (Apple Silicon) + install guide | https://corevideo.io/documentation/#mac-beta |
 | Source code | https://github.com/iamfatness/CoreVideo |
 | Issues & bug reports | https://github.com/iamfatness/CoreVideo/issues |
 | Releases | https://github.com/iamfatness/CoreVideo/releases |


### PR DESCRIPTION
Follow-up to #181: the landing page's release link was pinned to v0.1.18; now /releases/latest, plus a row linking the macOS beta install guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)