### PR TITLE
docs: backfill CHANGELOG compare links for 0.1.28-0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,6 +493,14 @@ Manager, and the initial Windows release packaging and CI pipeline.
 [Unreleased]: https://github.com/iamfatness/CoreVideo/compare/v0.1.38...HEAD
 [0.1.38]: https://github.com/iamfatness/CoreVideo/compare/v0.1.37...v0.1.38
 [0.1.37]: https://github.com/iamfatness/CoreVideo/compare/v0.1.36...v0.1.37
+[0.1.36]: https://github.com/iamfatness/CoreVideo/compare/v0.1.35...v0.1.36
+[0.1.35]: https://github.com/iamfatness/CoreVideo/compare/v0.1.34...v0.1.35
+[0.1.34]: https://github.com/iamfatness/CoreVideo/compare/v0.1.33...v0.1.34
+[0.1.33]: https://github.com/iamfatness/CoreVideo/compare/v0.1.31...v0.1.33
+[0.1.31]: https://github.com/iamfatness/CoreVideo/compare/v0.1.30...v0.1.31
+[0.1.30]: https://github.com/iamfatness/CoreVideo/compare/v0.1.29...v0.1.30
+[0.1.29]: https://github.com/iamfatness/CoreVideo/compare/v0.1.28...v0.1.29
+[0.1.28]: https://github.com/iamfatness/CoreVideo/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/iamfatness/CoreVideo/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/iamfatness/CoreVideo/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/iamfatness/CoreVideo/compare/v0.1.24...v0.1.25


### PR DESCRIPTION
## What

`CHANGELOG.md`'s Keep a Changelog link-reference block jumped straight from `[0.1.37]` to `[0.1.27]`. The convention lapsed for nine releases and was only picked back up at 0.1.37, so every version in between rendered as plain text instead of a compare link.

This backfills the missing references in the same descending order and exact format as the surrounding entries.

## Backfilled (8)

| Version | Compare range |
| --- | --- |
| 0.1.36 | `v0.1.35...v0.1.36` |
| 0.1.35 | `v0.1.34...v0.1.35` |
| 0.1.34 | `v0.1.33...v0.1.34` |
| 0.1.33 | `v0.1.31...v0.1.33` |
| 0.1.31 | `v0.1.30...v0.1.31` |
| 0.1.30 | `v0.1.29...v0.1.30` |
| 0.1.29 | `v0.1.28...v0.1.29` |
| 0.1.28 | `v0.1.27...v0.1.28` |

## Deliberately skipped: 0.1.32

- It has **no `## [0.1.32]` section** in the document — the prose goes 0.1.33 -> 0.1.31 directly.
- **No plain `v0.1.32` tag was ever cut.** The only thing in that slot is `v0.1.32-beta.1`.

Adding a `[0.1.32]` reference would have invented an entry for a release that neither exists in the document nor in the tag list. Instead, `[0.1.33]` compares against `v0.1.31` — the previous release actually documented here.

## Verification

Every tag referenced was checked against `git tag -l "v0.1.*"`. All 9 distinct tags used (`v0.1.27` through `v0.1.36`) exist; no link points at a tag that was never cut.

Link references only — no prose was touched. The diff is 8 pure additions.

> Note: the `Windows x64` check is red for the known unrelated reason (a header missing from the Zoom SDK archive on the private draft release). This PR touches only `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)