### PR TITLE
Gate per-frame debug logging behind CV_ZOOM_VERBOSE_LOG

### DIFF
--- a/engine/src/engine-audio.cpp
+++ b/engine/src/engine-audio.cpp
@@ -63,9 +63,9 @@ bool EngineAudio::subscribe_if_needed(const std::string &source_uuid,
 {
     std::lock_guard<std::mutex> subscribe_lock(m_subscribe_mtx);
     if (m_subscribed) {
-        EngineIpc::write(
-            R"({"cmd":"debug","stage":"audio_target_added","source_uuid":")" +
-            source_uuid + "\"}");
+        // Already subscribed to the single mixed-audio stream; this call is
+        // a no-op share. Emitting a debug line on every roster tick / source
+        // added ~2300 lines to a 90-minute log for no signal — stay quiet.
         return true;
     }
 

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -9,8 +9,33 @@
 #include <obs-module.h>
 #include <util/platform.h>
 #include <chrono>
+#include <cstdlib>
 #include <thread>
 #include <unordered_map>
+
+bool cv_zoom_verbose_logging()
+{
+    static const bool verbose = [] {
+        const char *v = std::getenv("CV_ZOOM_VERBOSE_LOG");
+        return v && *v && !(v[0] == '0' && v[1] == '\0');
+    }();
+    return verbose;
+}
+
+// Stages emitted per video/audio frame or per roster tick — the bulk of the
+// log volume. Kept out of the OBS log unless verbose; always still recorded
+// in the diagnostics ring buffer.
+static bool is_high_frequency_stage(const QString &stage)
+{
+    return stage == QLatin1String("video_frame_received") ||
+           stage == QLatin1String("audio_frame_received") ||
+           stage == QLatin1String("audio_one_way_frame_received") ||
+           stage == QLatin1String("audio_target_added") ||
+           stage == QLatin1String("share_frame_received") ||
+           stage == QLatin1String("set_resolution") ||
+           stage == QLatin1String("video_subscribe_noop_existing") ||
+           stage == QLatin1String("video_raw_status");
+}
 
 static bool is_permanent_meeting_failure(int code)
 {
@@ -671,8 +696,10 @@ void ZoomEngineClient::handle_event(const std::string &line)
         return;
     }
     if (cmd == "debug") {
-        blog(LOG_INFO, "[obs-zoom-plugin] Zoom engine debug: %s", line.c_str());
         const QString stage = obj.value("stage").toString();
+        if (cv_zoom_verbose_logging() || !is_high_frequency_stage(stage))
+            blog(LOG_INFO, "[obs-zoom-plugin] Zoom engine debug: %s",
+                 line.c_str());
         {
             std::lock_guard<std::mutex> lk(m_mtx);
             DebugEvent event;
@@ -850,7 +877,8 @@ void ZoomEngineClient::handle_event(const std::string &line)
             static std::unordered_map<std::string, uint64_t> frame_counts;
             frame_count = ++frame_counts[uuid];
         }
-        if (frame_count == 1 || frame_count % 120 == 0) {
+        if (cv_zoom_verbose_logging() &&
+            (frame_count == 1 || frame_count % 120 == 0)) {
             blog(LOG_INFO,
                  "[obs-zoom-plugin] Dispatching Zoom video frame: source_uuid=%s count=%llu w=%d h=%d",
                  uuid.c_str(), static_cast<unsigned long long>(frame_count),

--- a/src/zoom-engine-client.h
+++ b/src/zoom-engine-client.h
@@ -11,6 +11,14 @@
 #include <unordered_map>
 #include <vector>
 
+// Verbose logging gate. Per-frame / per-roster-tick telemetry (frame
+// received, audio target churn, resolution noops) produced ~27 MB of OBS
+// log in a 90-minute meeting, bloating support bundles and adding hot-path
+// I/O. Those lines are suppressed from the OBS log by default and only
+// emitted when CV_ZOOM_VERBOSE_LOG is set; they are still captured in the
+// in-memory diagnostics ring buffer regardless. Read once, cached.
+bool cv_zoom_verbose_logging();
+
 class ZoomEngineClient {
 public:
     struct DebugEvent {

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -1357,7 +1357,8 @@ bool ZoomSource::output_video_from_shared_memory(
         m_fps_window_start_ns = ts;
         m_fps_window_frames = 0;
     }
-    if (m_frame_count == 1 || m_frame_count % 120 == 0) {
+    if (cv_zoom_verbose_logging() &&
+        (m_frame_count == 1 || m_frame_count % 120 == 0)) {
         blog(LOG_INFO,
              "[obs-zoom-plugin] Output Zoom video frame: source=%s uuid=%s count=%llu w=%u h=%u fmt=%d y_center=%u y_tl=%u",
              output_name().c_str(), source_uuid.c_str(),
@@ -1473,7 +1474,8 @@ void ZoomSource::on_engine_audio(uint32_t event_byte_len,
         output_info(), resolved_participant_id, m_audio_buf.data(), byte_len,
         sample_rate, channels, ts);
     ++m_audio_frame_count;
-    if (m_audio_frame_count == 1 || m_audio_frame_count % 250 == 0) {
+    if (cv_zoom_verbose_logging() &&
+        (m_audio_frame_count == 1 || m_audio_frame_count % 250 == 0)) {
         int peak = 0;
         const uint32_t sample_count = byte_len / kZoomBytesPerSample;
         for (uint32_t i = 0; i < sample_count; ++i)


### PR DESCRIPTION
From the live meeting: a 90-minute 8-feed session produced a **27 MB** OBS log, almost entirely per-frame / per-tick telemetry — the plugin re-logged every engine `debug` line at INFO (10.7k `video_frame_received`, 5.7k `audio_frame_received`), its own Output/Dispatch frame lines, and the engine emitted `audio_target_added` on every no-op share (~2,300 lines). Bloats support bundles, adds hot-path I/O, buries real events.

- High-frequency stages suppressed from the OBS log unless `CV_ZOOM_VERBOSE_LOG` is set; still captured in the diagnostics ring buffer for support bundles.
- State-change / error / join / recovery events always logged.
- Engine stops emitting `audio_target_added` for the no-op already-subscribed case.

18/18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)