### PR TITLE
docs: document CoreVideo Tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Changelog: **[Release notes & version history ->](CHANGELOG.md)**
 - **Assignment modes** - each source independently follows: a fixed participant, the active speaker, a ZoomISO-style spotlight slot (1-8), or the active screen share
 - **Failover participant** - configure a secondary participant that activates automatically when the primary leaves
 - **Active Speaker Director** - configurable sensitivity + hold-time switching, manual take/release supersede, and a dedicated `CoreVideo Active Speaker` OBS source for clean speaker-follow output
+- **CoreVideo Tiles** - a single `CoreVideo Tiles` source that lays every participant out as a gallery wall in one OBS source, filling automatically with everyone who has video or with tiles you assign by hand. Tile shape (16:9 through 9:16, or a custom ratio), gap and margin, background colour and background source, borders with square or rounded corners, an outer glow, and per-tile left/right crop are all operator-settable. Optionally names a scene or group where the wall creates one audio source per participant, so each person gets their own fader and ISO track
 - **Spotlight / ZoomISO** - subscribe a source to Spotlight 1-8; engine resolves which participant is spotlighted
 - **Screen share capture** - source subscribes to the active meeting screen-share feed
 - **Zoom interpretation audio channel capture** - dedicated OBS source for existing Zoom interpretation audio channels

--- a/docs/CORE_PLUGIN_FUNCTIONALITY.md
+++ b/docs/CORE_PLUGIN_FUNCTIONALITY.md
@@ -148,6 +148,87 @@ two-slot handoff internally: the current participant remains visible while the
 next participant warms on a hidden slot, then the source cuts only after a valid
 frame is available.
 
+## CoreVideo Tiles
+
+**CoreVideo Tiles** is one OBS source that draws every participant as a gallery
+wall. Where a participant source is one person, Tiles is the whole grid: it
+picks the layout for the number of people on screen, and repaints itself as
+people join and leave. Add it from **Sources -> Add -> CoreVideo Tiles**.
+
+Every tile is filled, never letterboxed. A tile narrower than the camera feeding
+it crops the sides rather than adding bars, which is what keeps a wall of mixed
+cameras looking even.
+
+### Filling the wall
+
+| Control | Does |
+| --- | --- |
+| **Fill mode** | `Auto - everyone with video` fills the wall with whoever currently has video, in roster order. `Manual - choose per tile` gives you a **Tile 1..N** dropdown per position, so you place people yourself. |
+| **Maximum tiles** | Upper bound on how many tiles Auto mode will draw. |
+| **Never show** | Participants Auto mode skips — the stage camera, a recording bot, anyone who should never land on the wall. |
+| **Refresh participant list** | Re-reads the roster if someone joined while the properties dialog was open. |
+
+### Shape and spacing
+
+| Control | Default | Does |
+| --- | --- | --- |
+| **Tile shape** | `16:9 (widescreen)` | Shape of every tile: 16:9, 4:3, 5:4, 1:1 (square), 3:4 (portrait), 9:16 (vertical), or `Custom ratio`. |
+| **Custom ratio (width / height)** | 16:9 | Used only when Tile shape is `Custom ratio`. |
+| **Gap between tiles (% of canvas height)** | 0.741% | Space between tiles. A percentage of canvas height, so spacing scales with the canvas — 0.741% is the 8 px at 1080p the wall has always used. |
+| **Margin around the wall (% of canvas height)** | 0.741% | Space between the wall and the canvas edge. |
+
+### Background
+
+**Background colour** fills the gutters, the margin, and any canvas the wall does
+not cover. **Background source** draws any video-producing OBS source — an Image,
+a Media Source, a Browser Source — behind the tiles and over that colour; leave
+it on `- none -` for colour only. A background source that is deleted, or one
+that would render itself (the wall, or a scene containing it), falls back to the
+colour rather than breaking the wall.
+
+### Borders and glow
+
+| Control | Default | Does |
+| --- | --- | --- |
+| **Border width** | 0 (off) | Border drawn inside each tile's edge. |
+| **Border colour** | black | |
+| **Corner shape** | Square | `Square` or `Rounded`. |
+| **Corner radius** | 16 | Shown only when Corner shape is `Rounded`. |
+| **Glow size** | 0 (off) | Outer glow drawn around each tile, in a pass behind the tiles. |
+| **Glow colour** | white | |
+| **Glow intensity (%)** | 100 | |
+| **Glow softness (%)** | 0 | How gradually the glow falls off. |
+
+Border width and corner radius are clamped against the tile they are drawn on —
+past half the shorter side there is no interior left — so an extreme value
+degrades gracefully instead of inverting the tile.
+
+### Per-tile crop
+
+**Per-tile crop** gives each tile its own `crop left %` and `crop right %`, for
+trimming a participant who is sitting off-centre without touching the others.
+
+### Per-participant audio
+
+The wall itself carries no audio. **Participant audio scene or group** names a
+scene or group in which the wall creates one Zoom participant audio source per
+tile, so every person on the wall gets their own fader and their own ISO track.
+Leave it blank and nothing is created.
+
+Points worth knowing before you switch it on:
+
+- **Add that scene or group to every scene.** Audio then stays put while you cut
+  between scenes, instead of appearing and disappearing with the wall.
+- **A nested scene is safer than a group.** A group can be dissolved with
+  **Ungroup**, which scatters the sources inside it.
+- **Use the audio group on one Tiles source only.** If you run a second wall — a
+  panel wall beside a main one — leave its audio field blank. Audio for each
+  person belongs to whichever wall created it, so on a second wall someone who
+  drops off that wall can be left muted while still on screen on the other one,
+  and both walls number their ISO stems from track 2 up, which can put two
+  people on the same stem in the recording. The plugin logs a warning if it sees
+  a second wall with a group set.
+
 ## Active Speaker Director
 
 The Active Speaker Director is controlled from the Zoom Control dock. It is not

