### PR TITLE
fix(hwaccel): stop using av_opt_set_int_list, removed in current FFmpeg

### DIFF
--- a/src/hw-video-pipeline.cpp
+++ b/src/hw-video-pipeline.cpp
@@ -220,9 +220,19 @@ bool HwVideoPipeline::build_filter_graph(int w, int h)
     }
 
     // Constrain sink output to NV12 only.
-    const enum AVPixelFormat sink_fmts[] = { AV_PIX_FMT_NV12, AV_PIX_FMT_NONE };
-    if (av_opt_set_int_list(m_buf_sink, "pix_fmts", sink_fmts,
-                            AV_PIX_FMT_NONE, AV_OPT_SEARCH_CHILDREN) < 0) {
+    //
+    // Set the binary option directly rather than through av_opt_set_int_list().
+    // That macro was deprecated and has now been removed, and CI takes FFmpeg
+    // from a "latest" build that picked the removal up — so the plugin stopped
+    // compiling on Windows without a line of our code changing. av_opt_set_bin()
+    // is what the macro expanded to, and it exists either side of the removal.
+    // The size it wants counts the formats only, never the AV_PIX_FMT_NONE
+    // terminator, so the array does not carry one.
+    const enum AVPixelFormat sink_fmts[] = { AV_PIX_FMT_NV12 };
+    if (av_opt_set_bin(m_buf_sink, "pix_fmts",
+                       reinterpret_cast<const uint8_t *>(sink_fmts),
+                       static_cast<int>(sizeof(sink_fmts)),
+                       AV_OPT_SEARCH_CHILDREN) < 0) {
         teardown_graph();
         return false;
     }


### PR DESCRIPTION
The Windows plugin build breaks with:

```
src/hw-video-pipeline.cpp(224,9): error C3861: 'av_opt_set_int_list': identifier not found
```

without a line of our code changing — `hw-video-pipeline.cpp` is untouched since v0.1.36. `av_opt_set_int_list()` was deprecated and has now been removed, and CI takes FFmpeg from BtbN's **"latest"** LGPL shared build, which picked the removal up.

`av_opt_set_bin()` is what the macro expanded to and exists either side of the removal, so this compiles against both. The size it wants counts the formats only and never the `AV_PIX_FMT_NONE` terminator, so the array no longer carries one. Verified compiling locally.

**Why this was invisible:** the Windows job's Zoom SDK lookup was failing, so CI configured with `COREVIDEO_BUILD_PLUGIN=OFF` and never compiled the plugin at all. Repairing that lookup in #214 is what surfaced this.

**Worth considering separately:** CI pinning FFmpeg to a known-good build rather than tracking `latest`. A dependency that can remove APIs between two runs of the same commit will do this again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)