### PR TITLE
Fix SHM resize deadlock: generation-suffixed region names

### DIFF
--- a/engine/src/engine-audio.cpp
+++ b/engine/src/engine-audio.cpp
@@ -163,8 +163,15 @@ bool EngineAudio::ensure_shm(AudioTarget &target,
     const size_t total = sizeof(ShmAudioHeader) + byte_len;
     if (target.shm.ptr && target.shm.size >= total) return true;
 
-    const std::string region_name = IPC_SHM_PREFIX + source_uuid + "_audio";
-    return shm_region_create(target.shm, region_name, total);
+    // Bump the generation BEFORE creating and bake it into the name: a
+    // resize under the old name deadlocks while the plugin still maps the
+    // old (smaller) section (see shm_region_name in engine-ipc.h).
+    const uint32_t next_gen = target.shm_gen + 1;
+    const std::string region_name =
+        shm_region_name(IPC_SHM_PREFIX + source_uuid + "_audio", next_gen);
+    if (!shm_region_create(target.shm, region_name, total)) return false;
+    target.shm_gen = next_gen;
+    return true;
 }
 
 void EngineAudio::output_audio_frame(AudioTarget &target,
@@ -183,7 +190,8 @@ void EngineAudio::output_audio_frame(AudioTarget &target,
             EngineIpc::write(
                 R"({"cmd":"debug","stage":"audio_shm_create_failed","source_uuid":")" +
                 source_uuid + R"(","byte_len":)" +
-                std::to_string(byte_len) + "}");
+                std::to_string(byte_len) + R"(,"last_error":)" +
+                std::to_string(target.shm.last_error) + "}");
             EngineIpc::write(
                 R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
                 source_uuid + R"(","byte_len":)" +
@@ -227,7 +235,8 @@ void EngineAudio::output_audio_frame(AudioTarget &target,
     EngineIpc::write(
         R"({"cmd":"audio","source_uuid":")" + source_uuid +
         R"(","participant_id":)" + std::to_string(target.participant_id) +
-        R"(,"byte_len":)" + std::to_string(byte_len) + "}");
+        R"(,"byte_len":)" + std::to_string(byte_len) +
+        R"(,"shm_gen":)" + std::to_string(target.shm_gen) + "}");
 }
 
 void EngineAudio::onMixedAudioRawDataReceived(AudioRawData *data)

--- a/engine/src/engine-audio.h
+++ b/engine/src/engine-audio.h
@@ -60,6 +60,7 @@ private:
         bool isolate_audio = false;
         bool audience_audio = false;
         ShmRegion shm;
+        uint32_t shm_gen = 0; // region generation; part of the name from gen 2
         uint64_t frame_count = 0;
         // True after an ensure_shm() failure has been surfaced as an error —
         // avoids re-emitting once per audio callback while the failure persists.

--- a/engine/src/engine-share.cpp
+++ b/engine/src/engine-share.cpp
@@ -254,9 +254,14 @@ bool EngineShare::ensure_shm(ShareTarget &target,
     if (total < y_len) return false;
     if (target.shm.ptr && target.shm.size >= total) return true;
 
-    const std::string region_name = IPC_SHM_PREFIX + source_uuid;
+    // Bump the generation BEFORE creating and bake it into the name: a
+    // resize under the old name deadlocks while the plugin still maps the
+    // old (smaller) section (see shm_region_name in engine-ipc.h).
+    const uint32_t next_gen = target.shm_gen + 1;
+    const std::string region_name =
+        shm_region_name(IPC_SHM_PREFIX + source_uuid, next_gen);
     if (!shm_region_create(target.shm, region_name, total)) return false;
-    ++target.shm_gen; // new region — old plugin-side mappings are now stale
+    target.shm_gen = next_gen; // old plugin-side mappings are now stale
     return true;
 }
 