--- a/docs/OPERATOR_QUICKSTART.md
+++ b/docs/OPERATOR_QUICKSTART.md
@@ -61,6 +61,29 @@ changing settings. The bundle redacts tokens and includes OBS/engine/ISO status.
 CoreVideo keeps OBS sources at a stable canvas size and lets OBS scale lower
 quality feeds instead of changing source geometry during a meeting.
 
+## Tiles Wall
+
+Use **CoreVideo Tiles** when you want everyone on screen at once as a gallery,
+in a single OBS source that relays itself as people come and go.
+
+1. Add **CoreVideo Tiles** from **Sources -> Add**.
+2. Leave **Fill mode** on `Auto - everyone with video` to fill the wall with
+   whoever has video, or pick `Manual - choose per tile` to place people
+   yourself.
+3. Set **Maximum tiles** to the largest wall you want, and list anyone who
+   should never appear under **Never show** — a stage camera or a recording bot.
+4. Style it: **Tile shape**, **Gap between tiles**, **Margin around the wall**,
+   **Background colour** and optional **Background source**, then borders and
+   glow if the show wants them.
+5. For per-person faders and ISO tracks, set **Participant audio scene or
+   group** to a scene or group, and add that scene or group to every scene so
+   audio does not come and go as you cut. Leave it blank if you do not want the
+   wall creating audio sources.
+
+Tiles are always filled, never letterboxed: a tile narrower than the camera
+feeding it crops the sides. If you run a second wall, leave its audio field
+blank — only one wall should own participant audio.
+
 ## Active Speaker
 
 Use the **CoreVideo Active Speaker** OBS source when you want one clean output

--- a/docs/VALIDATION_MATRIX.md
+++ b/docs/VALIDATION_MATRIX.md
@@ -28,6 +28,35 @@ changing the Zoom sign-in or meeting-join path.
 - Use manual take/release and confirm release does not cut away unnecessarily
   when the manual speaker remains valid.
 
+## Tiles Wall Live Validation
+
+- Use at least four participants with video enabled.
+- In `Auto - everyone with video`, confirm the wall relays itself as
+  participants join and leave, and that it never exceeds **Maximum tiles**.
+- Add a participant to **Never show** and confirm they leave the wall and no
+  gap is left behind.
+- Switch to `Manual - choose per tile`, assign specific people, and confirm
+  each tile holds its assignment across a join/leave.
+- Change **Tile shape** and confirm tiles crop to fill rather than letterbox.
+- Change **Gap between tiles** and **Margin around the wall** and confirm the
+  spacing scales with canvas height.
+- Set a **Background source** and confirm it draws behind the tiles; delete that
+  source mid-show and confirm the wall falls back to **Background colour**
+  instead of breaking.
+- Point **Background source** at the wall itself, or a scene containing it, and
+  confirm the self-reference falls back to colour.
+- Enable borders and glow; confirm an extreme **Border width** or **Corner
+  radius** clamps instead of inverting the tile.
+- Apply a per-tile **crop left %** / **crop right %** and confirm only that tile
+  changes.
+- Set **Participant audio scene or group** and confirm one audio source per tile
+  is created inside it, each with its own fader and ISO track, and that the wall
+  itself carries no audio.
+- Cut between scenes with the audio scene/group present in each and confirm
+  audio does not drop.
+- Add a second Tiles source with an audio group set and confirm the plugin logs
+  a warning about the second wall.
+
 ## OBS Lifecycle And Reopen
 
 - Start OBS with the plugin installed.


### PR DESCRIPTION
Tiles is the headline feature of 0.1.37 and had zero mentions in README.md, docs/CORE_PLUGIN_FUNCTIONALITY.md, docs/OPERATOR_QUICKSTART.md, or docs/VALIDATION_MATRIX.md. The release checklist requires the first three to match the current plugin.

This commit was pushed to the 0.1.37 release branch a few minutes after #212 had already merged, so it missed that merge. Same branch, docs only — no code.

- **README**: feature bullet
- **CORE_PLUGIN_FUNCTIONALITY**: full section — fill mode and exclusions, tile shape and spacing, background colour/source and its fallback when the source is deleted or self-referencing, borders and glow with clamping, per-tile crop, per-participant audio and the one-wall-only caveat
- **OPERATOR_QUICKSTART**: task-shaped walkthrough
- **VALIDATION_MATRIX**: live pass/fail rows, including deleted and self-referencing background sources, extreme border values, and a second wall claiming participant audio

Labels and defaults come from `data/locale/en-US.ini` and the property defaults in `src/zoom-supersource.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)