### PR TITLE
OBS 32.2.2: header staging, deprecated config API, macOS shm fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       # needed at link time; OBS resolves all obs_* symbols at load time.
       - name: Get OBS headers
         run: |
-          OBS_VER=30.2.2
+          OBS_VER=32.2.2
           curl -fL \
               "https://github.com/obsproject/obs-studio/archive/refs/tags/${OBS_VER}.tar.gz" \
               -o obs-source.tar.gz
@@ -60,20 +60,45 @@ jobs:
           tar -xzf obs-source.tar.gz --strip-components=1 \
               -C /tmp/obs-source \
               "obs-studio-${OBS_VER}/libobs" \
-              "obs-studio-${OBS_VER}/UI/obs-frontend-api"
+              "obs-studio-${OBS_VER}/frontend/api"
 
           mkdir -p /tmp/obs-sdk/include/obs \
                    /tmp/obs-sdk/cmake/LibObs \
                    /tmp/obs-sdk/cmake/obs-frontend-api
 
           cp -R /tmp/obs-source/libobs/*                            /tmp/obs-sdk/include/obs/
-          cp /tmp/obs-source/UI/obs-frontend-api/obs-frontend-api.h /tmp/obs-sdk/include/obs/
+          cp /tmp/obs-source/frontend/api/obs-frontend-api.h /tmp/obs-sdk/include/obs/
+
+          # OBS 31+ removed the vendored simde tree (util/sse-intrin.h needs
+          # it on ARM; it now ships via obs-deps prebuilts) and obs-config.h
+          # includes the build-generated obsconfig.h unconditionally. Stage
+          # header-only simde and synthesize a minimal obsconfig.h -- the
+          # values are irrelevant to a plugin, they only have to resolve.
+          SIMDE_VER=0.8.2
+          curl -fL \
+              "https://github.com/simd-everywhere/simde/archive/refs/tags/v${SIMDE_VER}.tar.gz" \
+              -o simde.tar.gz
+          mkdir -p /tmp/simde-src
+          tar -xzf simde.tar.gz --strip-components=1 -C /tmp/simde-src
+          cp -R /tmp/simde-src/simde /tmp/obs-sdk/include/
+
+          printf '%s\n' \
+              '#pragma once' \
+              '#define OBS_VERSION "32.2.2"' \
+              '#define OBS_VERSION_CANONICAL "32.2.2"' \
+              '#define OBS_DATA_PATH "data"' \
+              '#define OBS_INSTALL_PREFIX "/usr/local"' \
+              '#define OBS_PLUGIN_DESTINATION "obs-plugins"' \
+              '#define OBS_QT_VERSION 6' \
+              '#define OBS_RELEASE_CANDIDATE 0' \
+              '#define OBS_BETA 0' \
+              > /tmp/obs-sdk/include/obs/obsconfig.h
 
           # Write cmake config files using printf (avoids heredoc quoting issues).
           printf '%s\n' \
               'add_library(OBS::libobs INTERFACE IMPORTED GLOBAL)' \
               'set_target_properties(OBS::libobs PROPERTIES' \
-              '    INTERFACE_INCLUDE_DIRECTORIES "/tmp/obs-sdk/include/obs")' \
+              '    INTERFACE_INCLUDE_DIRECTORIES "/tmp/obs-sdk/include/obs;/tmp/obs-sdk/include")' \
               'set(LibObs_FOUND TRUE)' \
               > /tmp/obs-sdk/cmake/LibObs/LibObsConfig.cmake
 

--- a/src/engine-ipc.h
+++ b/src/engine-ipc.h
@@ -420,6 +420,7 @@ inline std::string shm_region_name(const std::string &base, uint32_t gen)
    }
 #else
 #  include <sys/mman.h>
+#  include <sys/stat.h>
 #  include <fcntl.h>
 #  include <cerrno>
    struct ShmRegion {
@@ -460,13 +461,48 @@ inline std::string shm_region_name(const std::string &base, uint32_t gen)
        r.fd = shm_open(r.name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
        if (r.fd < 0 && errno == EEXIST) {
            r.already_existed = true;
-           r.fd = shm_open(r.name.c_str(), O_CREAT | O_RDWR, 0600);
-       }
-       if (r.fd < 0) { r.last_error = static_cast<uint32_t>(errno); return false; }
-       if (ftruncate(r.fd, static_cast<off_t>(size)) < 0) {
-           r.last_error = static_cast<uint32_t>(errno);
-           shm_region_destroy(r);
-           return false;
+           r.fd = shm_open(r.name.c_str(), O_RDWR, 0600);
+           if (r.fd >= 0) {
+               // An existing object must be size-checked with fstat, not
+               // blindly ftruncated: on macOS a POSIX shm object is sized
+               // exactly once and ftruncate on an existing one fails EINVAL,
+               // which made every create-over-a-held-name fail outright
+               // there. Big enough -> map as-is (open-and-flag). Undersized
+               // -> grow it where the OS allows, recreate where it does not;
+               // already_existed stays true either way so callers still
+               // learn about the ghost holder.
+               struct stat st {};
+               const bool fits = fstat(r.fd, &st) == 0 &&
+                                 static_cast<size_t>(st.st_size) >= size;
+               if (!fits) {
+#if defined(__APPLE__)
+                   close(r.fd);
+                   shm_unlink(r.name.c_str());
+                   r.fd = shm_open(r.name.c_str(),
+                                   O_CREAT | O_EXCL | O_RDWR, 0600);
+                   if (r.fd >= 0 &&
+                       ftruncate(r.fd, static_cast<off_t>(size)) < 0) {
+                       r.last_error = static_cast<uint32_t>(errno);
+                       shm_region_destroy(r);
+                       return false;
+                   }
+#else
+                   if (ftruncate(r.fd, static_cast<off_t>(size)) < 0) {
+                       r.last_error = static_cast<uint32_t>(errno);
+                       shm_region_destroy(r);
+                       return false;
+                   }
+#endif
+               }
+           }
+           if (r.fd < 0) { r.last_error = static_cast<uint32_t>(errno); return false; }
+       } else {
+           if (r.fd < 0) { r.last_error = static_cast<uint32_t>(errno); return false; }
+           if (ftruncate(r.fd, static_cast<off_t>(size)) < 0) {
+               r.last_error = static_cast<uint32_t>(errno);
+               shm_region_destroy(r);
+               return false;
+           }
        }
        r.ptr  = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, r.fd, 0);
        r.size = (r.ptr != MAP_FAILED) ? size : 0;

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -8,6 +8,11 @@
 #include <QMessageAuthenticationCode>
 #include <obs-frontend-api.h>
 #include <util/base.h>
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 #include <util/config-file.h>
 #if defined(_WIN32)
 #include <windows.h>
@@ -229,9 +234,38 @@ static std::string unprotect_secret(const char *stored, const char *account)
 #endif
 }
 
+// OBS 31 split the frontend "global" config into app and user scopes and
+// deprecated obs_frontend_get_global_config — which also logs a DEPRECATION
+// warning on EVERY call, flooding logs on OBS 31+. The deprecated accessor
+// maps to the app config (the same global.ini this plugin has always written),
+// so obs_frontend_get_app_config is the drop-in successor with zero settings
+// migration. It does not exist on OBS 30, and referencing it statically would
+// stop the plugin from loading there, so resolve it at runtime and keep the
+// old accessor as the OBS 30 fallback.
+static config_t *frontend_settings_config()
+{
+    using config_fn = config_t *(*)(void);
+    static const config_fn app_config_fn = []() -> config_fn {
+#if defined(_WIN32)
+        HMODULE mod = GetModuleHandleA("obs-frontend-api.dll");
+        return mod ? reinterpret_cast<config_fn>(reinterpret_cast<void *>(
+                         GetProcAddress(mod, "obs_frontend_get_app_config")))
+                   : nullptr;
+#else
+        return reinterpret_cast<config_fn>(
+            dlsym(RTLD_DEFAULT, "obs_frontend_get_app_config"));
+#endif
+    }();
+    if (app_config_fn) return app_config_fn();
+    QT_WARNING_PUSH
+    QT_WARNING_DISABLE_DEPRECATED
+    return obs_frontend_get_global_config();
+    QT_WARNING_POP
+}
+
 ZoomPluginSettings ZoomPluginSettings::load()
 {
-    config_t *cfg = obs_frontend_get_global_config();
+    config_t *cfg = frontend_settings_config();
     ZoomPluginSettings s;
 
     const bool embedded_public_app_key =
@@ -446,7 +480,7 @@ bool ZoomPluginSettings::use_broker_sdk_jwt() const
 
 void ZoomPluginSettings::save() const
 {
-    config_t *cfg = obs_frontend_get_global_config();
+    config_t *cfg = frontend_settings_config();
     const bool embedded_public_app_key =
         has_embedded_value(kEmbeddedMeetingSdkPublicAppKey);
     const bool embedded_oauth_client_id =


### PR DESCRIPTION
Updates the OBS-version story in one pass:

1. **CI builds against OBS 32.2.2** (was 30.2.2): frontend API moved to `frontend/api`, `simde` staged from its own release (no longer vendored by OBS; required by `util/sse-intrin.h` on ARM), minimal `obsconfig.h` synthesized (32.x includes it unconditionally).
2. **Deprecation-warning flood fixed**: `obs_frontend_get_global_config` → `obs_frontend_get_app_config` (same `global.ini`, zero settings migration — the deprecated accessor maps to app config), resolved at runtime with fallback so OBS 30 still loads the plugin.
3. **Fixes the red macOS CI** (`CoreVideoAudioRing`): create-over-a-held-name now fstats and maps the existing object instead of ftruncating it (sized-exactly-once on macOS → EINVAL); ghost-writer `already_existed` detection preserved on all paths.

49/49 tests pass locally on macOS (arm64) against the staged 32.2.2 headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)