@@ -304,7 +309,9 @@ void EngineShare::onRawDataFrameReceived(YUVRawDataI420 *data)
             if (!target.shm_fail_reported) {
                 target.shm_fail_reported = true;
                 EngineIpc::write(
-                    R"({"cmd":"debug","stage":"share_shm_create_failed","source_uuid":")" +
+                    R"({"cmd":"debug","stage":"share_shm_create_failed","last_error":)" +
+                    std::to_string(target.shm.last_error) +
+                    R"(,"source_uuid":")" +
                     source_uuid + R"(","w":)" + std::to_string(w) +
                     R"(,"h":)" + std::to_string(h) + "}");
                 EngineIpc::write(

--- a/engine/src/engine-video.cpp
+++ b/engine/src/engine-video.cpp
@@ -168,9 +168,14 @@ bool ParticipantSubscription::ensure_shm(SourceTarget &target,
     if (total < y_len) return false;
     if (target.shm.ptr && target.shm.size >= total) return true;
 
-    const std::string region_name = IPC_SHM_PREFIX + source_uuid;
+    // Bump the generation BEFORE creating and bake it into the name: a
+    // resize under the old name deadlocks while the plugin still maps the
+    // old (smaller) section (see shm_region_name in engine-ipc.h).
+    const uint32_t next_gen = target.shm_gen + 1;
+    const std::string region_name =
+        shm_region_name(IPC_SHM_PREFIX + source_uuid, next_gen);
     if (!shm_region_create(target.shm, region_name, total)) return false;
-    ++target.shm_gen; // new region — old plugin-side mappings are now stale
+    target.shm_gen = next_gen; // old plugin-side mappings are now stale
     return true;
 }
 
@@ -203,7 +208,9 @@ void ParticipantSubscription::onRawDataFrameReceived(YUVRawDataI420 *data)
                     R"({"cmd":"debug","stage":"video_shm_create_failed","source_uuid":")" +
                     source_uuid + R"(","participant_id":)" +
                     std::to_string(m_participant_id) + R"(,"w":)" +
-                    std::to_string(w) + R"(,"h":)" + std::to_string(h) + "}");
+                    std::to_string(w) + R"(,"h":)" + std::to_string(h) +
+                    R"(,"last_error":)" +
+                    std::to_string(target.shm.last_error) + "}");
                 EngineIpc::write(
                     R"({"cmd":"error","msg":"shm_create_failed","source_uuid":")" +
                     source_uuid + R"(","participant_id":)" +

--- a/src/engine-ipc.h
+++ b/src/engine-ipc.h
@@ -112,11 +112,25 @@ struct ShmAudioHeader {
 #endif
 
 // ── Shared-memory region ──────────────────────────────────────────────────────
+
+// A region's name carries its generation from the second generation on.
+// A Windows named section cannot be recreated at a larger size while any
+// process still maps the old one (CreateFileMapping returns the existing
+// smaller section and the larger MapViewOfFile fails forever), so a resize
+// must move to a fresh name. Generations 0/1 keep the legacy unsuffixed
+// name so engines that never resize interoperate with older plugins.
+inline std::string shm_region_name(const std::string &base, uint32_t gen)
+{
+    if (gen <= 1) return base;
+    return base + "_g" + std::to_string(gen);
+}
+
 #if defined(WIN32)
    struct ShmRegion {
        HANDLE  map_handle = nullptr;
        void   *ptr        = nullptr;
        size_t  size       = 0;
+       uint32_t last_error = 0; // GetLastError() of the most recent failure
    };
 
    inline void shm_region_destroy(ShmRegion &r)
@@ -132,10 +146,15 @@ struct ShmAudioHeader {
        r.map_handle = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr,
                                          PAGE_READWRITE, 0,
                                          static_cast<DWORD>(size), name.c_str());
-       if (!r.map_handle) return false;
+       if (!r.map_handle) { r.last_error = GetLastError(); return false; }
        r.ptr  = MapViewOfFile(r.map_handle, FILE_MAP_WRITE, 0, 0, size);
        r.size = r.ptr ? size : 0;
-       if (!r.ptr) { shm_region_destroy(r); return false; }
+       if (!r.ptr) {
+           r.last_error = GetLastError();
+           shm_region_destroy(r);
+           return false;
+       }
+       r.last_error = 0;
        return true;
    }
 
