### PR TITLE
Speaker director: cap undebounced vacancy fills at one per hold window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ are tagged `vMAJOR.MINOR.PATCH` and published as
 
 ## [Unreleased]
 
+### Fixed
+- **Active speaker can no longer cut faster than the hold time when someone
+  becomes ineligible.** Excluding whoever is on air still moves off them
+  immediately — that part is deliberate — but the *replacement* was chosen with
+  neither the hold nor the sensitivity window applied. Anything that emptied the
+  active speaker slot repeatedly (an exclusion list that flapped, a participant
+  dropping out of the roster) therefore handed out a free cut every time it
+  happened; a live show saw cuts 0.3 seconds apart on a 2 second hold. The first
+  such cut is still instant, so one operator action still cuts at once. A second
+  one inside the same hold window now has to hold the floor for the sensitivity
+  window first, so a cough or a moment of cross-talk can no longer take the
+  program output just because the slot happened to be empty.
+
 ## [0.1.38] - 2026-08-12
 
 ### Fixed

--- a/src/speaker-director.cpp
+++ b/src/speaker-director.cpp
@@ -42,6 +42,8 @@ void SpeakerDirector::reset()
     m_excluded_participant_ids.clear();
     m_candidate_since_ms = 0;
     m_last_switch_ms = 0;
+    m_last_forced_fill_ms = 0;
+    m_forced_vacancy = false;
 }
 
 // Strict vetting for NEW candidates only. The incumbent is judged by
@@ -88,16 +90,16 @@ void SpeakerDirector::enforce_incumbent_eligibility_locked(uint64_t now_ms)
     const auto enforce = [&](uint32_t &holder, uint64_t &missing_since) {
         if (holder == 0) {
             missing_since = 0;
-            return;
+            return false;
         }
         if (participant_excluded_locked(holder)) {
             holder = 0;
             missing_since = 0;
-            return;
+            return true;
         }
         if (participant_in_roster_locked(holder)) {
             missing_since = 0;
-            return;
+            return false;
         }
         // Absent from the roster: could be a transient blip (engine
         // reconnect) — dethrone only after the grace window.
@@ -107,9 +109,16 @@ void SpeakerDirector::enforce_incumbent_eligibility_locked(uint64_t now_ms)
                  now_ms - missing_since > kAbsenceGraceMs) {
             holder = 0;
             missing_since = 0;
+            return true;
         }
+        return false;
     };
-    enforce(m_directed_speaker_id, m_directed_missing_since_ms);
+    // Remember that the chair was emptied by enforcement, not by a cold
+    // start: fill_vacancy_locked() debounces the replacement in that case.
+    // Sticky until something is actually promoted — the vacancy is still a
+    // forced one on the ticks that follow.
+    if (enforce(m_directed_speaker_id, m_directed_missing_since_ms))
+        m_forced_vacancy = true;
     enforce(m_manual_speaker_id, m_manual_missing_since_ms);
 }
 
@@ -134,7 +143,64 @@ bool SpeakerDirector::promote_locked(uint32_t participant_id, uint64_t now_ms)
     m_candidate_speaker_id = 0;
     m_candidate_since_ms = 0;
     m_last_switch_ms = now_ms;
+    m_forced_vacancy = false;
     return true;
