### PR TITLE
Home page: macOS beta card in resource grid

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -162,6 +162,7 @@ function homeContent() {
 </section>
 <section class="link-grid" aria-label="CoreVideo resources">
   <a href="/documentation/"><strong>Plugin Docs</strong><span>Architecture, setup, control APIs, and operating notes.</span></a>
+  <a href="/documentation/#mac-beta"><strong>macOS Beta (Apple Silicon)</strong><span>Install the CoreVideo OBS plugin beta on Apple Silicon Macs.</span></a>
   <a href="/core-plugin/"><strong>Core Plugin Guide</strong><span>OBS workflows, participant routing, isolated audio, and ISO recording.</span></a>
   <a href="/pro/"><strong>CoreVideo Pro</strong><span>Standalone production app for live and recorded conversations.</span></a>
   <a href="/pro/documentation/"><strong>CoreVideo Pro Architecture</strong><span>Native media core, typed IPC, capture, AI direction, and outputs &mdash; with diagrams.</span></a>


### PR DESCRIPTION
The root page is a hardcoded template in build-site.mjs; adds a card linking /documentation/#mac-beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)