@@ -158,6 +177,7 @@ struct ShmAudioHeader {
        size_t      size = 0;
        std::string name; // stored so we can shm_unlink on destroy
        bool        owner = false;
+       uint32_t    last_error = 0; // errno of the most recent failure
    };
 
    inline void shm_region_destroy(ShmRegion &r)
@@ -179,11 +199,21 @@ struct ShmAudioHeader {
        r.name = "/" + name; // shm_open requires a leading '/'
        r.owner = true;
        r.fd   = shm_open(r.name.c_str(), O_CREAT | O_RDWR, 0600);
-       if (r.fd < 0) return false;
-       if (ftruncate(r.fd, static_cast<off_t>(size)) < 0) { shm_region_destroy(r); return false; }
+       if (r.fd < 0) { r.last_error = static_cast<uint32_t>(errno); return false; }
+       if (ftruncate(r.fd, static_cast<off_t>(size)) < 0) {
+           r.last_error = static_cast<uint32_t>(errno);
+           shm_region_destroy(r);
+           return false;
+       }
        r.ptr  = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, r.fd, 0);
        r.size = (r.ptr != MAP_FAILED) ? size : 0;
-       if (r.ptr == MAP_FAILED) { r.ptr = nullptr; shm_region_destroy(r); return false; }
+       if (r.ptr == MAP_FAILED) {
+           r.last_error = static_cast<uint32_t>(errno);
+           r.ptr = nullptr;
+           shm_region_destroy(r);
+           return false;
+       }
+       r.last_error = 0;
        return true;
    }
 

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -867,7 +867,8 @@ void ZoomEngineClient::handle_event(const std::string &line)
     if (cmd == "audio" && callbacks.on_audio) {
         callbacks.on_audio(static_cast<uint32_t>(obj.value("byte_len").toInt()),
                            static_cast<uint32_t>(
-                               obj.value("participant_id").toInt()));
+                               obj.value("participant_id").toInt()),
+                           static_cast<uint32_t>(obj.value("shm_gen").toInt()));
     }
 }
 

--- a/src/zoom-engine-client.h
+++ b/src/zoom-engine-client.h
@@ -29,7 +29,8 @@ public:
                            uint32_t participant_id,
                            uint32_t shm_generation)> on_frame;
         std::function<void(uint32_t byte_len,
-                           uint32_t participant_id)> on_audio;
+                           uint32_t participant_id,
+                           uint32_t shm_generation)> on_audio;
     };
 
     static ZoomEngineClient &instance();