+}
+
+// The chair is empty. This used to be the one path that promoted with NEITHER
+// hold NOR sensitivity applied, and on 2026-08-10 that produced active-speaker
+// cuts 0.3 s apart on a 2 s hold: a settings-precedence bug flapped the
+// exclusion list, enforce_incumbent_eligibility_locked() dethroned the
+// directed speaker on nearly every cycle, and each dethrone handed out another
+// free cut to whatever choose_candidate_locked() returned at that instant.
+//
+// Leaving an ineligible incumbent must still be instant — when an operator
+// excludes whoever is on air, they expect them off air now — so the fill stays
+// immediate for the cases that matter and is only rate-limited on repeats:
+//
+//   * cold start (reset(), first roster of a meeting): nothing is on air, so
+//     there is no cut to debounce. Take the first eligible speaker at once.
+//   * first forced vacancy in a hold window: immediate, as before. One
+//     operator action, one instant cut.
+//   * a second forced vacancy inside that same hold window: this is the flap
+//     signature, and the replacement is unvetted — it could be a cough or a
+//     half-second of cross-talk. Make it earn the shot through the normal
+//     sensitivity window first.
+//
+// Waiting costs no picture: while the director reports 0, an ActiveSpeaker
+// source keeps its current subscription (zoom-source.cpp), so the last speaker
+// stays on the program output instead of cutting to black.
+//
+// Deliberately NOT done here: falling back to m_last_speaker_id. Under the
+// exact failure mode being hardened — a flapping eligibility set — the last
+// speaker is the participant most likely to have just flapped back into
+// eligibility, so preferring them would trade the free-cut bug for a free
+// A→B→A ping-pong. Vetting has to be temporal (has this candidate held the
+// floor for sensitivity_ms?), not historical.
+bool SpeakerDirector::fill_vacancy_locked(uint32_t candidate, uint64_t now_ms)
+{
+    // Track the candidate even while the chair is empty, so the sensitivity
+    // clock runs and a candidate that changes mid-window re-arms it.
+    if (candidate != m_candidate_speaker_id) {
+        m_candidate_speaker_id = candidate;
+        m_candidate_since_ms = candidate != 0 ? now_ms : 0;
+    }
+    if (candidate == 0)
+        return false;
+
+    if (m_forced_vacancy) {
+        const bool immediate_fill_available =
+            m_last_forced_fill_ms == 0 || now_ms < m_last_forced_fill_ms ||
+            now_ms - m_last_forced_fill_ms >= m_hold_ms;
+        if (!immediate_fill_available &&
+            (now_ms < m_candidate_since_ms ||
+             now_ms - m_candidate_since_ms < m_sensitivity_ms)) {
+            return false;
+        }
+        m_last_forced_fill_ms = now_ms;
+    }
+
+    return promote_locked(candidate, now_ms);
 }
 
 bool SpeakerDirector::set_manual_speaker(uint32_t participant_id, uint64_t now_ms)
