### PR TITLE
fix(ci): repair the Zoom SDK draft-asset lookup on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,29 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
-          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          # Filter in PowerShell, not in --jq. The jq filter needs a quoted
+          # string literal for the asset name, and there is no reliable way to
+          # get one through Windows PowerShell's native-argument handling: \"
+          # is not a PowerShell escape, so it ended the string early and gh saw
+          # the rest of the filter as extra positional arguments ("accepts 1
+          # arg(s), received 3"), while a correctly-quoted PowerShell string
+          # arrives at gh with the inner quotes stripped ("failed to parse jq
+          # expression"). The lookup found nothing either way and this step
+          # degraded to a runtime-less build, which on a tag silently cost us a
+          # release.
+          $releases = gh api "repos/$env:GITHUB_REPOSITORY/releases" | ConvertFrom-Json
+          $assetId = ($releases |
+              Where-Object { $_.draft } |
+              ForEach-Object { $_.assets } |
+              Where-Object { $_.name -eq $assetName } |
+              Select-Object -First 1).id
           if (-not $assetId) {
+              # On a tag this is a release build, and a release without the Zoom
+              # runtime is not publishable — fail loudly rather than skip the
+              # release job and leave a tag with nothing attached to it.
+              if ($env:GITHUB_REF -like 'refs/tags/*') {
+                  throw "$assetName not found on any draft release (or the token cannot see drafts). Refusing to build a release tag without the Zoom runtime."
+              }
               "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
               "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
               Write-Warning "$assetName not found on any draft release (or token lacks access). Building Windows validation artifact without ZoomObsEngine runtime."

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -113,12 +113,28 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $assetName = "zoom-sdk-windows-7.1.5.43953.zip"
-          $assetId = gh api "repos/$env:GITHUB_REPOSITORY/releases" --jq ".[] | select(.draft) | .assets[] | select(.name==\"$assetName\") | .id" | Select-Object -First 1
+          # Filter in PowerShell, not in --jq. The jq filter needs a quoted
+          # string literal for the asset name, and there is no reliable way to
+          # get one through Windows PowerShell's native-argument handling: \"
+          # is not a PowerShell escape, so it ended the string early and gh saw
+          # the rest of the filter as extra positional arguments ("accepts 1
+          # arg(s), received 3"), while a correctly-quoted PowerShell string
+          # arrives at gh with the inner quotes stripped ("failed to parse jq
+          # expression"). The lookup found nothing either way, this step warned
+          # and exited 0, and the build carried on without the plugin until
+          # packaging failed on the missing DLL — which is how v0.1.37 ended up
+          # tagged with no release attached to it.
+          $releases = gh api "repos/$env:GITHUB_REPOSITORY/releases" | ConvertFrom-Json
+          $assetId = ($releases |
+              Where-Object { $_.draft } |
+              ForEach-Object { $_.assets } |
+              Where-Object { $_.name -eq $assetName } |
+              Select-Object -First 1).id
           if (-not $assetId) {
-            "COREVIDEO_HAS_ZOOM_RUNTIME=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-            "has_zoom_runtime=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Warning "$assetName not found on any draft release (or token lacks access). Building a validation-only package without ZoomObsEngine runtime."
-            exit 0
+            # This workflow only ever runs to publish a release, so there is no
+            # legitimate runtime-less path here. Fail where the cause is
+            # visible instead of ten minutes later in package validation.
+            throw "$assetName not found on any draft release (or the token cannot see drafts). A release build cannot proceed without the Zoom runtime."
           }
           Write-Host "Fetching $assetName (asset id $assetId)"
           curl.exe -sSfL -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/octet-stream" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/assets/$assetId" -o zoom-sdk.zip


### PR DESCRIPTION
**The v0.1.37 tag published nothing.** Both Windows jobs look the Zoom SDK up with a jq filter passed to `gh`, and that filter needs a quoted string literal for the asset name — which cannot be reliably passed through Windows PowerShell's native-argument handling:

- `\"` is not a PowerShell escape, so the string ended early and `gh` saw the rest of the filter as extra positional arguments → `accepts 1 arg(s), received 3`
- quoting it correctly for PowerShell instead delivers it to `gh` with the inner quotes stripped → `failed to parse jq expression`

Both reproduced against the live API before changing anything.

Either way the lookup found nothing, and both steps degraded quietly:

- `release-windows.yml` warned, exited 0, built without the plugin, then failed package validation on the missing `obs-zoom-plugin.dll`
- `build.yml` did the same and reported `has_zoom_runtime=false` — a condition on its `Create GitHub Release` job, which therefore **skipped**, leaving the tag with no release attached

## Fix

Filter in PowerShell against the parsed JSON. `gh` takes exactly one argument and there is no quoting to get wrong. Verified locally: the old form reproduces the CI error, the new form returns asset id `494784646`.

Both steps also stop degrading silently on a release build. `release-windows.yml` only ever runs to publish, so a missing runtime now throws. `build.yml` keeps the soft path for ordinary pushes and PRs, where a runtime-less validation build is legitimate, but throws on a tag.

The macOS lookup is left alone — it is bash, where `\"` inside double quotes is a real escape, and it resolved its asset correctly in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)