--- a/src/zoom-participant-audio-source.cpp
+++ b/src/zoom-participant-audio-source.cpp
@@ -55,6 +55,7 @@ struct CoreVideoAudioSource {
     std::atomic<bool> active{false};
     std::mutex mtx;
     ShmRegion audio_shm;
+    uint32_t audio_shm_gen = 0;
     std::vector<uint8_t> audio_buf;
     std::vector<int16_t> stereo_buf;
     uint64_t frame_count = 0;
@@ -134,22 +135,34 @@ static void maybe_resubscribe_for_roster(CoreVideoAudioSource *ctx)
 
 static void output_audio_frame(CoreVideoAudioSource *ctx,
                                uint32_t event_byte_len,
-                               uint32_t resolved_participant_id)
+                               uint32_t resolved_participant_id,
+                               uint32_t event_shm_gen)
 {
     if (!ctx || event_byte_len == 0) return;
 
     std::lock_guard<std::mutex> lk(ctx->mtx);
-    const std::string shm_name = IPC_SHM_PREFIX + ctx->source_uuid + "_audio";
+    const std::string audio_base = IPC_SHM_PREFIX + ctx->source_uuid + "_audio";
+    const std::string shm_name = shm_region_name(audio_base, event_shm_gen);
     const size_t audio_bytes = sizeof(ShmAudioHeader) + event_byte_len;
-    if ((!ctx->audio_shm.ptr || ctx->audio_shm.size < audio_bytes) &&
-        !shm_region_open_read(ctx->audio_shm, shm_name, audio_bytes)) {
-        if (ctx->frame_count == 0) {
-            blog(LOG_WARNING,
-                 "[obs-zoom-plugin] Failed to open CoreVideo audio shared memory: source=%s uuid=%s bytes=%zu",
-                 obs_source_get_name(ctx->source), ctx->source_uuid.c_str(),
-                 audio_bytes);
+    const bool gen_changed = event_shm_gen != 0 &&
+                             event_shm_gen != ctx->audio_shm_gen;
+    if (ctx->audio_shm.ptr && gen_changed)
+        shm_region_destroy(ctx->audio_shm);
+    if (!ctx->audio_shm.ptr || ctx->audio_shm.size < audio_bytes) {
+        if (!shm_region_open_read(ctx->audio_shm, shm_name, audio_bytes) &&
+            // Engines predating suffixed names recreate the legacy name for
+            // every generation — fall back to it.
+            (event_shm_gen <= 1 ||
+             !shm_region_open_read(ctx->audio_shm, audio_base, audio_bytes))) {
+            if (ctx->frame_count == 0) {
+                blog(LOG_WARNING,
+                     "[obs-zoom-plugin] Failed to open CoreVideo audio shared memory: source=%s uuid=%s bytes=%zu gen=%u",
+                     obs_source_get_name(ctx->source), ctx->source_uuid.c_str(),
+                     audio_bytes, event_shm_gen);
+            }
+            return;
         }
-        return;
+        ctx->audio_shm_gen = event_shm_gen;
     }
 
     auto *hdr = static_cast<const ShmAudioHeader *>(ctx->audio_shm.ptr);
@@ -250,10 +263,11 @@ static void *audio_create_common(obs_data_t *settings, obs_source_t *source,
     ZoomEngineClient::instance().register_source(ctx->source_uuid, {
         {},
         [ctx, gate = ctx->callback_gate](uint32_t byte_len,
-                                         uint32_t participant_id) {
+                                         uint32_t participant_id,
+                                         uint32_t shm_gen) {
             std::lock_guard<std::mutex> callback_lock(gate->mtx);
             if (!gate->alive) return;
-            output_audio_frame(ctx, byte_len, participant_id);
+            output_audio_frame(ctx, byte_len, participant_id, shm_gen);
         }
     });
     ZoomEngineClient::instance().add_roster_callback(ctx,

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -795,6 +795,10 @@ void ZoomSource::clear_subscription_state()
     ZoomEngineClient::instance().unsubscribe(source_uuid);
     if (!m_director_preview_uuid.empty())
         ZoomEngineClient::instance().unsubscribe(m_director_preview_uuid);
+    // Drop our SHM mappings: a held mapping keeps the named section alive,
+    // which blocks the engine from ever recreating it at a larger size —
+    // and makes clearing the assignment an operator recovery tool.
+    release_shared_memory();
     m_subscribed = false;
     m_current_subscription_id = 0;
     m_director_preview_subscription_id = 0;
@@ -1126,15 +1130,20 @@ bool ZoomSource::output_video_from_shared_memory(
     uint32_t event_shm_gen,
     bool commit_director_cut)
 {
-    const std::string shm_name = IPC_SHM_PREFIX + uuid;
+    // From generation 2 on, the engine creates the region under a
+    // generation-suffixed name so a resize is never blocked by our old
+    // mapping (see shm_region_name in engine-ipc.h).
+    const std::string shm_name =
+        shm_region_name(IPC_SHM_PREFIX + uuid, event_shm_gen);
     if (event_width == 0 || event_height == 0) return false;
     const size_t frame_bytes = sizeof(ShmFrameHeader) +
         static_cast<size_t>(event_width) * event_height * 3 / 2;
     if (shm_mapping_stale(video_shm.ptr, video_shm.size, frame_bytes,
                           event_shm_gen, video_shm_gen)) {
         // A generation change means the engine recreated the region (e.g.
-        // after a restart) — our old mapping points at an orphaned region
-        // that will never update again, so drop it and re-open by name.
+        // after a restart or a resolution increase) — our old mapping points
+        // at an orphaned region that will never update again, so drop it and
+        // re-open by name.
         if (video_shm.ptr && event_shm_gen != 0 &&
             event_shm_gen != video_shm_gen) {
             blog(LOG_INFO,
@@ -1143,12 +1152,17 @@ bool ZoomSource::output_video_from_shared_memory(
                  event_shm_gen);
             shm_region_destroy(video_shm);
         }
-        if (!shm_region_open_read(video_shm, shm_name, frame_bytes)) {
+        if (!shm_region_open_read(video_shm, shm_name, frame_bytes) &&
+            // Engines predating suffixed names recreate the legacy name for
+            // every generation — fall back to it.
+            (event_shm_gen <= 1 ||
+             !shm_region_open_read(video_shm, IPC_SHM_PREFIX + uuid,
+                                   frame_bytes))) {
             if (m_frame_count == 0) {
                 blog(LOG_WARNING,
-                     "[obs-zoom-plugin] Failed to open video shared memory: source=%s uuid=%s w=%u h=%u bytes=%zu",
+                     "[obs-zoom-plugin] Failed to open video shared memory: source=%s uuid=%s w=%u h=%u bytes=%zu gen=%u",
                      output_name().c_str(), uuid.c_str(), event_width,
-                     event_height, frame_bytes);
+                     event_height, frame_bytes, event_shm_gen);
             }
             return false;
         }
@@ -1339,20 +1353,33 @@ bool ZoomSource::output_video_from_shared_memory(
 }
 
 void ZoomSource::on_engine_audio(uint32_t event_byte_len,
-                                 uint32_t resolved_participant_id)
+                                 uint32_t resolved_participant_id,
+                                 uint32_t event_shm_gen)
 {
     std::lock_guard<std::mutex> lk(m_mtx);
-    const std::string shm_name = IPC_SHM_PREFIX + source_uuid + "_audio";
+    const std::string audio_base = IPC_SHM_PREFIX + source_uuid + "_audio";
+    const std::string shm_name = shm_region_name(audio_base, event_shm_gen);
     if (event_byte_len == 0) return;
     const size_t audio_bytes = sizeof(ShmAudioHeader) + event_byte_len;
-    if ((!m_audio_shm.ptr || m_audio_shm.size < audio_bytes) &&
-        !shm_region_open_read(m_audio_shm, shm_name, audio_bytes)) {
-        if (m_audio_frame_count == 0) {
-            blog(LOG_WARNING,
-                 "[obs-zoom-plugin] Failed to open audio shared memory: source=%s uuid=%s bytes=%zu",
-                 output_name().c_str(), source_uuid.c_str(), audio_bytes);
+    const bool gen_changed = event_shm_gen != 0 &&
+                             event_shm_gen != m_audio_shm_gen;
+    if (m_audio_shm.ptr && gen_changed)
+        shm_region_destroy(m_audio_shm);
+    if (!m_audio_shm.ptr || m_audio_shm.size < audio_bytes) {
+        if (!shm_region_open_read(m_audio_shm, shm_name, audio_bytes) &&
+            // Engines predating suffixed names recreate the legacy name for
+            // every generation — fall back to it.
+            (event_shm_gen <= 1 ||
+             !shm_region_open_read(m_audio_shm, audio_base, audio_bytes))) {
+            if (m_audio_frame_count == 0) {
+                blog(LOG_WARNING,
+                     "[obs-zoom-plugin] Failed to open audio shared memory: source=%s uuid=%s bytes=%zu gen=%u",
+                     output_name().c_str(), source_uuid.c_str(), audio_bytes,
+                     event_shm_gen);
+            }
+            return;
         }
-        return;
+        m_audio_shm_gen = event_shm_gen;
     }
 
     auto *hdr = static_cast<const ShmAudioHeader *>(m_audio_shm.ptr);
@@ -1531,6 +1558,7 @@ void ZoomSource::release_shared_memory()
     shm_region_destroy(m_audio_shm);
     m_video_shm_gen = 0;
     m_director_preview_shm_gen = 0;
+    m_audio_shm_gen = 0;
 }
 
 static const char *zoom_source_get_name(void *)
@@ -1573,10 +1601,11 @@ static void *zoom_source_create_common(obs_data_t *settings, obs_source_t *sourc
             ctx->on_engine_frame(w, h, participant_id, shm_gen);
         },
         [ctx, gate = ctx->m_callback_gate](uint32_t byte_len,
-                                           uint32_t participant_id) {
+                                           uint32_t participant_id,
+                                           uint32_t shm_gen) {
             std::lock_guard<std::mutex> callback_lock(gate->mtx);
             if (!gate->alive) return;
-            ctx->on_engine_audio(byte_len, participant_id);
+            ctx->on_engine_audio(byte_len, participant_id, shm_gen);
         }
     });
     if (dedicated_active_speaker) {
@@ -1588,7 +1617,7 @@ static void *zoom_source_create_common(obs_data_t *settings, obs_source_t *sourc
                 if (!gate->alive) return;
                 ctx->on_director_preview_frame(w, h, participant_id, shm_gen);
             },
-            [gate = ctx->m_callback_gate](uint32_t, uint32_t) {
+            [gate = ctx->m_callback_gate](uint32_t, uint32_t, uint32_t) {
                 std::lock_guard<std::mutex> callback_lock(gate->mtx);
                 if (!gate->alive) return;
                 // Audio cuts follow the committed current slot. The preview

--- a/src/zoom-source.h
+++ b/src/zoom-source.h
@@ -89,7 +89,8 @@ struct ZoomSource {
                                    uint32_t resolved_participant_id,
                                    uint32_t shm_generation);
     void on_engine_audio(uint32_t byte_len,
-                         uint32_t resolved_participant_id);
+                         uint32_t resolved_participant_id,
+                         uint32_t shm_generation);
 
     uint32_t width() const;
     uint32_t height() const;
@@ -123,6 +124,7 @@ private:
     ShmRegion m_video_shm;
     ShmRegion m_director_preview_shm;
     ShmRegion m_audio_shm;
+    uint32_t m_audio_shm_gen = 0;
     // Engine-reported SHM generation each mapping was opened against. Used to
     // detect a recreated (orphaned) region so we re-open instead of reading a
     // frozen frame forever. 0 = opened without a generation (older engine).

--- a/tests/ipc-hardening-test.cpp
+++ b/tests/ipc-hardening-test.cpp
@@ -151,15 +151,68 @@ static void test_win_invalid_fd()
 }
 #endif // WIN32
 
+// ── Generation-suffixed region names (resize deadlock, live incident fix) ────
+static void test_shm_region_name()
+{
+    // Generations 0/1 keep the legacy unsuffixed name (compat with engines
+    // that never resize and with pre-suffix plugin binaries).
+    check(shm_region_name("ZoomObsPlugin_abc", 0) == "ZoomObsPlugin_abc",
+          "gen 0 uses the legacy name");
+    check(shm_region_name("ZoomObsPlugin_abc", 1) == "ZoomObsPlugin_abc",
+          "gen 1 uses the legacy name");
+    check(shm_region_name("ZoomObsPlugin_abc", 2) == "ZoomObsPlugin_abc_g2",
+          "gen 2 is suffixed");
+    check(shm_region_name("ZoomObsPlugin_abc_audio", 3) ==
+              "ZoomObsPlugin_abc_audio_g3",
+          "audio base names suffix the same way");
+}
+
+#if defined(WIN32)
+// Pins the OS behavior behind the 2026-08-08 live incident: a named section
+// cannot be recreated at a larger size while another mapping keeps it alive
+// (CreateFileMapping returns the old smaller section; the larger view fails),
+// but a generation-suffixed fresh name succeeds immediately.
+static void test_win_shm_resize_requires_new_name()
+{
+    const std::string base = "CoreVideoShmResizeTest_" +
+        std::to_string(GetCurrentProcessId());
+
+    ShmRegion writer;
+    check(shm_region_create(writer, shm_region_name(base, 1), 4096),
+          "initial region creates");
+
+    ShmRegion reader; // simulates the plugin holding a mapping
+    check(shm_region_open_read(reader, shm_region_name(base, 1), 4096),
+          "reader maps the initial region");
+
+    // The engine's old behavior: recreate LARGER under the SAME name while
+    // the reader still maps it — must fail (this was the deadlock).
+    ShmRegion resized;
+    check(!shm_region_create(resized, shm_region_name(base, 1), 65536),
+          "larger recreate under the same live name fails");
+
+    // The fix: a generation-suffixed fresh name succeeds immediately.
+    check(shm_region_create(resized, shm_region_name(base, 2), 65536),
+          "larger recreate under the gen-suffixed name succeeds");
+    check(resized.size == 65536, "suffixed region has the requested size");
+
+    shm_region_destroy(resized);
+    shm_region_destroy(reader);
+    shm_region_destroy(writer);
+}
+#endif // WIN32
+
 int main()
 {
     test_heartbeat_expiry();
     test_shm_mapping_stale();
     test_shm_source_cap();
+    test_shm_region_name();
 #if defined(WIN32)
     test_win_line_io();
     test_win_broken_pipe();
     test_win_invalid_fd();
+    test_win_shm_resize_requires_new_name();
 #endif
 
     if (g_failures == 0)


### PR DESCRIPTION
## Live incident (2026-08-08)
Mid-meeting, participant feeds hit "Zoom engine could not allocate shared memory for source … — its frames are being dropped", repeating forever, unrecoverable via None→reassign.

## Root cause
A Windows named section cannot be recreated at a larger size while any process still maps the old one — `CreateFileMapping` returns the existing smaller section and the larger `MapViewOfFile` fails. When a feed's resolution increased (quality upgrade), the engine recreated the region **under the same name**, and only bumped the generation **after** a successful create, while the plugin only remaps after seeing a new generation — a deadlock that never self-heals. `clear_subscription_state()` also never unmapped, so clearing the assignment couldn't break the cycle either.

## Fix
- **Generation-suffixed region names** (`…_g2`, `…_g3`, …) from generation 2 on; the engine bumps the generation **before** creating, so a resize always lands on a fresh name no stale mapping can block. Gen 0/1 keep the legacy name; the plugin falls back to the legacy name, so engines that predate suffixed names (including the macOS beta engine) keep working with the new plugin.
- Audio events now carry `shm_gen` (audio buffers will resize once stereo lands); both audio consumers handle generation changes.
- `clear_subscription_state()` now releases all SHM mappings — None→reassign becomes a genuine operator recovery action.
- SHM create/open failures record `GetLastError()`/`errno` and the engine's failure events include it (support-bundle diagnosability).

## Verification
- New regression test in `ipc-hardening-test.cpp` pins the OS behavior: larger recreate under a live name **fails**; generation-suffixed name **succeeds** (plus `shm_region_name` derivation cases).
- 17/17 tests pass; plugin + engine build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)