### PR TITLE
Keep Zoom subscriptions warm across scene switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 ## [Unreleased]
 
 ### Fixed
+- **Rapid scene switching no longer risks killing the Zoom engine — and
+  scene cuts are instant now.** Zoom subscriptions were torn down whenever a
+  scene hid a CoreVideo source and rebuilt when one appeared, so every scene
+  jump churned the Zoom SDK's raw-data pipeline for all sources at once;
+  fast switching could drive the SDK into an internal fatal that closed the
+  engine (all video dropping to color bars), and every cut briefly showed
+  placeholders while feeds resubscribed. Subscriptions now follow the
+  assignment, not scene visibility: feeds stay warm across scene switches.
+
+### Fixed
 - **The Active Speaker output now always keeps the last speaker on screen.**
   When the current speaker muted, turned their camera off, or blipped out of
   the roster during a reconnect, the director dethroned them immediately —

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -922,11 +922,22 @@ bool ZoomSource::upgrade_low_quality_video(uint64_t now_ns, bool force)
     return true;
 }
 
+// Subscriptions belong to the ASSIGNMENT (the Output Manager row), not to
+// scene visibility. Tearing the Zoom subscription down on every scene exit
+// and rebuilding it on entry meant a scene jump churned the SDK's raw-data
+// pipeline for every CoreVideo source at once — rapid scene switching
+// (2026-08-09) drove the SDK into an internal fatal that killed the engine
+// process (exit code 1), and every cut showed placeholder frames while
+// feeds resubscribed. Feeds now stay warm while the source exists and is
+// assigned; only assignment changes, source destruction, or engine
+// teardown end a subscription.
 void ZoomSource::activate()
 {
     m_active.store(true, std::memory_order_release);
     if (m_width.load(std::memory_order_relaxed) == 0)
         output_placeholder_frame(true);
+    if (m_subscribed.load(std::memory_order_acquire))
+        return; // feed already warm — a scene switch must not touch it
     const AssignmentMode mode = assignment.load(std::memory_order_acquire);
     if (source_wants_subscription(mode, participant_id.load(std::memory_order_acquire)))
         subscribe();
@@ -935,7 +946,7 @@ void ZoomSource::activate()
 void ZoomSource::deactivate()
 {
     m_active.store(false, std::memory_order_release);
-    unsubscribe();
+    // Intentionally NOT unsubscribing: the feed stays warm for the next cut.
 }
 
 void ZoomSource::on_roster_changed()


### PR DESCRIPTION
Live incident: rapid scene jumping → all video to color bars → ZoomObsEngine exited with code 1 (no dump — the SDK's own fatal `exit()` path). The log shows a scene switch firing 7 re-subscriptions within 35 ms; `deactivate()` unsubscribed every hidden CoreVideo source and `activate()` resubscribed every shown one, so fast switching churned the SDK raw-data pipeline until it died.

**Subscriptions now follow the assignment, not scene visibility** — matching the Output Manager model. `activate()` leaves warm feeds untouched; `deactivate()` no longer unsubscribes. Assignment changes, source destruction, and engine teardown remain the only ways a subscription ends. Side benefit: scene cuts are instant (no placeholder flash while feeds resubscribe) with zero SDK traffic.

Operator note: with auto-reconnect's "On engine crash" trigger enabled, any future engine death self-heals in seconds; worth recommending in docs (the reporting rig had reconnect disabled).

18/18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)