### PR TITLE
Test the director-preview frame ownership guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,6 +825,19 @@ if(BUILD_TESTING)
     add_test(NAME CoreVideoSpeakerSettingsMerge
              COMMAND CoreVideoSpeakerSettingsMergeTest)
 
+    # Which frames the hidden director-preview subscription may put on air. It
+    # warms the next speaker only; a frame from anyone else is a stale in-flight
+    # frame and publishing it is the wrong face on a live broadcast — see the
+    # 2026-08-11 incident described in the test.
+    add_executable(CoreVideoDirectorPreviewFrameGuardTest
+        tests/director-preview-frame-guard-test.cpp
+    )
+    target_include_directories(CoreVideoDirectorPreviewFrameGuardTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoDirectorPreviewFrameGuard
+             COMMAND CoreVideoDirectorPreviewFrameGuardTest)
+
     # Measures the luma range actually delivered by the SDK, so the full-range
     # vs limited-range question is settled by measurement, not assumption.
     add_executable(CoreVideoLumaRangeProbeTest

--- a/src/director-preview-frame-guard.h
+++ b/src/director-preview-frame-guard.h
@@ -1,0 +1,28 @@
+// src/director-preview-frame-guard.h
+#pragma once
+
+#include <cstdint>
+
+// Whether a frame delivered by the hidden director-preview subscription may be
+// published to the program output.
+//
+// The preview slot exists only to warm the NEXT speaker's region so the cut
+// lands on a real frame instead of a gap, but publishing pushes straight to the
+// program output — so a frame from anyone other than the participant the slot
+// is currently pointed at puts the wrong face on air. Two of those arrive
+// routinely: frames still in flight for the previous target after the slot is
+// re-pointed, and frames the engine had already queued when the cut
+// unsubscribed it (which leaves nothing awaited, i.e. 0). On the 2026-08-11
+// live show that read as a participant flashing up with no speaker change
+// behind them, and a late frame carrying a different id than the one just cut
+// to made the commit logic cut straight back to it — sub-second A->B->A cuts.
+//
+// So: exactly one frame is the cut, the one belonging to the live preview
+// target. An idle slot (awaited 0) awaits nobody and publishes nothing, which
+// also keeps an unidentified frame (id 0) from reading as a match for it.
+inline bool should_publish_director_preview_frame(uint32_t awaited_participant_id,
+                                                  uint32_t frame_participant_id)
+{
+    return awaited_participant_id != 0 &&
+           frame_participant_id == awaited_participant_id;
+}

--- a/src/zoom-source.cpp
+++ b/src/zoom-source.cpp
@@ -1,4 +1,5 @@
 #include "zoom-source.h"
+#include "director-preview-frame-guard.h"
 #include "shm-resubscribe.h"
 #include "luma-range-probe.h"
 #include "speaker-director.h"
@@ -1224,9 +1225,14 @@ void ZoomSource::on_director_preview_frame(uint32_t event_width,
     // cut to, the commit below cut straight back to it — the sub-second A->B->A
     // pairs. Publish only the frame that belongs to the live preview target;
     // that frame, and only that frame, is the cut.
+    //
+    // The decision itself lives in director-preview-frame-guard.h so it can be
+    // tested without libobs: a regression here is silent everywhere except a
+    // live broadcast, so it is not left as an untested inline condition.
     const uint32_t awaited =
         m_director_preview_subscription_id.load(std::memory_order_acquire);
-    if (awaited == 0 || resolved_participant_id != awaited) {
+    if (!should_publish_director_preview_frame(awaited,
+                                               resolved_participant_id)) {
         if (cv_zoom_verbose_logging()) {
             blog(LOG_INFO,
                  "[obs-zoom-plugin] Dropped stale director preview frame: source=%s participant=%u awaited=%u",

--- a/tests/director-preview-frame-guard-test.cpp
+++ b/tests/director-preview-frame-guard-test.cpp
@@ -1,0 +1,70 @@
+// tests/director-preview-frame-guard-test.cpp
+// Which frames the hidden director-preview subscription is allowed to put on
+// air.
+//
+// The incident this guards (2026-08-11, live show): the `CoreVideo Active
+// Speaker` source keeps a second, hidden subscription that warms up the NEXT
+// speaker's video so the cut lands on a real frame instead of a gap.
+// ZoomSource::on_director_preview_frame() published every frame that slot
+// delivered straight to the program output. Two kinds of frame routinely arrive
+// that do not belong to the participant we are waiting on: frames still in
+// flight for the previous target after maybe_update_director_subscription()
+// re-points the slot, and frames the engine had already queued when the cut
+// unsubscribed it. On air that read as a participant flashing up with no
+// speaker change behind them — and when such a late frame carried a different
+// id than the one just cut to, the commit logic cut straight back to it,
+// producing sub-second A->B->A cuts.
+//
+// The guard lives in ZoomSource, which needs libobs to instantiate, so the
+// decision is factored out here as a pure rule and tested on its own — the same
+// treatment speaker-settings-merge.h gets, and for the same reason: the only
+// symptom of a regression is the wrong face on a live broadcast.
+
+#include "director-preview-frame-guard.h"
+
+#include <iostream>
+
+static int failures = 0;
+
+static void check(bool ok, const char *message)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+int main()
+{
+    // --- The frame we are waiting on is the cut, and must publish ---
+    check(should_publish_director_preview_frame(16790528, 16790528),
+          "the awaited participant's frame was dropped — the cut would land on "
+          "a gap instead of a real frame");
+
+    // --- A frame for anyone else is a stale in-flight frame from the slot's
+    // previous target: publishing it puts the wrong face on air ---
+    check(!should_publish_director_preview_frame(16790528, 16778240),
+          "a frame for a participant other than the awaited one was published — "
+          "this is the wrong-face flash, and the id mismatch is what drove the "
+          "A->B->A cuts");
+
+    // --- Nothing awaited (the cut already unsubscribed the slot, which stores
+    // 0): every frame still queued in the engine must be dropped ---
+    check(!should_publish_director_preview_frame(0, 16790528),
+          "a frame arriving after the cut unsubscribed the preview slot was "
+          "published");
+
+    // --- A frame with no participant id is not a match for an idle slot: two
+    // zeroes must not read as 'the awaited participant arrived' ---
+    check(!should_publish_director_preview_frame(0, 0),
+          "an unidentified frame was treated as matching an idle preview slot");
+
+    // --- ...nor may an unidentified frame ride out on a live slot ---
+    check(!should_publish_director_preview_frame(16790528, 0),
+          "an unidentified frame was published while a real participant was "
+          "awaited");
+
+    if (failures == 0)
+        std::cout << "director-preview-frame-guard tests passed\n";
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## The on-air failure this protects against

The `CoreVideo Active Speaker` source keeps two subscriptions: a "current" one that is on air, and a hidden "director preview" one that warms up the NEXT speaker's video so the cut lands on a real frame instead of a gap.

Until today's fix, `ZoomSource::on_director_preview_frame()` published **every** frame the preview slot delivered straight to the program output. Two kinds of frame routinely arrive that do not belong to the participant the slot is currently pointed at:

- frames still in flight for the **previous** preview target, after `maybe_update_director_subscription()` re-points the slot;
- frames the engine had **already queued** when the cut unsubscribed the slot.

On air (2026-08-11, live show) that read as a participant flashing up with no speaker change behind them. Worse, when such a late frame carried a different participant id than the one just cut to, the commit logic cut straight back to it — the sub-second A→B→A cuts.

The fix was an ownership guard at the top of `on_director_preview_frame()`: read the `m_director_preview_subscription_id` atomic and drop the frame unless the resolved participant id equals it (and it is non-zero).

## Why this PR

That guard had **no automated test**. It lives in `ZoomSource`, which needs libobs to instantiate, so the condition sat inline and untested — it could regress silently, and the only symptom would be the wrong face on a live broadcast.

## What changed

- **`src/director-preview-frame-guard.h`** (new): a pure header, no libobs dependency, with the single decision:

  ```cpp
  bool should_publish_director_preview_frame(uint32_t awaited_participant_id,
                                             uint32_t frame_participant_id);
  ```

  This is the idiom the repo already uses for exactly this situation — see `src/speaker-settings-merge.h` and its test.

- **`tests/director-preview-frame-guard-test.cpp`** (new), registered in `CMakeLists.txt` as `CoreVideoDirectorPreviewFrameGuard`, alongside the other pure-unit tests. Covers:
  - the awaited participant's frame **publishes** — otherwise the cut lands on a gap;
  - a frame for a **different** participant is dropped — the wrong-face flash, and the id mismatch that drove the A→B→A cuts;
  - a frame arriving when **nothing is awaited** (id 0, i.e. after the cut unsubscribed the slot) is dropped;
  - a frame with participant id **0** is dropped rather than treated as a match — against both an idle slot (0 vs 0 must not read as "the awaited participant arrived") and a live one.

- **`src/zoom-source.cpp`**: `on_director_preview_frame()` now calls the helper instead of duplicating the condition inline, so the test guards the live code path rather than a copy.

## No behaviour change

`!should_publish_director_preview_frame(awaited, resolved)` is exactly the previous `awaited == 0 || resolved_participant_id != awaited`. The verbose-logging line that reports dropped frames is untouched. Nothing else was changed or refactored.

## Test-first evidence

Written strictly test-first. The test was committed against a stub that deliberately returned the **wrong** answer — specifically the pre-fix behaviour, "publish everything" — so the failure was behavioural rather than a compile error:

```
FAIL: a frame for a participant other than the awaited one was published — this is the wrong-face flash, and the id mismatch is what drove the A->B->A cuts
FAIL: a frame arriving after the cut unsubscribed the preview slot was published
FAIL: an unidentified frame was treated as matching an idle preview slot
FAIL: an unidentified frame was published while a real participant was awaited
exit=1
```

Note the awaited-frame case passed even against the stub, so the four failures isolate exactly the drop logic. With the real rule in place:

```
director-preview-frame-guard tests passed
exit=0
```

Full suite after wiring the live code to the helper:

```
100% tests passed, 0 tests failed out of 40
```

(39 before this PR, plus the new one.)

## CI note

The "Windows x64" check is currently red for an unrelated known reason — the Zoom SDK archive on the private draft release is missing a header. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
