### PR TITLE
Auto-restore dropped feeds by intent, not by a stale subscription flag

### DIFF
--- a/src/zoom-output-manager.cpp
+++ b/src/zoom-output-manager.cpp
@@ -230,8 +230,13 @@ bool ZoomOutputManager::configure_output_ex(const std::string &source_name,
 void ZoomOutputManager::resubscribe_all()
 {
     std::lock_guard<std::mutex> lk(m_mtx);
+    // Re-subscribe by INTENT, not by the current flag. After an engine
+    // crash/reconnect the engine is brand new and knows nothing, yet a
+    // source's stale m_subscribed flag may be either true or false; gating
+    // on is_subscribed() left feeds dark until the operator hit Apply/Recover
+    // by hand (2026-08-09). Every source that wants a feed re-subscribes.
     for (auto *src : m_sources)
-        if (src && src->is_subscribed()) src->subscribe();
+        if (src && src->wants_subscription()) src->subscribe();
 }
 
 uint32_t ZoomOutputManager::recover_stale_sources(bool force)

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -689,6 +689,15 @@ void ZoomSource::configure_output_ex(AssignmentMode mode,
     if (m_subscribed) subscribe();
 }
 
+bool ZoomSource::wants_subscription() const
+{
+    if (!m_active.load(std::memory_order_acquire))
+        return false;
+    return source_wants_subscription(
+        assignment.load(std::memory_order_acquire),
+        participant_id.load(std::memory_order_acquire));
+}
+
 void ZoomSource::subscribe()
 {
     if (source_uuid.empty()) source_uuid = make_source_uuid();
@@ -816,13 +825,26 @@ void ZoomSource::clear_subscription_state()
 
 bool ZoomSource::recover_stale_video(uint64_t now_ns, bool force)
 {
-    if (!m_active.load(std::memory_order_acquire) ||
-        !m_subscribed.load(std::memory_order_acquire))
+    if (!m_active.load(std::memory_order_acquire))
         return false;
     if (!ZoomEngineClient::instance().is_running() ||
         ZoomEngineClient::instance().state() != MeetingState::InMeeting ||
         !ZoomEngineClient::instance().is_media_active())
         return false;
+    // A source that wants a feed but lost its subscription (engine
+    // reconnect, a cleared flag) has no other automatic way back — the
+    // periodic recovery must be able to re-establish it, not just refresh
+    // an already-subscribed one. Otherwise only a manual Apply/Recover
+    // restored video (2026-08-09).
+    if (!m_subscribed.load(std::memory_order_acquire)) {
+        if (!wants_subscription())
+            return false;
+        blog(LOG_INFO,
+             "[obs-zoom-plugin] Recovery re-subscribing dropped source: source=%s uuid=%s",
+             output_name().c_str(), source_uuid.c_str());
+        subscribe();
+        return true;
+    }
 
     const uint64_t last_frame_ns =
         m_last_frame_ns.load(std::memory_order_acquire);

--- a/src/zoom-source.h
+++ b/src/zoom-source.h
@@ -95,6 +95,10 @@ struct ZoomSource {
     uint32_t width() const;
     uint32_t height() const;
     bool is_subscribed() const { return m_subscribed; }
+    // True when the source's assignment means it SHOULD have a live feed
+    // (regardless of whether it currently does). Used by reconnect/recovery
+    // to re-establish feeds by intent instead of by a possibly-stale flag.
+    bool wants_subscription() const;
     void set_preview_cb(ZoomPreviewCallback cb);
     void clear_preview_cb();
     void release_shared_memory();


### PR DESCRIPTION
Owner-reported (live, repeatedly): video went dark and only a manual **Apply** / **Recover** brought it back after an engine reconnect or scene churn.

Both automatic recovery paths gated on the current subscription flag — `resubscribe_all()` only re-subscribed sources already `is_subscribed()`, and `recover_stale_video()` returned early unless `m_subscribed` was true. A source that *should* have a feed but lost its flag (engine replaced on reconnect; flag cleared) had no automatic path back; only an explicit configure/subscribe (Apply/Recover) restored it.

Now recovery is driven by **intent**: new `ZoomSource::wants_subscription()` (active + assignment ⇒ wants a feed). `resubscribe_all()` re-subscribes everything that wants a feed; the 1s stale-recovery timer re-subscribes a wanted-but-dropped source instead of skipping it. Together with #201 (feeds stay warm across scene switches), a mapped participant behaves like a webcam — always subscribed, self-healing.

18/18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)