### PR TITLE
Speaker director: the incumbent holds until someone else takes over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+### Fixed
+- **The Active Speaker output now always keeps the last speaker on screen.**
+  When the current speaker muted, turned their camera off, or blipped out of
+  the roster during a reconnect, the director dethroned them immediately —
+  dropping the video until somebody else spoke. The incumbent speaker now
+  holds through mute, video-off, silence, and roster blips; only an explicit
+  exclusion, a genuine departure (gone for over a minute), or another
+  participant speaking replaces them. Candidate vetting (mute/video/exclusion
+  rules) is unchanged for new speakers, and manual Take pins hold the same
+  way.
+
 ## [0.1.35] - 2026-08-09
 
 ### Added

--- a/src/speaker-director.cpp
+++ b/src/speaker-director.cpp
@@ -34,6 +34,8 @@ void SpeakerDirector::reset()
     m_roster.clear();
     m_raw_speaker_id = 0;
     m_directed_speaker_id = 0;
+    m_directed_missing_since_ms = 0;
+    m_manual_missing_since_ms = 0;
     m_candidate_speaker_id = 0;
     m_last_speaker_id = 0;
     m_manual_speaker_id = 0;
@@ -42,13 +44,14 @@ void SpeakerDirector::reset()
     m_last_switch_ms = 0;
 }
 
