### PR TITLE
ISO: drop frames when the encoder falls behind instead of buffering RAM

### DIFF
--- a/src/zoom-iso-panel.cpp
+++ b/src/zoom-iso-panel.cpp
@@ -650,6 +650,8 @@ void ZoomIsoPanel::refresh_status()
         const QString ffmpeg_output = s.value("ffmpeg_output_tail").toString();
         const QString session_health = s.value("session_health").toString();
         const int video_frames = s.value("video_frames").toInt();
+        const double frames_dropped =
+            s.value("video_frames_dropped").toDouble(0.0);
         const int audio_chunks = s.value("audio_chunks").toInt();
         const double last_video_age_ms =
             s.value("last_video_age_ms").toDouble(-1.0);
@@ -660,12 +662,19 @@ void ZoomIsoPanel::refresh_status()
             : (ffmpeg_running ? QStringLiteral("Recording") : QStringLiteral("Encoder stopped"));
         if (!ffmpeg_error.isEmpty())
             status = QStringLiteral("Encoder error");
+        else if (session_health == QLatin1String("encoder_behind"))
+            status = QString("Encoder falling behind (%1 dropped)")
+                .arg(static_cast<qint64>(frames_dropped));
         else if (video_frames == 0)
             status = QString("Waiting for video (%1)")
                 .arg(age_text(static_cast<double>(elapsed_ms)));
         else if (!completed && audio_chunks == 0)
             status += QString(" / no audio (%1)")
                 .arg(age_text(static_cast<double>(elapsed_ms)));
+        if (frames_dropped > 0 &&
+            session_health != QLatin1String("encoder_behind"))
+            status += QString(" (%1 dropped)")
+                .arg(static_cast<qint64>(frames_dropped));
         QString participant = s.value("display_name").toString();
         const int participant_id =
             static_cast<int>(s.value("resolved_participant_id").toDouble());

--- a/src/zoom-iso-recorder.cpp
+++ b/src/zoom-iso-recorder.cpp
@@ -564,6 +564,8 @@ QJsonObject ZoomIsoRecorder::session_status_json_locked(Session &s,
     obj["width"] = static_cast<int>(s.width);
     obj["height"] = static_cast<int>(s.height);
     obj["video_frames"] = static_cast<int>(s.video_frames);
+    obj["video_frames_dropped"] =
+        static_cast<double>(s.video_frames_dropped);
     obj["audio_chunks"] = static_cast<int>(s.audio_chunks);
     const uint64_t now_ns = os_gettime_ns();
     obj["elapsed_ms"] = s.started_ns > 0 && now_ns >= s.started_ns
@@ -587,6 +589,10 @@ QJsonObject ZoomIsoRecorder::session_status_json_locked(Session &s,
         QString::fromStdString(s.requested_video_encoder);
     obj["video_encoder"] = QString::fromStdString(s.video_encoder);
     obj["encoder_fallback"] = s.encoder_fallback;
+    const uint64_t health_now_ns = os_gettime_ns();
+    const bool dropping_recently = s.last_drop_ns > 0 &&
+        health_now_ns >= s.last_drop_ns &&
+        health_now_ns - s.last_drop_ns < 5000000000ULL;
     QString session_health = QStringLiteral("recording");
     if (s.disk_full) {
         session_health = QStringLiteral("disk_full");
@@ -596,6 +602,8 @@ QJsonObject ZoomIsoRecorder::session_status_json_locked(Session &s,
         session_health = QStringLiteral("encoder_error");
     } else if (!ffmpeg_running) {
         session_health = QStringLiteral("encoder_stopped");
+    } else if (dropping_recently) {
+        session_health = QStringLiteral("encoder_behind");
     } else if (s.video_frames == 0) {
         session_health = QStringLiteral("waiting_for_video");
     } else if (s.audio_chunks == 0) {
@@ -740,6 +748,37 @@ void ZoomIsoRecorder::record_video_frame(const ZoomOutputInfo &info,
             mark_ffmpeg_failure_locked(
                 session, QStringLiteral("FFmpeg is not running."));
         return;
+    }
+
+    // Realtime backpressure: if FFmpeg consumes slower than frames arrive
+    // (typically an oversubscribed hardware encoder), QProcess buffers the
+    // pipe writes in RAM without bound. Drop whole frames past a small
+    // backlog instead — memory stays flat, EOF at stop drains quickly, and
+    // the operator sees the drop count instead of a mystery hang/kill.
+    const qint64 frame_bytes =
+        static_cast<qint64>(width) * height * 3 / 2;
+    const qint64 backlog = session.ffmpeg->bytesToWrite();
+    if (backlog > frame_bytes * 4) {
+        ++session.video_frames_dropped;
+        session.last_drop_ns = timestamp_ns;
+        if (!session.backlog_reported) {
+            session.backlog_reported = true;
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] ISO encoder for %s is falling behind "
+                 "(write backlog %lld bytes) — dropping frames to protect "
+                 "memory and the meeting. Hardware encoder session limit?",
+                 session.source_name.c_str(),
+                 static_cast<long long>(backlog));
+        }
+        return;
+    }
+    if (session.backlog_reported) {
+        session.backlog_reported = false;
+        blog(LOG_INFO,
+             "[obs-zoom-plugin] ISO encoder for %s caught up after dropping "
+             "%llu frames",
+             session.source_name.c_str(),
+             static_cast<unsigned long long>(session.video_frames_dropped));
     }
 
     const std::string source_uuid = session.source_uuid;

--- a/src/zoom-iso-recorder.h
+++ b/src/zoom-iso-recorder.h
@@ -80,6 +80,9 @@ private:
         uint32_t width = 0;
         uint32_t height = 0;
         uint32_t video_frames = 0;
+        uint64_t video_frames_dropped = 0;
+        uint64_t last_drop_ns = 0;
+        bool backlog_reported = false;
         uint32_t audio_chunks = 0;
         uint64_t started_ns = 0;
         uint64_t last_video_ns = 0;


### PR DESCRIPTION
Completes the ISO shutdown story from #191. In tonight's 8×1080p NVENC test the new stop path worked (no engine stall, honest labels) but every FFmpeg still needed the kill: with the hardware encoder oversubscribed (8 ISO sessions + OBS program output), FFmpeg consumed slower than realtime and QProcess buffered our pipe writes in RAM without bound — so EOF couldn't be delivered until the whole backlog drained, which exceeded any budget. (The accompanying meeting end was `EndMeetingReason_EndByHost` — not a crash.)

- `record_video_frame` now drops whole frames once the per-session write backlog exceeds 4 frames: flat memory, near-instant EOF at stop, no corruption (drops are frame-aligned).
- Drops are counted, logged once per episode with a catch-up notice, exposed via `video_frames_dropped` + `encoder_behind` session health, and displayed in the ISO panel as "Encoder falling behind (N dropped)".

Operator guidance stands: for 8×1080p, expect NVENC session pressure — the panel already recommends moving a path to CPU x264.

17/17 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)