### PR TITLE
Recovery: exponential backoff + surface a stalled feed to the operator

### DIFF
--- a/src/zoom-output-dialog.cpp
+++ b/src/zoom-output-dialog.cpp
@@ -143,7 +143,9 @@ static QString signal_text(const ZoomOutputInfo &output)
     if (output.health_reason == ZoomOutputHealthReason::SpotlightUnavailable)
         return QString("Spotlight %1\nunavailable").arg(output.spotlight_slot);
     if (output.observed_width == 0 || output.observed_height == 0)
-        return QStringLiteral("No signal");
+        return output.recovery_stalled
+            ? QStringLiteral("! Can't\nsubscribe")
+            : QStringLiteral("No signal");
     if (output.video_stale)
         return QString("! Stale\n%1.%2s")
             .arg(output.last_frame_age_ms / 1000)

--- a/src/zoom-output-manager.h
+++ b/src/zoom-output-manager.h
@@ -39,6 +39,10 @@ struct ZoomOutputInfo {
     bool video_stale = false;
     uint32_t stale_recovery_attempts = 0;
     uint64_t stale_recovery_cooldown_ms = 0;
+    // True once recovery has failed repeatedly: the feed is still retried at
+    // the slow backoff cadence, but the operator should be told it can't
+    // currently be subscribed (participant likely camera-off / phone-only).
+    bool recovery_stalled = false;
     uint32_t quality_upgrade_attempts = 0;
     uint64_t quality_upgrade_cooldown_ms = 0;
     uint64_t subscribed_age_ms = 0;

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -52,6 +52,20 @@ static constexpr uint64_t kPreviewIntervalNs = 200'000'000ULL;
 static constexpr uint64_t kStaleVideoNs = 3'000'000'000ULL;
 static constexpr uint64_t kNoSignalRecoverNs = 5'000'000'000ULL;
 static constexpr uint64_t kStaleRecoverCooldownNs = 10'000'000'000ULL;
+// After this many consecutive failed recovery attempts a feed is treated as
+// "stalled": recovery keeps trying but at the slow max cadence, and the
+// operator sees a clear status instead of an invisible retry storm (a feed
+// once retried 128x every 10s — 2026-08-09). A frame arriving resets this.
+static constexpr uint32_t kStaleRecoverStalledAfter = 6;
+
+// Exponential backoff for stale recovery: 10s, 20s, 40s, 80s, capped at
+// ~2.5 min, so a feed that cannot come back (camera off, phone-only) stops
+// hammering the SDK while still retrying periodically if it recovers.
+static uint64_t stale_recover_cooldown_ns(uint32_t attempts)
+{
+    const uint32_t shift = std::min<uint32_t>(attempts, 4);
+    return kStaleRecoverCooldownNs << shift;
+}
 static constexpr uint64_t kQualityUpgradeStableNs = 20'000'000'000ULL;
 static constexpr uint64_t kQualityUpgradeBaseCooldownNs = 60'000'000'000ULL;
 
@@ -567,9 +581,11 @@ ZoomOutputInfo ZoomSource::output_info() const
         if (last_recover_ns != 0) {
             const uint64_t recover_age_ns =
                 now_ns > last_recover_ns ? now_ns - last_recover_ns : 0;
-            if (recover_age_ns < kStaleRecoverCooldownNs) {
+            const uint64_t recover_cooldown_ns = stale_recover_cooldown_ns(
+                m_stale_recover_attempts.load(std::memory_order_relaxed));
+            if (recover_age_ns < recover_cooldown_ns) {
                 info.stale_recovery_cooldown_ms =
-                    (kStaleRecoverCooldownNs - recover_age_ns) / 1'000'000ULL;
+                    (recover_cooldown_ns - recover_age_ns) / 1'000'000ULL;
             }
         }
         const uint64_t last_upgrade_ns =
@@ -591,6 +607,8 @@ ZoomOutputInfo ZoomSource::output_info() const
         info.subscribed_age_ms = (now_ns - last_subscribe_ns) / 1'000'000ULL;
     info.stale_recovery_attempts =
         m_stale_recover_attempts.load(std::memory_order_relaxed);
+    info.recovery_stalled =
+        info.stale_recovery_attempts >= kStaleRecoverStalledAfter;
     info.quality_upgrade_attempts =
         m_quality_upgrade_attempts.load(std::memory_order_relaxed);
     info.assignment = mode;
@@ -866,8 +884,10 @@ bool ZoomSource::recover_stale_video(uint64_t now_ns, bool force)
 
     const uint64_t last_recover_ns =
         m_last_stale_recover_ns.load(std::memory_order_acquire);
+    const uint64_t cooldown_ns = stale_recover_cooldown_ns(
+        m_stale_recover_attempts.load(std::memory_order_relaxed));
     if (!force && last_recover_ns != 0 &&
-        now_ns - last_recover_ns < kStaleRecoverCooldownNs)
+        now_ns - last_recover_ns < cooldown_ns)
         return false;
 
     uint64_t expected = last_recover_ns;


### PR DESCRIPTION
Follow-up to #204. Stale-video recovery retried on a flat 10s cooldown with no ceiling — a feed that genuinely can't subscribe (camera-off / phone-only) retried **128 times** over ~20 min, hammering the SDK and burying the log, with no operator-visible sign it had given up.

- **Exponential backoff** (10s → 20s → 40s → 80s, capped ~2.5 min) keyed on the consecutive-attempt counter.
- After 6 failed attempts the output reports `recovery_stalled` → Output Manager shows **"Can't subscribe"** instead of a bare "No signal".
- A frame arriving resets the counter, so a participant re-enabling video recovers automatically at the fast cadence.

18/18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)