### PR TITLE
Engine: raise video resolution in place instead of destroy+recreate

### DIFF
--- a/engine/src/engine-video.cpp
+++ b/engine/src/engine-video.cpp
@@ -106,6 +106,27 @@ ParticipantSubscription::ParticipantSubscription(uint32_t participant_id,
         std::to_string(resolution) + "}");
 }
 
+bool ParticipantSubscription::set_resolution(uint32_t resolution)
+{
+    if (resolution > 2) resolution = 1;
+    if (!m_renderer)
+        return false;
+    if (resolution == m_resolution)
+        return true;
+    const ZOOMSDK::SDKError err =
+        m_renderer->setRawDataResolution(sdk_resolution(resolution));
+    EngineIpc::write(
+        R"({"cmd":"debug","stage":"set_resolution_inplace","participant_id":)" +
+        std::to_string(m_participant_id) + R"(,"code":)" +
+        std::to_string(static_cast<int>(err)) + R"(,"from":)" +
+        std::to_string(m_resolution) + R"(,"to":)" +
+        std::to_string(resolution) + "}");
+    if (err != ZOOMSDK::SDKERR_SUCCESS)
+        return false;
+    m_resolution = resolution;
+    return true;
+}
+
 ParticipantSubscription::~ParticipantSubscription()
 {
     if (m_renderer) {
@@ -354,38 +375,17 @@ void EngineVideo::subscribe(uint32_t participant_id,
     if (it != m_subs.end() && it->second) {
         if (it->second->active()) {
             if (resolution > it->second->resolution()) {
-                auto targets = it->second->sources();
-                const auto already_targeted =
-                    std::find_if(targets.begin(), targets.end(),
-                                 [&source_uuid](const auto &target) {
-                                     return target.first == source_uuid;
-                                 }) != targets.end();
-                if (!already_targeted)
-                    targets.emplace_back(source_uuid, e2p_fd);
-                EngineIpc::write(
-                    R"({"cmd":"debug","stage":"video_upgrade_subscription","source_uuid":")" +
-                    source_uuid + R"(","participant_id":)" +
-                    std::to_string(participant_id) + R"(,"requested":)" +
-                    std::to_string(resolution) + R"(,"previous":)" +
-                    std::to_string(it->second->resolution()) + R"(,"active_targets":)" +
-                    std::to_string(targets.size()) + "}");
-
-                m_subs.erase(it);
-                for (const auto &target : targets)
-                    m_source_participants.erase(target.first);
-
-                it = m_subs.emplace(
-                    participant_id,
-                    std::make_unique<ParticipantSubscription>(
-                        participant_id, targets.front().first,
-                        targets.front().second, resolution)).first;
-                if (!it->second || it->second->empty()) {
-                    m_subs.erase(it);
-                    return;
-                }
-                for (size_t i = 1; i < targets.size(); ++i)
-                    it->second->add_source(targets[i].first, targets[i].second);
-                for (const auto &target : targets) {
+                // Raise the resolution on the LIVE renderer. The old path
+                // destroyed and recreated the renderer, which races the
+                // SDK's async participant release and returns WRONG_USAGE on
+                // the recreate — killing every source sharing this
+                // participant (the "switch to Active Speaker kills a mapped
+                // source, Apply restores it" report). Change it in place and
+                // just attach the new source as another target.
+                const uint32_t previous = it->second->resolution();
+                const bool raised = it->second->set_resolution(resolution);
+                it->second->add_source(source_uuid, e2p_fd);
+                for (const auto &target : it->second->sources()) {
                     m_source_participants[target.first] = {
                         participant_id,
                         it->second->resolution(),
@@ -396,8 +396,11 @@ void EngineVideo::subscribe(uint32_t participant_id,
                     R"({"cmd":"debug","stage":"video_subscription_upgraded","source_uuid":")" +
                     source_uuid + R"(","participant_id":)" +
                     std::to_string(participant_id) + R"(,"requested":)" +
-                    std::to_string(resolution) + R"(,"actual":)" +
-                    std::to_string(it->second->resolution()) + R"(,"active_targets":)" +
+                    std::to_string(resolution) + R"(,"previous":)" +
+                    std::to_string(previous) + R"(,"actual":)" +
+                    std::to_string(it->second->resolution()) +
+                    R"(,"in_place":)" + (raised ? "true" : "false") +
+                    R"(,"active_targets":)" +
                     std::to_string(it->second->target_count()) + "}");
                 return;
             }

--- a/engine/src/engine-video.h
+++ b/engine/src/engine-video.h
@@ -28,6 +28,11 @@ public:
     uint32_t participant_id() const { return m_participant_id; }
     uint32_t resolution() const { return m_resolution; }
     bool active() const { return m_renderer != nullptr; }
+    // Change the raw-data resolution on the LIVE renderer, in place. Avoids
+    // destroy+recreate of the renderer (which races the SDK's async release
+    // of the participant and returns SDKERR_WRONG_USAGE on the recreate —
+    // the "switching to Active Speaker kills a mapped source" failure).
+    bool set_resolution(uint32_t resolution);
     size_t target_count() const;
     void add_source(const std::string &source_uuid, IpcFd e2p_fd);
     void remove_source(const std::string &source_uuid);


### PR DESCRIPTION
## The root cause behind today's video losses
Owner-reported (live): **switching a source to Active Speaker kills other sources until you hit Apply in Output Manager.**

When a source resolves to a participant already subscribed at a lower resolution — e.g. a manual slot showing someone at 720p who then becomes the 1080p active speaker — `EngineVideo::subscribe` took the resolution-**upgrade** path, which:
1. `m_subs.erase()` → destroys the `ParticipantSubscription` → `unSubscribe()` + `destroyRenderer()`
2. immediately recreates the renderer at the higher resolution

The Zoom SDK releases a participant's video **asynchronously**, so the back-to-back recreate returned `SDKERR_WRONG_USAGE` (code 2) → `video_subscribe_failed_all` → every source sharing that participant went dark until a manual Apply/Recover retried after the SDK settled. The live log showed **1,824 code-2 failures** and one source stuck through **128** recovery attempts.

## Fix
`ParticipantSubscription::set_resolution()` changes the raw-data resolution on the **live** renderer via `setRawDataResolution()`. The upgrade path now raises resolution in place and attaches the new source as an additional target — the renderer is never torn down, so there is no re-subscribe and no WRONG_USAGE race.

This is the deep fix I flagged earlier; it turned out to be a clean destroy-vs-async-release race, not an unpredictable SDK-behavior guess. Complements #201 (no scene churn) and #203 (intent recovery).

Follow-up still worth doing (separately): recovery backoff + retry cap so a genuinely unsubscribable feed doesn't retry 128×.

Plugin tests 18/18; engine builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)