### PR TITLE
Render CoreVideo sources unbuffered to kill scene-switch freeze

### DIFF
--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -1638,6 +1638,12 @@ static void *zoom_source_create_common(obs_data_t *settings, obs_source_t *sourc
     ctx->source = source;
     ctx->source_uuid = make_source_uuid();
     ctx->dedicated_active_speaker_source = dedicated_active_speaker;
+    // Render each frame the instant it arrives instead of buffering. A
+    // buffered async source discards and rebuilds its frame buffer every
+    // time a scene reactivates it, holding the last frame frozen until the
+    // buffer refills — the per-scene-switch freeze/stutter operators saw.
+    // Unbuffered also cuts latency, which is the point of this product.
+    obs_source_set_async_unbuffered(source, true);
     if (dedicated_active_speaker) {
         ctx->m_director_preview_uuid = make_source_uuid();
         obs_data_set_int(settings, PROP_ASSIGNMENT_MODE,


### PR DESCRIPTION
Owner-reported (live): program video freezes/stutters on every scene switch. Verified it's **not resource contention** — CPU 13%, GPU 23% during the switching.

Cause: CoreVideo sources are `OBS_SOURCE_ASYNC_VIDEO` with OBS's default frame buffering. OBS discards and rebuilds a source's async frame buffer each time a scene reactivates it, so the source holds its last frame frozen until the buffer refills — a hitch on every cut. (Now visible because #201 keeps feeds warm, so the freeze isn't masked by a resubscribe.)

`obs_source_set_async_unbuffered(source, true)` at creation renders each frame immediately on arrival — no buffer to rebuild on reactivation, and lower latency (the product's premise). Frame timestamps are already monotonic `os_gettime_ns`, so unbuffered playback is smooth.

18/18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)