### PR TITLE
ISO: automatic encoder placement within hardware session budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+### Added
+- **Automatic ISO encoder placement (new default).** Hardware encoders have
+  a shared session budget (GeForce NVENC allows 8 concurrent sessions,
+  shared with OBS's own program/stream outputs) — so instead of letting an
+  8-feed NVENC configuration oversubscribe the GPU, CoreVideo now places
+  each ISO feed itself: NVENC while the budget lasts (counting OBS's active
+  NVENC encoders), then Intel Quick Sync, then CPU x264. The per-row
+  Encoder column shows each feed's placement. Explicit encoder choices are
+  still honored, but overflow beyond the session budget is placed down the
+  same chain instead of failing. A feed whose encoder fails at startup
+  automatically retries on the next encoder down.
+- ISO sessions that fall behind the encoder now drop frames (bounded
+  memory) and show "Encoder falling behind (N dropped)" instead of
+  failing opaquely. *(shipped in the code with 0.1.35; see PR #193)*
+
 ## [0.1.34] - 2026-08-08
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,6 +542,15 @@ if(BUILD_TESTING)
                  COMMAND CoreVideoFfmpegRuntimeTest)
     endif()
 
+    add_executable(CoreVideoIsoEncoderPlanTest
+        tests/iso-encoder-plan-test.cpp
+    )
+    target_include_directories(CoreVideoIsoEncoderPlanTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoIsoEncoderPlan
+             COMMAND CoreVideoIsoEncoderPlanTest)
+
     add_executable(CoreVideoSpeakerDirectorTest
         tests/speaker-director-test.cpp
         src/speaker-director.cpp

--- a/src/iso-encoder-plan.h
+++ b/src/iso-encoder-plan.h
@@ -1,0 +1,79 @@
+#pragma once
+#include <string>
+
+// Encoder placement for ISO sessions.
+//
+// Hardware encoders have hard concurrency budgets (GeForce NVENC allows a
+// fixed number of sessions per system — 8 on current drivers — shared with
+// OBS's own program/stream/vertical outputs). Letting an operator start
+// 8 ISO feeds + program on NVENC oversubscribes the encoder: sessions fail
+// to open or fall behind realtime. Rather than surfacing that as per-row
+// encoder errors, sessions are placed automatically: NVENC while the budget
+// lasts, then Intel QSV (separate silicon, no shared budget with NVENC),
+// then CPU x264. Explicit encoder choices are honored up to the budget and
+// overflow down the same chain.
+//
+// Pure logic — unit tested in tests/iso-encoder-plan-test.cpp.
+
+struct IsoEncoderAvailability {
+    bool nvenc = false;
+    bool qsv = false;
+    bool amf = false;
+};
+
+inline int iso_nvenc_default_session_limit()
+{
+    // GeForce consumer driver session cap (driver 570+, required by the OBS
+    // versions we support). Pro GPUs allow more; treating them as 8 is safe.
+    return 8;
+}
+
+// Chooses the encoder for the next session to be created.
+//   requested        "auto" or an explicit ffmpeg encoder name
+//   nvenc_remaining  NVENC budget minus OBS's own active NVENC encoders
+//                    minus ISO sessions already recording via NVENC
+inline std::string iso_choose_session_encoder(
+    const std::string &requested,
+    int nvenc_remaining,
+    const IsoEncoderAvailability &avail)
+{
+    const bool automatic = requested == "auto";
+
+    if (!automatic && requested != "h264_nvenc") {
+        // Explicit non-NVENC choice: QSV/AMF have no meaningful shared
+        // session budget on the hardware we target; x264 always works.
+        // (Availability probing/fallback for absent hardware happens at
+        // start, as before.)
+        return requested;
+    }
+
+    // "auto", or explicit NVENC: NVENC while the budget lasts.
+    if (avail.nvenc && nvenc_remaining > 0)
+        return "h264_nvenc";
+    if (avail.qsv)
+        return "h264_qsv";
+    if (avail.amf)
+        return "h264_amf";
+    return "libx264";
+}
+
+// The next encoder to try when a session's encoder fails at startup
+// (e.g. the session budget estimate was wrong). Ends at x264, which
+// cannot run out of sessions.
+inline std::string iso_demote_encoder(const std::string &failed,
+                                      const IsoEncoderAvailability &avail)
+{
+    if (failed == "h264_nvenc") {
+        if (avail.qsv)
+            return "h264_qsv";
+        if (avail.amf)
+            return "h264_amf";
+        return "libx264";
+    }
+    if (failed == "h264_qsv") {
+        if (avail.amf)
+            return "h264_amf";
+        return "libx264";
+    }
+    return "libx264";
+}

--- a/src/zoom-iso-panel.cpp
+++ b/src/zoom-iso-panel.cpp
@@ -220,6 +220,14 @@ static bool ffmpeg_has_encoder(const QString &path, const QString &encoder)
 
 static QString encoder_guidance_text(const QString &encoder)
 {
+    if (encoder == QStringLiteral("auto")) {
+        return QStringLiteral(
+            "Automatic places each ISO feed on the best available encoder "
+            "within hardware session limits: NVENC first (counting OBS's own "
+            "program/stream encoders against the GPU budget), then Intel "
+            "Quick Sync, then CPU x264. The Encoder column shows each feed's "
+            "placement.");
+    }
     if (encoder == QStringLiteral("libx264")) {
         return QStringLiteral(
             "CPU x264 avoids GPU encoder session limits but can be heavy with 8 ISO feeds plus program streaming. Use veryfast/fast CPU presets and monitor OBS CPU load.");
@@ -338,6 +346,7 @@ ZoomIsoPanel::ZoomIsoPanel(QWidget *parent)
     auto *encoder_row = new QHBoxLayout;
     encoder_row->setSpacing(6);
     m_video_encoder = new QComboBox(config_group);
+    m_video_encoder->addItem("Automatic (recommended)", "auto");
     m_video_encoder->addItem("CPU - x264 (safe fallback)", "libx264");
     m_video_encoder->addItem("NVIDIA NVENC - H.264", "h264_nvenc");
     m_video_encoder->addItem("Intel Quick Sync - H.264", "h264_qsv");

--- a/src/zoom-iso-recorder.cpp
+++ b/src/zoom-iso-recorder.cpp
@@ -1,4 +1,5 @@
 #include "zoom-iso-recorder.h"
+#include "iso-encoder-plan.h"
 #include <QDateTime>
 #include <QDir>
 #include <QElapsedTimer>
@@ -14,6 +15,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <set>
 
 static constexpr qint64 kIsoMinimumFreeBytes = 2ll * 1024ll * 1024ll * 1024ll;
 static constexpr qint64 kIsoWarningFreeBytes = 10ll * 1024ll * 1024ll * 1024ll;
@@ -61,6 +63,7 @@ static QString bytes_text(qint64 bytes)
 }
 
 static std::string normalized_video_encoder(const std::string &encoder);
+static int count_obs_nvenc_encoders();
 static bool is_hardware_encoder(const std::string &encoder);
 static bool ffmpeg_encoder_available(const QString &ffmpeg_path,
                                      const std::string &encoder,
@@ -176,8 +179,23 @@ bool ZoomIsoRecorder::start(const ZoomIsoRecordConfig &config,
     }
     std::string encoder_error;
     QString status_warning;
-    if (!ffmpeg_encoder_available(ffmpegProgram, normalized.video_encoder,
-                                  &encoder_error)) {
+    // Probe which hardware encoder families this FFmpeg build offers; the
+    // per-session placement logic (iso-encoder-plan.h) uses this to spread
+    // sessions across NVENC/QSV/AMF/x264 within hardware session budgets.
+    IsoEncoderAvailability avail;
+    avail.nvenc = ffmpeg_encoder_available(ffmpegProgram, "h264_nvenc", nullptr);
+    avail.qsv = ffmpeg_encoder_available(ffmpegProgram, "h264_qsv", nullptr);
+    avail.amf = ffmpeg_encoder_available(ffmpegProgram, "h264_amf", nullptr);
+    if (normalized.video_encoder == "auto") {
+        blog(LOG_INFO,
+             "[obs-zoom-plugin] ISO encoder placement: automatic "
+             "(nvenc=%d qsv=%d amf=%d, NVENC session limit %d, "
+             "OBS NVENC encoders active %d)",
+             avail.nvenc, avail.qsv, avail.amf,
+             iso_nvenc_default_session_limit(), count_obs_nvenc_encoders());
+    } else if (!ffmpeg_encoder_available(ffmpegProgram,
+                                         normalized.video_encoder,
+                                         &encoder_error)) {
         if (is_hardware_encoder(normalized.video_encoder) &&
             ffmpeg_encoder_available(ffmpegProgram, "libx264", nullptr)) {
             status_warning = QString("Requested hardware encoder '%1' was not "
@@ -231,6 +249,9 @@ bool ZoomIsoRecorder::start(const ZoomIsoRecordConfig &config,
         m_sessions.clear();
         m_config = normalized;
         m_requested_video_encoder = requested_encoder;
+        m_encoder_avail = avail;
+        m_nvenc_session_limit = iso_nvenc_default_session_limit();
+        m_encoder_demotions.clear();
         m_status_warning = status_warning;
         m_started_program_recording = false;
         m_completed_sessions.clear();
@@ -458,7 +479,28 @@ ZoomIsoRecorder::ensure_session_locked(const ZoomOutputInfo &info,
     session.requested_video_encoder = m_requested_video_encoder.empty()
         ? normalized_video_encoder(m_config.video_encoder)
         : m_requested_video_encoder;
-    session.video_encoder = normalized_video_encoder(m_config.video_encoder);
+    // Encoder placement: hardware sessions are a shared, finite budget
+    // (OBS's own outputs included), so each ISO session is placed
+    // individually — NVENC while the budget lasts, then QSV/AMF/x264.
+    // A session that already failed once on a hardware encoder was demoted
+    // and stays demoted for this run.
+    const auto demoted = m_encoder_demotions.find(session.source_uuid);
+    if (demoted != m_encoder_demotions.end()) {
+        session.video_encoder = demoted->second;
+    } else {
+        int nvenc_in_use_iso = 0;
+        for (const auto &other : m_sessions) {
+            if (other.second.video_encoder == "h264_nvenc" &&
+                other.second.ffmpeg &&
+                other.second.ffmpeg->state() == QProcess::Running)
+                ++nvenc_in_use_iso;
+        }
+        const int remaining = m_nvenc_session_limit -
+                              count_obs_nvenc_encoders() - nvenc_in_use_iso;
+        session.video_encoder = iso_choose_session_encoder(
+            normalized_video_encoder(m_config.video_encoder), remaining,
+            m_encoder_avail);
+    }
     session.encoder_fallback =
         session.requested_video_encoder != session.video_encoder;
 
@@ -493,6 +535,8 @@ ZoomIsoRecorder::ensure_session_locked(const ZoomOutputInfo &info,
              "[obs-zoom-plugin] ISO ffmpeg failed to start for %s: %s",
              session.source_name.c_str(),
              session.ffmpeg->errorString().toUtf8().constData());
+    } else {
+        session.ffmpeg_started_ns = os_gettime_ns();
     }
 
     blog(LOG_INFO,
@@ -744,6 +788,28 @@ void ZoomIsoRecorder::record_video_frame(const ZoomOutputInfo &info,
     refresh_ffmpeg_status_locked(session);
     if (!session.ffmpeg ||
         session.ffmpeg->state() != QProcess::Running) {
+        // Startup-time death of a hardware encoder usually means the
+        // session-budget estimate was wrong for this GPU (driver caps
+        // vary). Demote this source one tier and recreate on the next
+        // frame instead of surfacing a dead "Encoder error" row.
+        const uint64_t now_ns = os_gettime_ns();
+        if (session.video_encoder != "libx264" &&
+            session.ffmpeg_started_ns != 0 &&
+            now_ns - session.ffmpeg_started_ns < 10000000000ULL &&
+            m_encoder_demotions.find(session.source_uuid) ==
+                m_encoder_demotions.end()) {
+            const std::string next =
+                iso_demote_encoder(session.video_encoder, m_encoder_avail);
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] ISO encoder %s failed at startup for "
+                 "%s; retrying with %s",
+                 session.video_encoder.c_str(),
+                 session.source_name.c_str(), next.c_str());
+            const std::string uuid = session.source_uuid;
+            m_encoder_demotions[uuid] = next;
+            close_session_locked(uuid);
+            return;
+        }
         if (session.ffmpeg_error.isEmpty())
             mark_ffmpeg_failure_locked(
                 session, QStringLiteral("FFmpeg is not running."));
@@ -847,11 +913,40 @@ void ZoomIsoRecorder::record_audio_frame(const ZoomOutputInfo &info,
 
 static std::string normalized_video_encoder(const std::string &encoder)
 {
-    if (encoder == "h264_nvenc" || encoder == "h264_qsv" ||
-        encoder == "h264_amf" || encoder == "libx264") {
+    if (encoder == "auto" || encoder == "h264_nvenc" ||
+        encoder == "h264_qsv" || encoder == "h264_amf" ||
+        encoder == "libx264") {
         return encoder;
     }
-    return "libx264";
+    return "auto";
+}
+
+// Number of distinct hardware NVENC encoders OBS itself has active right
+// now (program recording, streaming, vertical canvas, replay buffer, ...).
+// These share the GPU's session budget with our ISO FFmpeg children.
+static int count_obs_nvenc_encoders()
+{
+    struct Census {
+        std::set<obs_encoder_t *> seen;
+    } census;
+    obs_enum_outputs(
+        [](void *param, obs_output_t *output) -> bool {
+            auto *c = static_cast<Census *>(param);
+            if (!obs_output_active(output))
+                return true;
+            for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; ++i) {
+                obs_encoder_t *enc =
+                    obs_output_get_video_encoder2(output, i);
+                if (!enc)
+                    continue;
+                const char *id = obs_encoder_get_id(enc);
+                if (id && strstr(id, "nvenc"))
+                    c->seen.insert(enc);
+            }
+            return true;
+        },
+        &census);
+    return static_cast<int>(census.seen.size());
 }
 
 static bool is_hardware_encoder(const std::string &encoder)

--- a/src/zoom-iso-recorder.h
+++ b/src/zoom-iso-recorder.h
@@ -2,6 +2,7 @@
 
 #include "zoom-output-manager.h"
 #include "zoom-types.h"
+#include "iso-encoder-plan.h"
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QProcess>
@@ -83,6 +84,7 @@ private:
         uint64_t video_frames_dropped = 0;
         uint64_t last_drop_ns = 0;
         bool backlog_reported = false;
+        uint64_t ffmpeg_started_ns = 0;
         uint32_t audio_chunks = 0;
         uint64_t started_ns = 0;
         uint64_t last_video_ns = 0;
@@ -122,6 +124,11 @@ private:
                              uint32_t byte_len);
     bool should_record(const ZoomOutputInfo &info,
                        uint32_t resolved_participant_id) const;
+
+    IsoEncoderAvailability m_encoder_avail;
+    int m_nvenc_session_limit = 8;
+    // source_uuid -> encoder to use after a startup failure demoted it.
+    std::unordered_map<std::string, std::string> m_encoder_demotions;
 
     mutable std::mutex m_mtx;
     std::atomic<bool> m_active{false};

--- a/src/zoom-settings.h
+++ b/src/zoom-settings.h
@@ -36,7 +36,7 @@ struct ZoomPluginSettings {
     // ISO recorder panel defaults.
     std::string         iso_output_dir;
     std::string         iso_ffmpeg_path = "ffmpeg";
-    std::string         iso_video_encoder = "libx264";
+    std::string         iso_video_encoder = "auto";
     bool                iso_record_program = true;
 
     // Active speaker director defaults.

--- a/tests/iso-encoder-plan-test.cpp
+++ b/tests/iso-encoder-plan-test.cpp
@@ -1,0 +1,109 @@
+// Unit tests for ISO encoder placement (iso-encoder-plan.h): NVENC session
+// budgeting with automatic overflow to QSV/AMF/x264, and the startup-failure
+// demotion chain. Motivated by the 2026-08-08 8x1080p test where 8 ISO NVENC
+// sessions + OBS program output oversubscribed the GPU.
+#include "iso-encoder-plan.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+static int g_failures = 0;
+
+static void check(bool ok, const char *what)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << what << "\n";
+        ++g_failures;
+    }
+}
+
+static std::vector<std::string> place(const std::string &requested,
+                                      int feeds,
+                                      int budget_after_obs,
+                                      const IsoEncoderAvailability &avail)
+{
+    // Mirrors the recorder: each new session consumes NVENC budget only if
+    // it was actually placed on NVENC.
+    std::vector<std::string> out;
+    int remaining = budget_after_obs;
+    for (int i = 0; i < feeds; ++i) {
+        std::string enc =
+            iso_choose_session_encoder(requested, remaining, avail);
+        if (enc == "h264_nvenc")
+            --remaining;
+        out.push_back(enc);
+    }
+    return out;
+}
+
+static int count(const std::vector<std::string> &v, const std::string &e)
+{
+    int n = 0;
+    for (const auto &x : v)
+        if (x == e)
+            ++n;
+    return n;
+}
+
+int main()
+{
+    const IsoEncoderAvailability nv_qsv{true, true, false};
+    const IsoEncoderAvailability nv_only{true, false, false};
+    const IsoEncoderAvailability none{false, false, false};
+
+    // The incident scenario: 8 feeds, program recording already holds one
+    // NVENC session (budget 8 - 1 = 7). Auto places 7 on NVENC, 1 on QSV.
+    {
+        auto plan = place("auto", 8, 7, nv_qsv);
+        check(count(plan, "h264_nvenc") == 7, "auto: 7 of 8 feeds on NVENC");
+        check(count(plan, "h264_qsv") == 1, "auto: overflow feed on QSV");
+    }
+
+    // No QSV: overflow lands on x264.
+    {
+        auto plan = place("auto", 8, 6, nv_only);
+        check(count(plan, "h264_nvenc") == 6, "auto: NVENC up to budget");
+        check(count(plan, "libx264") == 2, "auto: overflow on x264 without QSV");
+    }
+
+    // Explicit NVENC choice is honored up to the budget, then overflows —
+    // it must never oversubscribe.
+    {
+        auto plan = place("h264_nvenc", 8, 5, nv_qsv);
+        check(count(plan, "h264_nvenc") == 5,
+              "explicit nvenc: capped at budget");
+        check(count(plan, "h264_qsv") == 3,
+              "explicit nvenc: overflow goes to QSV");
+    }
+
+    // Explicit CPU choice is never second-guessed.
+    check(count(place("libx264", 4, 8, nv_qsv), "libx264") == 4,
+          "explicit x264: all feeds honored");
+
+    // Explicit QSV: no session budget applies.
+    check(count(place("h264_qsv", 8, 0, nv_qsv), "h264_qsv") == 8,
+          "explicit qsv: unaffected by NVENC budget");
+
+    // No hardware at all: everything on x264 even if requested.
+    check(count(place("auto", 3, 5, none), "libx264") == 3,
+          "auto without hardware: x264");
+
+    // Budget exhausted before any feed: auto goes straight to QSV.
+    check(place("auto", 1, 0, nv_qsv)[0] == "h264_qsv",
+          "auto with zero budget: QSV first");
+
+    // Demotion chain ends at x264 and never loops.
+    check(iso_demote_encoder("h264_nvenc", nv_qsv) == "h264_qsv",
+          "demote nvenc -> qsv");
+    check(iso_demote_encoder("h264_qsv", nv_qsv) == "libx264",
+          "demote qsv -> x264 (no AMF)");
+    check(iso_demote_encoder("h264_nvenc", none) == "libx264",
+          "demote nvenc -> x264 without other hardware");
+    check(iso_demote_encoder("libx264", nv_qsv) == "libx264",
+          "x264 never demotes further");
+
+    if (g_failures == 0)
+        std::cout << "All ISO encoder plan tests passed\n";
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Implements the product decision from tonight's 8×1080p testing: **the plugin manages encoder placement — configurations that can't work are no longer selectable outcomes.**

- **"Automatic (recommended)" is the new default.** Each ISO session is placed at creation: NVENC while the GPU session budget lasts — counting OBS's own active NVENC encoders (program/stream/vertical canvas, via `obs_enum_outputs`) and ISO sessions already recording — then Intel QSV, then AMF, then CPU x264. The per-row Encoder column shows actual placement.
- **Explicit choices can't oversubscribe**: picking NVENC for 8 feeds places what fits and overflows the rest down the chain, logged.
- **Startup-failure demotion**: a session whose hardware encoder dies within 10 s is demoted one tier and recreated automatically — covers GPUs whose real session cap differs from the assumed 8.
- Placement logic is pure and unit-tested (`src/iso-encoder-plan.h`, `tests/iso-encoder-plan-test.cpp`), including the exact incident scenario: 8 feeds + program recording → 7 NVENC + 1 QSV.

18/18 tests pass. Builds on #191/#193 (shutdown + backpressure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)