+// Strict vetting for NEW candidates only. The incumbent is judged by
+// enforce_incumbent_eligibility_locked instead: someone who mutes or turns
+// their camera off after speaking must stay on the program output.
 bool SpeakerDirector::participant_allowed_locked(uint32_t participant_id) const
 {
     if (participant_id == 0)
         return false;
-    if (std::find(m_excluded_participant_ids.begin(),
-                  m_excluded_participant_ids.end(),
-                  participant_id) != m_excluded_participant_ids.end())
+    if (participant_excluded_locked(participant_id))
         return false;
 
     const auto it = std::find_if(m_roster.begin(), m_roster.end(),
@@ -62,6 +65,52 @@ bool SpeakerDirector::participant_allowed_locked(uint32_t participant_id) const
     if (m_require_video && !it->has_video)
         return false;
     return true;
+}
+
+bool SpeakerDirector::participant_excluded_locked(uint32_t participant_id) const
+{
+    return std::find(m_excluded_participant_ids.begin(),
+                     m_excluded_participant_ids.end(),
+                     participant_id) != m_excluded_participant_ids.end();
+}
+
+bool SpeakerDirector::participant_in_roster_locked(uint32_t participant_id) const
+{
+    return std::any_of(m_roster.begin(), m_roster.end(),
+        [participant_id](const ParticipantInfo &p) {
+            return p.user_id == participant_id;
+        });
+}
+
+void SpeakerDirector::enforce_incumbent_eligibility_locked(uint64_t now_ms)
+{
+    constexpr uint64_t kAbsenceGraceMs = 60000;
+    const auto enforce = [&](uint32_t &holder, uint64_t &missing_since) {
+        if (holder == 0) {
+            missing_since = 0;
+            return;
+        }
+        if (participant_excluded_locked(holder)) {
+            holder = 0;
+            missing_since = 0;
+            return;
+        }
+        if (participant_in_roster_locked(holder)) {
+            missing_since = 0;
+            return;
+        }
+        // Absent from the roster: could be a transient blip (engine
+        // reconnect) — dethrone only after the grace window.
+        if (missing_since == 0)
+            missing_since = now_ms;
+        else if (now_ms >= missing_since &&
+                 now_ms - missing_since > kAbsenceGraceMs) {
+            holder = 0;
+            missing_since = 0;
+        }
+    };
+    enforce(m_directed_speaker_id, m_directed_missing_since_ms);
+    enforce(m_manual_speaker_id, m_manual_missing_since_ms);
 }
 
 uint32_t SpeakerDirector::choose_candidate_locked(uint32_t raw_speaker_id) const
@@ -118,10 +167,7 @@ bool SpeakerDirector::update_roster(const std::vector<ParticipantInfo> &roster,
     m_roster = roster;
     m_raw_speaker_id = raw_speaker_id;
 
-    if (!participant_allowed_locked(m_directed_speaker_id))
-        m_directed_speaker_id = 0;
-    if (m_manual_speaker_id != 0 && !participant_allowed_locked(m_manual_speaker_id))
-        m_manual_speaker_id = 0;
+    enforce_incumbent_eligibility_locked(now_ms);
     if (m_manual_speaker_id != 0)
         return promote_locked(m_manual_speaker_id, now_ms);
 
@@ -145,13 +191,11 @@ bool SpeakerDirector::update_roster(const std::vector<ParticipantInfo> &roster,
 
 bool SpeakerDirector::tick_locked(uint64_t now_ms)
 {
-    if (m_manual_speaker_id != 0) {
-        if (participant_allowed_locked(m_manual_speaker_id))
-            return promote_locked(m_manual_speaker_id, now_ms);
-        m_manual_speaker_id = 0;
-    }
+    enforce_incumbent_eligibility_locked(now_ms);
+    if (m_manual_speaker_id != 0)
+        return promote_locked(m_manual_speaker_id, now_ms);
 
-    if (!participant_allowed_locked(m_directed_speaker_id))
+    if (m_directed_speaker_id == 0)
         return promote_locked(choose_candidate_locked(m_raw_speaker_id), now_ms);
 
     if (!participant_allowed_locked(m_candidate_speaker_id))

--- a/src/speaker-director.h
+++ b/src/speaker-director.h
@@ -43,6 +43,13 @@ private:
 
     bool promote_locked(uint32_t participant_id, uint64_t now_ms);
     bool participant_allowed_locked(uint32_t participant_id) const;
+    bool participant_excluded_locked(uint32_t participant_id) const;
+    bool participant_in_roster_locked(uint32_t participant_id) const;
+    // Dethrones the incumbent/manual speaker only on exclusion or on
+    // absence from the roster beyond the grace window; mute, video-off,
+    // and momentary roster blips never dethrone (the Active Speaker output
+    // must keep showing the last speaker until someone else takes over).
+    void enforce_incumbent_eligibility_locked(uint64_t now_ms);
     uint32_t choose_candidate_locked(uint32_t raw_speaker_id) const;
     bool tick_locked(uint64_t now_ms);
 
@@ -50,6 +57,8 @@ private:
     std::vector<ParticipantInfo> m_roster;
     uint32_t m_raw_speaker_id = 0;
     uint32_t m_directed_speaker_id = 0;
+    uint64_t m_directed_missing_since_ms = 0;
+    uint64_t m_manual_missing_since_ms = 0;
     uint32_t m_candidate_speaker_id = 0;
     uint32_t m_last_speaker_id = 0;
     uint32_t m_manual_speaker_id = 0;

--- a/tests/speaker-director-test.cpp
+++ b/tests/speaker-director-test.cpp
@@ -104,11 +104,16 @@ int main()
     director.update_roster(roster({p(401, true, true), p(402, true, false)}), 401, t);
     if (!check_directed(402)) fail("manual speaker was stolen by raw speaker");
 
-    // Make the manual speaker invalid (leaves / video off) while manual is active.
-    // The director should auto-clear manual and fall back.
+    // The manual speaker leaving the roster is treated as a possible
+    // transient blip: the pin HOLDS through the absence grace window (the
+    // program output keeps showing the last speaker) and only falls back
+    // once they have been gone for over a minute.
     t += 50;
     director.update_roster(roster({p(401, true, true)}), 401, t);  // 402 no longer in roster
-    if (!check_directed(401)) fail("did not auto-fallback when manual speaker became invalid");
+    if (!check_directed(402)) fail("manual pin should hold through a roster blip");
+    t += 61000; // past the absence grace window
+    director.update_roster(roster({p(401, true, true)}), 401, t);
+    if (!check_directed(401)) fail("did not fall back after manual speaker was gone past grace");
 
     // --- Manual release (when still valid) keeps current directed (no unnecessary cut) ---
     director.reset();
@@ -160,7 +165,7 @@ int main()
     director.update_roster(excluded_update_roster, 711, t + 10);
     if (!check_directed(712)) fail("dynamic exclusion did not move away from directed speaker");
 
-    // --- Current directed speaker becomes invalid -> fallback ---
+    // --- Departed speaker: hold through the grace window, then clear ---
     director.reset();
     director.configure(100, 1000, true, {});
     t = 53000;
@@ -168,14 +173,37 @@ int main()
     if (!check_directed(801)) fail("initial 801");
 
     t += 50;
-    // 801 leaves
+    // 801 leaves the roster: could be a reconnect blip — the incumbent
+    // holds (the output keeps showing the last speaker during silence).
     director.update_roster(roster({p(802, true, false)}), 0, t);
-    if (!check_directed(0)) fail("should have cleared directed when speaker left");
+    if (!check_directed(801)) fail("incumbent should hold through a roster blip");
 
-    // Next talking person should be promoted
-    t += 100;
+    // A new talker still takes over through the normal candidate flow —
+    // the hold never delays a genuine handover.
+    t += 2000;
+    director.update_roster(roster({p(802, true, true)}), 802, t);
+    t += 2000;
     director.update_roster(roster({p(802, true, true)}), 802, t);
     if (!check_directed(802)) fail("did not promote fallback speaker");
+
+    // --- Incumbent holds through mute and video-off (the report that
+    // motivated this: 'when the source stops talking, active speaker
+    // unsubscribes the last speaker') ---
+    director.reset();
+    director.configure(100, 1000, true, {});
+    t = 55000;
+    director.update_roster(roster({p(811, true, true), p(812, true, true)}), 811, t);
+    if (!check_directed(811)) fail("initial 811");
+    t += 500;
+    // 811 mutes and turns video off; nobody else is talking.
+    director.update_roster(roster({p(811, false, false, true), p(812, true, false)}), 0, t);
+    if (!check_directed(811))
+        fail("incumbent must hold after muting / stopping video");
+    t += 5000;
+    if (director.tick(t))
+        fail("tick must not dethrone a muted incumbent during silence");
+    if (!check_directed(811))
+        fail("incumbent must keep holding through silence");
 
     // --- Snapshot reports reasonable timing values ---
     director.reset();


### PR DESCRIPTION
Owner-reported live: when the current speaker stopped talking, the Active Speaker output unsubscribed them and sat empty until the next person spoke.

The director vetted the incumbent with the same strict rules as new candidates — so muting (the normal thing to do after speaking), turning the camera off, or a reconnect roster blip dethroned the current speaker instantly, and nobody was promoted again until someone talked.

Now: **candidates are vetted strictly (unchanged); the incumbent holds.** Only an explicit exclusion or genuine departure (absent >60s) dethrones — mute, video-off, silence, and roster blips never do. A new talker still takes over through the normal sensitivity/hold flow, so the hold can't delay a real handover. Manual Take pins get the same protection.

New regression test encodes the exact report; 18/18 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)