@@ -173,7 +239,7 @@ bool SpeakerDirector::update_roster(const std::vector<ParticipantInfo> &roster,
 
     const uint32_t candidate = choose_candidate_locked(raw_speaker_id);
     if (m_directed_speaker_id == 0)
-        return promote_locked(candidate, now_ms);
+        return fill_vacancy_locked(candidate, now_ms);
 
     if (candidate == 0 || candidate == m_directed_speaker_id) {
         m_candidate_speaker_id = 0;
@@ -195,8 +261,10 @@ bool SpeakerDirector::tick_locked(uint64_t now_ms)
     if (m_manual_speaker_id != 0)
         return promote_locked(m_manual_speaker_id, now_ms);
 
-    if (m_directed_speaker_id == 0)
-        return promote_locked(choose_candidate_locked(m_raw_speaker_id), now_ms);
+    if (m_directed_speaker_id == 0) {
+        return fill_vacancy_locked(choose_candidate_locked(m_raw_speaker_id),
+                                   now_ms);
+    }
 
     if (!participant_allowed_locked(m_candidate_speaker_id))
         return false;

--- a/src/speaker-director.h
+++ b/src/speaker-director.h
@@ -51,6 +51,9 @@ private:
     // must keep showing the last speaker until someone else takes over).
     void enforce_incumbent_eligibility_locked(uint64_t now_ms);
     uint32_t choose_candidate_locked(uint32_t raw_speaker_id) const;
+    // Fills an empty chair. Immediate on a cold start and on the first forced
+    // vacancy in a hold window; debounced by sensitivity on repeats.
+    bool fill_vacancy_locked(uint32_t candidate, uint64_t now_ms);
     bool tick_locked(uint64_t now_ms);
 
     mutable std::mutex m_mtx;
@@ -65,6 +68,12 @@ private:
     std::vector<uint32_t> m_excluded_participant_ids;
     uint64_t m_candidate_since_ms = 0;
     uint64_t m_last_switch_ms = 0;
+    // When the chair was emptied by enforce_incumbent_eligibility_locked
+    // rather than by a cold start, and when the last such emergency fill
+    // happened. Together these cap undebounced replacements at one per hold
+    // window — see fill_vacancy_locked() and the 2026-08-10 incident.
+    uint64_t m_last_forced_fill_ms = 0;
+    bool m_forced_vacancy = false;
     uint32_t m_sensitivity_ms = 500;
     uint32_t m_hold_ms = 2000;
     bool m_require_video = true;

--- a/tests/speaker-director-test.cpp
+++ b/tests/speaker-director-test.cpp
@@ -165,6 +165,105 @@ int main()
     director.update_roster(excluded_update_roster, 711, t + 10);
     if (!check_directed(712)) fail("dynamic exclusion did not move away from directed speaker");
 
+    // --- A forced vacancy hands out at most ONE undebounced cut per hold
+    //     window (the 2026-08-10 on-air defect). A settings-precedence bug
+    //     flapped the exclusion list, so the directed speaker was dethroned on
+    //     nearly every cycle; each dethrone took the "directed == 0" path and
+    //     promoted the instantaneous pick with neither hold nor sensitivity
+    //     applied, producing cuts 0.3 s apart on a 2 s hold. ---
+    director.reset();
+    director.configure(500, 2000, true, {});
+    t = 80000;
+    const auto flap_roster = roster({
+        p(1301, true, true),
+        p(1302, true, true),
+        p(1303, true, true)
+    });
+    director.update_roster(flap_roster, 1301, t);
+    if (!check_directed(1301)) fail("initial 1301 before exclusion flap");
+
+    // Excluding the on-air speaker still moves away at once: getting OFF an
+    // ineligible incumbent is never delayed.
+    t += 10;
+    director.configure(500, 2000, true, {1301});
+    director.update_roster(flap_roster, 1301, t);
+    if (!check_directed(1302)) fail("first exclusion should still cut away immediately");
+
+    // The flap: 0.3 s later the exclusion set swings onto the NEW on-air
+    // speaker. Leaving 1302 is still immediate, but the replacement has not
+    // earned the shot, so no cut is published. Reporting 0 does not black the
+    // program output — an ActiveSpeaker source keeps its current subscription
+    // while the director reports 0 (see zoom-source.cpp).
+    t += 300;
+    director.configure(500, 2000, true, {1302});
+    if (director.update_roster(flap_roster, 1301, t))
+        fail("second forced vacancy inside the hold window cut for free");
+    if (!check_directed(0)) fail("undebounced replacement promoted on a flap");
+
+    // The vacancy is not a dead end: once the replacement has been the
+    // candidate for a full sensitivity window it goes on air.
+    t += 500;
+    if (!director.tick(t)) fail("replacement should promote once sensitivity elapsed");
+    if (!check_directed(1301)) fail("did not promote the vetted replacement");
+
+    // --- The replacement chosen after a rate-limited forced vacancy has to be
+    //     STABLE: half a second of cross-talk or a cough must never reach the
+    //     program output just because the chair happened to be empty. ---
+    director.reset();
+    director.configure(500, 2000, true, {});
+    t = 90000;
+    director.update_roster(roster({
+        p(1401, true, true), p(1402, true, false), p(1403, true, false)
+    }), 1401, t);
+    if (!check_directed(1401)) fail("initial 1401 before cough test");
+
+    t += 10;
+    director.configure(500, 2000, true, {1401});   // operator excludes who is on air
+    director.update_roster(roster({
+        p(1401, true, true), p(1402, true, true), p(1403, true, false)
+    }), 1402, t);
+    if (!check_directed(1402)) fail("first exclusion should move to 1402");
+
+    // Flap 200 ms later: 1402 (now on air) is excluded while 1403 coughs.
+    t += 200;
+    director.configure(500, 2000, true, {1402});
+    director.update_roster(roster({
+        p(1401, true, false), p(1402, true, true), p(1403, true, true)
+    }), 1403, t);
+    if (!check_directed(0)) fail("a cough was promoted by a repeat forced vacancy");
+
+    // The cough stops after 200 ms and the real speaker resumes. The new
+    // candidate re-arms the sensitivity window rather than inheriting the
+    // cough's elapsed time.
+    t += 200;
+    director.update_roster(roster({
+        p(1401, true, true), p(1402, true, true), p(1403, true, false)
+    }), 1401, t);
+    if (!check_directed(0)) fail("candidate restart should re-arm the sensitivity window");
+    t += 500;
+    director.tick(t);
+    if (!check_directed(1401)) fail("stable speaker should take the vacancy after sensitivity");
+
+    // --- The immediate fill is a per-hold-window budget, not a one-shot: an
+    //     isolated exclusion later in the show still cuts at once. ---
+    director.reset();
+    director.configure(500, 2000, true, {});
+    t = 100000;
+    const auto late_roster = roster({p(1501, true, true), p(1502, true, true)});
+    director.update_roster(late_roster, 1501, t);
+    if (!check_directed(1501)) fail("initial 1501 before late exclusion");
+    t += 10;
+    director.configure(500, 2000, true, {1501});
+    director.update_roster(late_roster, 1501, t);
+    if (!check_directed(1502)) fail("first exclusion should cut immediately");
+
+    // A quiet minute passes, then the operator excludes the new speaker.
+    t += 60000;
+    director.configure(500, 2000, true, {1502});
+    director.update_roster(late_roster, 1501, t);
+    if (!check_directed(1501))
+        fail("an isolated forced vacancy must still be filled immediately");
+
     // --- Departed speaker: hold through the grace window, then clear ---
     director.reset();
     director.configure(100, 1000, true, {});


### PR DESCRIPTION
## The remaining risk

`src/speaker-director.cpp` had exactly one path that promoted a speaker with **neither hold nor sensitivity applied** — the vacancy branch, duplicated in `update_roster()` and `tick_locked()`:

```cpp
if (m_directed_speaker_id == 0)
    return promote_locked(candidate, now_ms);
```

On 2026-08-10 a settings-precedence bug flapped the exclusion list between "has participant X" and empty. `enforce_incumbent_eligibility_locked()` zeroes `m_directed_speaker_id` when the directed speaker becomes excluded, so every flap cycle went through that branch and handed out another free cut — active-speaker cuts **0.3 seconds apart** despite `hold_ms=2000`.

The trigger is fixed elsewhere. The mechanism was not. `m_directed_speaker_id` still reaches 0 via the 60 s absence grace window (`kAbsenceGraceMs`), `reset()`, and any future exclusion change, and each of those still promoted whatever `choose_candidate_locked()` returned at that instant — potentially a cough or half a second of cross-talk.

## The behaviour I chose, and why

**Getting off an ineligible incumbent stays immediate.** That is deliberate and correct: an operator who excludes whoever is on air expects them off air *now*. Only the *choice of replacement* is hardened, and only on repeats. `fill_vacancy_locked()` now applies:

| Case | Behaviour | Why |
|---|---|---|
| Cold start (`reset()`, first roster of a meeting) | Immediate | Nothing is on air, so there is no cut to debounce. Never leave the show with an empty slot at the top. |
| First forced vacancy in a hold window | Immediate (unchanged) | One operator action → one instant cut. This is what the existing "dynamic exclusion did not move away from directed speaker" test pins, and it stays green. |
| Second forced vacancy **inside the same hold window** | Replacement must hold the floor for `sensitivity_ms` first | This is the flap signature. The replacement here is entirely unvetted; making it earn the shot the normal way is the whole fix. |

### Should the replacement respect sensitivity?

Yes — but only in the repeat case, because **that is the only case where waiting is free**. Two things make it free: the fill returns `false`, so `ZoomDock` never calls `resubscribe_all()`; and even if it did, `zoom-source.cpp` returns early when the director reports 0 (`if (directed_id == 0 || ...) return;`, and `if (target != 0)` guards the subscribe). A momentary `directed == 0` therefore leaves the ActiveSpeaker source on its existing subscription — the last speaker stays on the program output. Nothing cuts to black. It is also not a new state: `promote_locked(0, …)` already returned false whenever no eligible talker existed.

Hold is deliberately **not** applied to the replacement. Hold exists to stop rapid cutting *between valid speakers*; the incumbent here is gone or ineligible, so the relevant protection is sensitivity ("has this candidate actually held the floor?"), not hold. Requiring hold would leave the slot unresolved for up to 2 s for no benefit.

### Is `m_last_speaker_id` a better fallback than an instantaneous raw pick?

**Considered and rejected**, and it is worth being explicit because it looks attractive. Under the exact failure mode being hardened — a *flapping* eligibility set — the last speaker is the participant most likely to have just flapped back into eligibility. Sequence: A is on air → A excluded → B promoted (`m_last_speaker_id = A`) → flap excludes B and releases A → a last-speaker preference promotes A immediately. That converts the free-cut bug into a free **A→B→A ping-pong** at exactly the reported cadence. Vetting has to be temporal (has this candidate held the floor for `sensitivity_ms`?), not historical.

### What happens when no candidate qualifies yet?

The director reports 0 and keeps tracking the candidate so the sensitivity clock runs; a candidate that changes mid-window re-arms it, so a cough that stops talking never accumulates enough time. `tick()` (100 ms in the dock) promotes as soon as someone is stable. Accepted trade, stated plainly: during chaotic cross-talk *following a repeat forced vacancy*, the previous (now ineligible) speaker can stay visible for up to `sensitivity_ms` past the second dethrone. Reaching that state needs two forced vacancies inside one hold window, which is already anomalous, and the existing code has the same property whenever no eligible talker exists.

## Tests — red first

Three tests added to `tests/speaker-director-test.cpp` in its existing style (plain `main()`, `check_directed()`, `fail()` counter).

**Before the fix**, the two incident tests failed for exactly the right reasons:

```
FAIL: second forced vacancy inside the hold window cut for free
Expected directed=0 got 1301
FAIL: undebounced replacement promoted on a flap
FAIL: replacement should promote once sensitivity elapsed
Expected directed=0 got 1403
FAIL: a cough was promoted by a repeat forced vacancy
Expected directed=0 got 1403
FAIL: candidate restart should re-arm the sensitivity window
Expected directed=1401 got 1403
FAIL: stable speaker should take the vacancy after sensitivity
6 test(s) failed.
```

The cough test is the sharpest evidence of on-air harm: participant 1403 talks for one cycle during a flap, takes the shot instantly with zero debounce, and is then **protected by the 2 s hold** against the participant who is actually speaking.

The third test (isolated exclusion a minute later still cuts at once) passed before and after by design — it is a regression guard on the responsiveness being preserved, and it would fail a naive "always debounce the replacement" implementation.

**After the fix:** `All SpeakerDirector tests passed.` and `100% tests passed, 0 tests failed out of 39`.

## Scope

- No public API change — one private helper (`fill_vacancy_locked`) and two private members (`m_last_forced_fill_ms`, `m_forced_vacancy`). `enforce_incumbent_eligibility_locked`'s internal lambda now reports whether it dethroned, which is what distinguishes a forced vacancy from a cold start.
- Comments explain the WHY against the on-air incident, matching the file's style.
- CHANGELOG entry under `[Unreleased]`.

CI note: the "Windows x64" check is red for the known unrelated reason (Zoom SDK archive on the private draft release is missing a header). Verified locally instead: full Release build + `ctest -C Release`, 39/39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
