### PR TITLE
Talkback dock: source, nomination, and keying UI (M7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,6 +555,26 @@ Every one of these is documented at length where it lives; the list is the map.
   HONEST ("0 of 1", since they were pruned out of `present`) and is
   recoverable by re-nominating; and `"attempt"` is emitted BEFORE `"nominees"`
   because `json_uint()` is a first-match scan, not a parser.
+- **The dock keys, by owner decision (Milestone 7)**: the spec
+  (`docs/superpowers/specs/2026-08-24-zoom-talkback-design.md`) locks keying to
+  Companion/control API/hotkey and says "**Not** the dock"; the owner has since
+  asked for a drivable dock, so `src/zoom-dock.cpp`'s Talkback group nominates
+  and keys — a deliberate, approved spec deviation, with everything else
+  unchanged (identity by display name, keying SELECTS a provisioned channel,
+  every refusal fails closed). Its decisions live in the Qt/OBS-free
+  `src/talkback-dock-state.h` (pinned by `CoreVideoTalkbackDockState`) because
+  the two Majors this feature shipped both lived in wiring no test could reach.
+  Dock keys pass **`needs_renewal = false`** — `src/talkback-key.h`'s rule for
+  a surface whose release is in-process and reliable: press/release are Qt
+  signals on the same main thread the controller's `QTimer` runs `evaluate()`/
+  `key_off()` on, with no transport to drop them, and demanding a heartbeat
+  from a UI-thread timer instead would close a genuinely held key on any ~1s
+  OBS UI stall. The one in-process way a release still vanishes — a held
+  `QPushButton` being disabled, which clears `down` without emitting
+  `released()` — is closed twice: the dock never disables a held button, and
+  `talkback_dock_release_lost()` closes any dock-owned PTT key whose button is
+  no longer down, read from the widget on the existing 100 ms tick (no second
+  timer) so a stalled UI cannot false-close.
 
 ## Live testing against a real meeting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,12 +569,26 @@ Every one of these is documented at length where it lives; the list is the map.
   signals on the same main thread the controller's `QTimer` runs `evaluate()`/
   `key_off()` on, with no transport to drop them, and demanding a heartbeat
   from a UI-thread timer instead would close a genuinely held key on any ~1s
-  OBS UI stall. The one in-process way a release still vanishes — a held
-  `QPushButton` being disabled, which clears `down` without emitting
-  `released()` — is closed twice: the dock never disables a held button, and
-  `talkback_dock_release_lost()` closes any dock-owned PTT key whose button is
-  no longer down, read from the widget on the existing 100 ms tick (no second
-  timer) so a stalled UI cannot false-close.
+  OBS UI stall. A release can still vanish in-process in SEVERAL ways —
+  `QAbstractButton` drops `down` without emitting `released()` on an
+  `EnabledChange`, on any non-popup focus loss, and anywhere `setDown(false)`
+  is reached — so `talkback_dock_release_lost()` is cause-agnostic by design:
+  it asks the widget whether it is still down, never why, and closes any
+  dock-owned PTT key that is not. It runs on the existing 100 ms tick (no
+  second timer), and reading the widget rather than a deadline is what makes it
+  unable to false-close during a stall. It is load-bearing, not a second
+  opinion — "the dock never disables a held button" closes one cause, not the
+  class. **Fix round 1 (M1, Major)**: the latch toggle-off used to read the
+  Latch CHECKBOX while the release path read the mode captured at the press, so
+  unchecking Latch while a latched key was live left it un-closeable from the
+  dock — `key_on()` answered "already open" and `released()` bailed out, with
+  the director still live to talent. One record now answers all three
+  questions (press / release / backstop): `TalkbackDockOpenKey`, carrying the
+  mode the open key was OPENED with. Buttons also refuse while another surface
+  holds the key (m3) and while no talk source is chosen (m4), instead of
+  offering a press that can only refuse; the source scan is gated to 1 Hz and
+  to the dock being visible (m2), since `obs_enum_sources()` holds libobs's
+  source mutex.
 
 ## Live testing against a real meeting
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1126,6 +1126,22 @@ if(BUILD_TESTING)
     add_test(NAME CoreVideoTalkbackNomination
              COMMAND CoreVideoTalkbackNominationTest)
 
+    # Milestone 7: what the dock's Talkback group shows and which of its key
+    # buttons are live. Extracted from the QWidget for the same reason every
+    # other decision in this feature was extracted from the engine: these are
+    # claims an operator acts on mid-show ("this button is safe to press",
+    # "this person hears nothing", "this source is on air"), and none of them
+    # could be exercised while they lived in code needing libobs, a Qt event
+    # loop and a running engine to construct. See src/talkback-dock-state.h.
+    add_executable(CoreVideoTalkbackDockStateTest
+        tests/talkback-dock-state-test.cpp
+    )
+    target_include_directories(CoreVideoTalkbackDockStateTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoTalkbackDockState
+             COMMAND CoreVideoTalkbackDockStateTest)
+
     # THE FIRST TEST TARGET THAT COMPILES AN ENGINE TRANSLATION UNIT.
     #
     # Every other talkback test above compiles a pure header with src/ on the

--- a/src/cv-style.h
+++ b/src/cv-style.h
@@ -151,6 +151,19 @@ QLabel#speakerValue { color: #999999; font-style: italic; }
 QLabel#errorLabel   { color: #ee5555; font-size: 11px; }
 QLabel[role="muted"] { color: #8a8a8a; font-size: 11px; }
 
+/* Talkback (Milestone 7). Each pair is a calm default plus one flagged state,
+   switched by a dynamic property from zoom-dock.cpp's set_style_flag(). Amber
+   is "you should look at this" (the same #f0b429 the output table uses for a
+   below-requested signal); red is reserved for a key that is actually live to
+   talent, because that is the one state where the director is audible. */
+QLabel#talkbackTrackWarning              { color: #8a8a8a; font-size: 11px; }
+QLabel#talkbackTrackWarning[risk="true"] { color: #f0b429; }
+QLabel#talkbackPlan                      { color: #b0b0b0; font-size: 11px; }
+QLabel#talkbackPlan[warn="true"]         { color: #f0b429; }
+QLabel#talkbackTally                     { color: #a0a0a0; font-weight: 600; }
+QLabel#talkbackTally[alert="true"]       { color: #f0b429; }
+QLabel#talkbackTally[live="true"]        { color: #ff5555; }
+
 QFrame#recoveryPanel {
     background-color: rgba(240,160,0,0.10);
     border: 1px solid rgba(240,160,0,0.40);

--- a/src/talkback-dock-state.h
+++ b/src/talkback-dock-state.h
@@ -50,18 +50,39 @@ struct TalkbackDockKeyButton {
     bool        all_talent = false;
 };
 
+// THE ONE RECORD OF THE KEY THAT IS CURRENTLY OPEN. Fix round 1 (M1, Major):
+// the dock used to decide "does this press close the held key?" from the Latch
+// CHECKBOX at press time while deciding "does this release close it?" from the
+// mode captured when the key opened. Unchecking Latch while a latched key was
+// live therefore made it un-closeable from the dock: the toggle-off branch was
+// skipped, key_on() refused ("A talkback key is already open"), and the
+// following released() bailed out because the captured mode still said latch --
+// leaving the director live to talent with the surface they are looking at
+// answering with an error. Every decision below now reads `latched` from HERE,
+// so there is one mode per key and it is the one that key was opened with.
+struct TalkbackDockOpenKey {
+    // A key is open somewhere -- TalkbackController's own view (its
+    // status_json()'s "open"), not the dock's intent.
+    bool open = false;
+    // ...and this dock is the surface that opened it. A key opened over the
+    // control API or Companion is NOT the dock's to close or to hold: key_on()
+    // refuses a second key outright, so every dock button must refuse while one
+    // is live (fix round 1, m3).
+    bool dock_owned = false;
+    std::string target;
+    // The mode CAPTURED AT THE OPENING PRESS, never re-read from the checkbox.
+    bool latched = false;
+};
+
 // The state the dock has about keying at the moment it rebuilds its buttons.
 struct TalkbackDockKeyContext {
     bool engine_running = false;
     bool in_meeting     = false;
-    // TalkbackController's own view (its status_json()'s "open"), not the
-    // dock's: a key opened over the control API disables the dock's other
-    // buttons too, because key_on() refuses a second key outright.
-    bool key_open = false;
-    // Which target that open key is on. The button for THIS target stays
-    // enabled -- it is the one being held, and disabling a pressed
-    // QPushButton is how its released() signal gets lost (see zoom-dock.cpp).
-    std::string open_target;
+    // An OBS audio source is selected. Without one key_on() cannot open a tap
+    // at all, so a button offered here could only ever refuse (fix round 1,
+    // m4).
+    bool source_chosen  = false;
+    TalkbackDockOpenKey open;
 };
 
 // One button per keyable target: "all" first, then every nominee in the order
@@ -85,12 +106,28 @@ inline std::vector<TalkbackDockKeyButton> talkback_dock_key_buttons(
         b.label      = label;
         b.all_talent = all_talent;
 
-        if (ctx.key_open && target != ctx.open_target) {
+        // The button for a key THIS DOCK is holding stays enabled, and is
+        // checked before everything else: it is the operator's only way to let
+        // go of a latch, and disabling a pressed QPushButton is itself how a
+        // release gets lost (see talkback_dock_release_lost()).
+        const bool held_here = ctx.open.open && ctx.open.dock_owned &&
+                               ctx.open.target == target;
+        if (held_here) {
+            b.enabled = true;
+        } else if (ctx.open.open && !ctx.open.dock_owned) {
+            // m3: not "another talkback key is open" -- naming the surface is
+            // what tells the operator that pressing here cannot help and that
+            // the thing holding the channel is somewhere else.
+            b.reason = "another surface (Companion or the control API) holds "
+                       "the talkback key";
+        } else if (ctx.open.open) {
             b.reason = "another talkback key is open";
         } else if (!ctx.engine_running) {
             b.reason = "the Zoom engine is not running";
         } else if (!ctx.in_meeting) {
             b.reason = "not in a meeting";
+        } else if (!ctx.source_chosen) {
+            b.reason = "choose the OBS audio source you talk through first";
         } else if (talkback_target_known_unprovisioned(
                        target, confirmed.requested, confirmed.uncovered_private)) {
             if (confirmed.requested.empty()) {
@@ -343,6 +380,44 @@ inline TalkbackDockTally talkback_dock_tally(const TalkbackDockSessionView &s)
     return t;
 }
 
+// ── What a press and a release mean ─────────────────────────────────────────
+
+enum class TalkbackDockPressAction {
+    OpenPushToTalk,
+    OpenLatch,
+    // Close the latched key this dock is already holding on this target.
+    CloseHeldKey,
+};
+
+// `latch_selected` is the Latch checkbox as it stands RIGHT NOW, and it decides
+// only what a NEW key would be opened as. Whether this press CLOSES one is
+// decided by `open.latched` -- the mode that key was opened with (M1). The two
+// disagree exactly when the operator toggles the checkbox while a key is live,
+// which is the interleaving that used to leave a latched key un-closeable.
+inline TalkbackDockPressAction talkback_dock_press_action(
+    const TalkbackDockOpenKey &open, const std::string &pressed_target,
+    bool latch_selected)
+{
+    if (open.open && open.dock_owned && open.latched &&
+        open.target == pressed_target)
+        return TalkbackDockPressAction::CloseHeldKey;
+    return latch_selected ? TalkbackDockPressAction::OpenLatch
+                          : TalkbackDockPressAction::OpenPushToTalk;
+}
+
+// Does this button release close the open key? Only a push-to-talk key this
+// dock owns, on the target being released. A latch is closed by the next PRESS
+// (above), never by a release -- and a key belonging to another surface, or to
+// another target, is not this release's to close: a stray release arriving
+// after the dead-man switch already closed something must not close whatever
+// was opened next.
+inline bool talkback_dock_release_closes(const TalkbackDockOpenKey &open,
+                                         const std::string &released_target)
+{
+    return open.open && open.dock_owned && !open.latched &&
+           open.target == released_target;
+}
+
 // ── The dock's own lost-release backstop ────────────────────────────────────
 //
 // The dock passes needs_renewal = false to key_on(): its press and release are
@@ -352,17 +427,21 @@ inline TalkbackDockTally talkback_dock_tally(const TalkbackDockSessionView &s)
 // renewal discussion at the top of src/talkback-key.h, which names exactly
 // this class of surface).
 //
-// One in-process way a release CAN still go missing: QAbstractButton clears
-// its pressed state on an EnabledChange without emitting released(), so
-// disabling a held button would strand the key open. The dock does not disable
-// a held button -- and this is the backstop for it either way. It compares the
-// controller's open key against the widget's own current state, so a stalled
-// UI thread cannot false-close a genuinely held key: while the thread is
+// A release can still go missing in-process, and NOT only in one way:
+// QAbstractButton clears its pressed state without emitting released() on an
+// EnabledChange, on any non-popup focus loss (focusOutEvent), and anywhere a
+// style or a caller reaches setDown(false). This backstop is deliberately
+// CAUSE-AGNOSTIC -- it asks the widget whether it is still down, not why it
+// stopped being down -- so it covers all of those and whatever Qt adds next.
+// It is load-bearing, not a redundant second opinion: "the dock never disables
+// a held button" closes exactly one of those causes and is not coverage.
+//
+// Reading the widget's state (rather than a renewal deadline) is also what
+// makes it unable to false-close a genuinely held key: while the UI thread is
 // stalled this does not run at all, and once it resumes isDown() is accurate
 // again. A latch is exempt by definition -- nothing is being held.
-inline bool talkback_dock_release_lost(bool dock_owns_open_key,
-                                       bool push_to_talk,
+inline bool talkback_dock_release_lost(const TalkbackDockOpenKey &open,
                                        bool button_down)
 {
-    return dock_owns_open_key && push_to_talk && !button_down;
+    return open.open && open.dock_owned && !open.latched && !button_down;
 }

--- a/src/talkback-dock-state.h
+++ b/src/talkback-dock-state.h
@@ -1,0 +1,368 @@
+#pragma once
+//
+// talkback-dock-state.h — what the dock's Talkback group shows, and which of
+// its key buttons are live.
+//
+// Milestone 7, and a DELIBERATE, OWNER-APPROVED DEVIATION from the spec:
+// docs/superpowers/specs/2026-08-24-zoom-talkback-design.md locks the keying
+// surfaces to "Companion/Stream Deck, TCP/OSC control API, OBS hotkey. **Not**
+// the dock", and its Dock section says "Configuration and tally only, by
+// operator preference -- no talk button". The owner has since asked for a
+// drivable dock, so the dock keys. Nothing else in that decision changed:
+// identity is still by display name, keying still SELECTS a pre-provisioned
+// channel, and every refusal still fails closed.
+//
+// Why a header with no Qt and no OBS in it, for UI code: every decision in
+// here is a claim the operator acts on mid-show -- "this button is safe to
+// press", "this person hears nothing", "this source is on air" -- and none of
+// them could be exercised at all while they lived inside a QWidget that needs
+// libobs, a Qt event loop and a running engine to construct. This is the same
+// treatment (and the same reason) src/talkback-plan.h and
+// src/talkback-nomination-dispatch.h already get; tests/talkback-dock-state-
+// test.cpp drives it.
+//
+// WHAT THIS FILE DOES NOT KNOW. It decides from the CONFIRMED nomination plan
+// (src/talkback-nomination.h) plus engine/meeting/key state. It cannot see the
+// nomination ladder's in-flight progress -- the plugin is only ever told the
+// finished plan -- so a button it reports enabled can still be refused by
+// TalkbackController::key_on() (a source that is not active, an OBS audio
+// setup talkback cannot use) or by the engine (`provisioning_incomplete`).
+// That is why the dock renders the refusal reason as well as the buttons.
+#include "talkback-nomination.h"
+#include "talkback-plan.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// ── Key buttons ─────────────────────────────────────────────────────────────
+
+struct TalkbackDockKeyButton {
+    // Passed verbatim to TalkbackController::key_on(). "all"
+    // (kTalkbackAllTalentTarget) or one nominee's display name -- never a Zoom
+    // user id, which is meeting-scoped and points at nobody after a rejoin.
+    std::string target;
+    std::string label;
+    bool        enabled = false;
+    // Empty when enabled. Operator-facing: it goes in the button's tooltip, so
+    // it must say which thing is wrong, not that talkback is unavailable.
+    std::string reason;
+    bool        all_talent = false;
+};
+
+// The state the dock has about keying at the moment it rebuilds its buttons.
+struct TalkbackDockKeyContext {
+    bool engine_running = false;
+    bool in_meeting     = false;
+    // TalkbackController's own view (its status_json()'s "open"), not the
+    // dock's: a key opened over the control API disables the dock's other
+    // buttons too, because key_on() refuses a second key outright.
+    bool key_open = false;
+    // Which target that open key is on. The button for THIS target stays
+    // enabled -- it is the one being held, and disabling a pressed
+    // QPushButton is how its released() signal gets lost (see zoom-dock.cpp).
+    std::string open_target;
+};
+
+// One button per keyable target: "all" first, then every nominee in the order
+// they were nominated.
+//
+// ENABLEMENT IS DELEGATED, NOT RE-DERIVED. The nomination half of the decision
+// is talkback_target_known_unprovisioned() (src/talkback-plan.h) -- the exact
+// predicate TalkbackController::key_on() refuses on -- so a button this
+// function reports enabled can never be one key_on() would reject for that
+// reason. Re-implementing the rule here is how the two would drift.
+inline std::vector<TalkbackDockKeyButton> talkback_dock_key_buttons(
+    const TalkbackNominationPlan &confirmed,
+    const TalkbackDockKeyContext &ctx)
+{
+    std::vector<TalkbackDockKeyButton> buttons;
+
+    const auto add = [&](const std::string &target, const std::string &label,
+                         bool all_talent) {
+        TalkbackDockKeyButton b;
+        b.target     = target;
+        b.label      = label;
+        b.all_talent = all_talent;
+
+        if (ctx.key_open && target != ctx.open_target) {
+            b.reason = "another talkback key is open";
+        } else if (!ctx.engine_running) {
+            b.reason = "the Zoom engine is not running";
+        } else if (!ctx.in_meeting) {
+            b.reason = "not in a meeting";
+        } else if (talkback_target_known_unprovisioned(
+                       target, confirmed.requested, confirmed.uncovered_private)) {
+            if (confirmed.requested.empty()) {
+                b.reason = "no one has been nominated yet";
+            } else {
+                bool unreachable = false;
+                for (const auto &u : confirmed.unreachable)
+                    if (u == target) { unreachable = true; break; }
+                b.reason = unreachable
+                    ? "on no channel at all -- re-nominate a shorter list"
+                    : "no private channel -- key All instead, or re-nominate";
+            }
+        } else {
+            b.enabled = true;
+        }
+        buttons.push_back(std::move(b));
+    };
+
+    add(kTalkbackAllTalentTarget, "All talent", true);
+    for (const auto &name : confirmed.requested)
+        add(name, name, false);
+    return buttons;
+}
+
+// ── The nomination outcome ──────────────────────────────────────────────────
+//
+// The budget outcome being visible AT NOMINATION TIME is the point of the
+// whole reporting chain (src/talkback-plan.h's header comment: a shortfall is
+// named, never swallowed, because it is invisible from the control room). So
+// this renders every shortfall by name rather than a count.
+
+struct TalkbackDockNominationReport {
+    std::string headline;
+    // Detail lines, each already operator-facing and safe to show verbatim.
+    std::vector<std::string> lines;
+    // True when something the operator asked for did not happen: a shortfall,
+    // or a failed attempt. The dock colours the block on this.
+    bool warn = false;
+};
+
+namespace talkback_dock_detail {
+
+inline std::string join_names(const std::vector<std::string> &names)
+{
+    std::string out;
+    for (std::size_t i = 0; i < names.size(); ++i) {
+        if (i != 0) out += ", ";
+        out += names[i];
+    }
+    return out;
+}
+
+inline std::string plural(std::size_t n, const char *one, const char *many)
+{
+    return std::to_string(n) + " " + (n == 1 ? one : many);
+}
+
+} // namespace talkback_dock_detail
+
+inline TalkbackDockNominationReport talkback_dock_nomination_report(
+    const TalkbackNominationPlan &confirmed)
+{
+    using namespace talkback_dock_detail;
+    TalkbackDockNominationReport report;
+
+    if (!confirmed.done) {
+        // Not "nothing happened": a failed-after-destroy or superseded
+        // outcome also lands here, with done reset to false and the reason
+        // kept (src/talkback-nomination.h). Saying "no channels" alone would
+        // hide the WHY on exactly the paths that need it most.
+        report.headline = "No talkback channels. Pick talent below and press "
+                          "Nominate.";
+    } else {
+        const std::vector<std::string> covered =
+            talkback_private_channel_names(confirmed.requested,
+                                           confirmed.uncovered_private);
+        report.headline =
+            plural(confirmed.channels, "channel", "channels") + " in use of " +
+            std::to_string(kTalkbackMaxChannels) + " for " +
+            plural(confirmed.requested.size(), "nominee", "nominees") + ".";
+        report.lines.push_back(
+            covered.empty()
+                ? std::string("Private channel: nobody.")
+                : "Private channel: " + join_names(covered) + ".");
+    }
+
+    if (!confirmed.uncovered_private.empty()) {
+        report.warn = true;
+        report.lines.push_back(
+            "No private channel (reach them by keying All): " +
+            join_names(confirmed.uncovered_private) + ".");
+    }
+    if (!confirmed.unreachable.empty()) {
+        report.warn = true;
+        // Strictly worse than losing the private aside, and always a subset of
+        // uncovered_private -- so it gets its own line rather than being
+        // buried in the one above. See TalkbackPlan::unreachable.
+        report.lines.push_back(
+            "On no channel at all -- they hear nothing: " +
+            join_names(confirmed.unreachable) + ".");
+    }
+    if (confirmed.done && !confirmed.all_talent_complete) {
+        report.warn = true;
+        report.lines.push_back(
+            "All talent does not reach everyone: this list is larger than "
+            "16 channels can fan out to.");
+    }
+    if (!confirmed.last_attempt_ok) {
+        report.warn = true;
+        // The last ATTEMPT, which can disagree with the confirmed plan above
+        // without contradicting it (a refused re-nomination leaves the
+        // standing channels exactly as they were). Said as a separate line
+        // for that reason.
+        report.lines.push_back(
+            "Last Nominate was refused: " +
+            (confirmed.last_attempt_reason.empty()
+                 ? std::string("no reason reported")
+                 : confirmed.last_attempt_reason) + ".");
+    }
+    return report;
+}
+
+// ── The program-track warning ───────────────────────────────────────────────
+//
+// The deferred half of the leak guarantee. The structural half holds
+// unconditionally (a capture callback observes a source and cannot add it to
+// any mix -- tests/talkback-isolation-test.cpp), but OBS enables all six mixer
+// tracks on every new audio source by default, so a director who points
+// talkback at the mic that is already on program puts the aside on air at full
+// level through OBS's own routing, entirely outside CoreVideo's path. The tap
+// already logs this at open() time (src/talkback-tap.cpp); this is the same
+// advisory where the operator is actually looking, and BEFORE the key, not on
+// it.
+
+struct TalkbackDockTrackWarning {
+    // True when the source has at least one mixer track enabled. "Enabled" is
+    // not the same as "on air" -- obs_source_get_audio_mixers() reports which
+    // tracks the source feeds, not which tracks are being recorded or
+    // streamed right now, and this file has no way to know that. The wording
+    // below is conditional for that reason.
+    bool on_air_risk = false;
+    // 1-based track numbers as OBS's Advanced Audio Properties shows them,
+    // e.g. "1, 3".
+    std::string tracks;
+    std::string text;
+};
+
+// `mixers` is obs_source_get_audio_mixers()'s bitmask. Six tracks, matching
+// both OBS's Advanced Audio Properties dialog and the identical loop in
+// TalkbackTap::open().
+inline TalkbackDockTrackWarning talkback_dock_track_warning(
+    const std::string &source_name, uint32_t mixers)
+{
+    TalkbackDockTrackWarning w;
+    if (source_name.empty()) {
+        w.text = "No talkback source chosen. The safe pattern is a dedicated "
+                 "audio source on an unused track.";
+        return w;
+    }
+    for (int i = 0; i < 6; ++i) {
+        if (!(mixers & (1u << i))) continue;
+        if (!w.tracks.empty()) w.tracks += ", ";
+        w.tracks += std::to_string(i + 1);
+    }
+    if (w.tracks.empty()) {
+        w.text = "\"" + source_name + "\" is on no OBS track -- talkback only. "
+                 "That is the safe pattern: a dedicated source on an unused "
+                 "track.";
+        return w;
+    }
+    w.on_air_risk = true;
+    w.text = "\"" + source_name + "\" is on OBS track(s) " + w.tracks +
+             ". If any of those are on air, the audience hears this talkback "
+             "aside at full level. Uncheck them in Advanced Audio Properties, "
+             "or use a dedicated source on an unused track.";
+    return w;
+}
+
+// ── Live tally ──────────────────────────────────────────────────────────────
+
+struct TalkbackDockTally {
+    std::string text;
+    // The key is open AND the engine has confirmed the channel. Anything less
+    // is not "on air" and must not be shown as such -- the spec's own
+    // requirement is that the tally reflects the engine's confirmed state,
+    // never the plugin's intent.
+    bool live = false;
+    // Something failed and the operator has to act. Distinct from `live`.
+    bool alert = false;
+};
+
+struct TalkbackDockSessionView {
+    bool        key_open = false;
+    std::string target;
+    bool        engine_live = false;
+    // The engine's own reason. Empty means "nothing reported yet", which is
+    // NOT the same as success -- see ZoomEngineClient::TalkbackSessionStatus.
+    std::string engine_reason;
+    // The engine's own recovery hint for that reason, echoed rather than
+    // inferred (`"recover":"re-nominate"` on a provisioning_incomplete
+    // refusal). Empty when the engine offered none.
+    std::string engine_recover;
+    // From the engine's session_live line, as of the moment the key opened.
+    // NOT refreshed while the key is held: the engine reports these once per
+    // key press, so a talent who rejoins mid-press is not counted until the
+    // next press. members_known is false when no session_live has arrived.
+    bool     members_known = false;
+    uint32_t members_present = 0;
+    uint32_t members_total = 0;
+};
+
+inline TalkbackDockTally talkback_dock_tally(const TalkbackDockSessionView &s)
+{
+    TalkbackDockTally t;
+    if (!s.key_open) {
+        t.text = "Not keyed.";
+        if (!s.engine_reason.empty() && !s.engine_live) {
+            // The reason outlives the key that earned it (talkback_start()
+            // clears it at the next press), so this is the last key's verdict
+            // -- said as such, not as a current state.
+            t.alert = true;
+            t.text += " Last key: " + s.engine_reason + ".";
+            if (!s.engine_recover.empty())
+                t.text += " Recovery: " + s.engine_recover + ".";
+        }
+        return t;
+    }
+
+    const std::string target = s.target.empty() ? std::string("(no target)")
+                                                : s.target;
+    if (s.engine_live) {
+        t.live = true;
+        t.text = "LIVE to " + target;
+        if (s.members_known) {
+            t.text += " -- " + std::to_string(s.members_present) + " of " +
+                      std::to_string(s.members_total) + " present";
+        }
+        t.text += ".";
+        return t;
+    }
+    if (s.engine_reason.empty()) {
+        t.text = "Keying " + target + " -- waiting for Zoom to confirm the "
+                 "channel.";
+        return t;
+    }
+    t.alert = true;
+    t.text = "Key refused for " + target + ": " + s.engine_reason + ".";
+    if (!s.engine_recover.empty())
+        t.text += " Recovery: " + s.engine_recover + ".";
+    return t;
+}
+
+// ── The dock's own lost-release backstop ────────────────────────────────────
+//
+// The dock passes needs_renewal = false to key_on(): its press and release are
+// QPushButton signals on the Qt main thread, the same thread
+// TalkbackController's QTimer runs evaluate()/key_off() on, so there is no
+// transport between them to lose a release the way a socket can (see the
+// renewal discussion at the top of src/talkback-key.h, which names exactly
+// this class of surface).
+//
+// One in-process way a release CAN still go missing: QAbstractButton clears
+// its pressed state on an EnabledChange without emitting released(), so
+// disabling a held button would strand the key open. The dock does not disable
+// a held button -- and this is the backstop for it either way. It compares the
+// controller's open key against the widget's own current state, so a stalled
+// UI thread cannot false-close a genuinely held key: while the thread is
+// stalled this does not run at all, and once it resumes isDown() is accurate
+// again. A latch is exempt by definition -- nothing is being held.
+inline bool talkback_dock_release_lost(bool dock_owns_open_key,
+                                       bool push_to_talk,
+                                       bool button_down)
+{
+    return dock_owns_open_key && push_to_talk && !button_down;
+}

--- a/src/talkback-plan.h
+++ b/src/talkback-plan.h
@@ -269,6 +269,33 @@ inline bool talkback_target_known_unprovisioned(
     return true; // never nominated at all
 }
 
+// Who, out of a confirmed nomination, actually got a private channel.
+//
+// The engine only ever names SHORTFALLS -- never successes (this file's
+// header comment says why) -- so every surface that wants to show "who can be
+// taken aside" has to subtract. zoom-control-server.cpp's
+// talkback_nomination_to_json() computed this inline for the wire and the dock
+// needed the same list; two copies of one subtraction is how a wire field and
+// a dock label drift into disagreeing about the same meeting. One
+// implementation, here, beside the semantics it depends on.
+//
+// `requested` and `uncovered_private` must both come from the CONFIRMED plan
+// (src/talkback-nomination.h). Mixing a confirmed list with an in-flight
+// attempt's shortfall names would name people who do have a channel.
+inline std::vector<std::string> talkback_private_channel_names(
+    const std::vector<std::string> &requested,
+    const std::vector<std::string> &uncovered_private)
+{
+    std::vector<std::string> covered;
+    for (const auto &name : requested) {
+        bool uncovered = false;
+        for (const auto &u : uncovered_private)
+            if (u == name) { uncovered = true; break; }
+        if (!uncovered) covered.push_back(name);
+    }
+    return covered;
+}
+
 inline bool talkback_channel_serves_target(bool is_all_talent,
                                            const std::vector<std::string> &members,
                                            const std::string &target)

--- a/src/zoom-control-server.cpp
+++ b/src/zoom-control-server.cpp
@@ -3,6 +3,7 @@
 #include "speaker-director.h"
 #include "talkback-controller.h"
 #include "talkback-key.h"
+#include "talkback-plan.h"
 #include "zoom-control-parse.h"
 #include "zoom-engine-client.h"
 #include "zoom-iso-recorder.h"
@@ -432,12 +433,14 @@ static QJsonObject talkback_nomination_to_json(
         uncovered.append(QString::fromStdString(name));
     for (const auto &name : n.unreachable)
         unreachable.append(QString::fromStdString(name));
-    for (const auto &name : n.requested) {
-        const bool is_uncovered =
-            std::find(n.uncovered_private.begin(), n.uncovered_private.end(), name) !=
-            n.uncovered_private.end();
-        if (!is_uncovered) has_private_channel.append(QString::fromStdString(name));
-    }
+    // The subtraction itself is talkback_private_channel_names()
+    // (src/talkback-plan.h) rather than a loop here: the dock's Talkback group
+    // shows the same list, and two copies of one subtraction is how a wire
+    // field and a dock label drift into describing the same meeting
+    // differently.
+    for (const auto &name : talkback_private_channel_names(n.requested,
+                                                           n.uncovered_private))
+        has_private_channel.append(QString::fromStdString(name));
     obj["uncovered_private"] = uncovered;
     obj["unreachable"] = unreachable;
     obj["has_private_channel"] = has_private_channel;

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -5,6 +5,10 @@
 #include "obs-utils.h"
 #include "speaker-director.h"
 #include "join-watchdog.h"
+#include "talkback-controller.h"
+#include "talkback-dock-state.h"
+#include "talkback-key.h"
+#include "talkback-plan.h"
 #include "zoom-engine-client.h"
 #include "zoom-join-decision.h"
 #include "zoom-oauth.h"
@@ -348,6 +352,17 @@ static void replace_combo_items(
         combo->setCurrentIndex(0);
         combo->blockSignals(false);
     }
+}
+
+// Does this item list already offer `data` as a selectable value? Used to keep
+// a saved talkback source visible when OBS does not currently have it.
+static bool combo_items_contain(
+    const std::vector<std::pair<QString, QVariant>> &items, const QVariant &data)
+{
+    for (const auto &item : items)
+        if (item.second == data)
+            return true;
+    return false;
 }
 
 static bool item_list_contains_data(
@@ -815,13 +830,151 @@ ZoomDock::ZoomDock(QWidget *parent)
     routing_layout->addWidget(m_output_manager_btn);
     vLayout->addWidget(routing_group);
 
+    // -- Talkback (Milestone 7) -------------------------------------------------
+    //
+    // A DELIBERATE, OWNER-APPROVED DEVIATION FROM THE SPEC. docs/superpowers/
+    // specs/2026-08-24-zoom-talkback-design.md locks the keying surfaces to
+    // "Companion/Stream Deck, TCP/OSC control API, OBS hotkey. **Not** the
+    // dock", and its Dock section says "Configuration and tally only, by
+    // operator preference -- no talk button". The owner has since asked for a
+    // dock that can actually be driven, so the dock keys. Nothing else in that
+    // decision moved: identity is still by display name, a key still SELECTS a
+    // channel nomination already created, and every refusal still fails closed.
+    //
+    // Every decision this group renders -- which buttons are live, what the
+    // nomination outcome says, whether the chosen source is on a program track
+    // -- lives in src/talkback-dock-state.h so it can be tested without OBS,
+    // Qt or a meeting. Keep it that way: the two Majors this feature shipped
+    // (F1, N1) both lived in wiring that no test could reach.
+    auto *tb_group = new QGroupBox("Talkback", this);
+    auto *tb_layout = new QVBoxLayout(tb_group);
+    tb_layout->setSpacing(6);
+
+    auto *tb_intro = new QLabel(
+        "Speak privately to nominated talent. Nominate first -- the Zoom "
+        "channels are created then, so a key press only opens the microphone.",
+        tb_group);
+    tb_intro->setWordWrap(true);
+    tb_intro->setProperty("role", "muted");
+    tb_layout->addWidget(tb_intro);
+
+    auto *tb_source_row = new QHBoxLayout;
+    tb_source_row->setSpacing(8);
+    m_talkback_source_combo = new QComboBox(tb_group);
+    m_talkback_source_combo->setMinimumWidth(200);
+    m_talkback_source_combo->setToolTip(
+        "The OBS audio source you talk through. Use a dedicated source with "
+        "every program track unchecked in Advanced Audio Properties.");
+    // Seeded from the saved name, not from a scan: the tick below rebuilds
+    // this from OBS, and seeding here is what makes the saved choice the
+    // preferred selection when it does (replace_combo_items() keeps the
+    // current data if it can still find it).
+    m_talkback_source_combo->addItem(
+        initial_settings.talkback_source.empty()
+            ? QStringLiteral("Select audio source")
+            : QString::fromStdString(initial_settings.talkback_source),
+        QVariant(QString::fromStdString(initial_settings.talkback_source)));
+    tb_source_row->addWidget(new QLabel("Talk source", tb_group));
+    tb_source_row->addWidget(m_talkback_source_combo, 1);
+    tb_layout->addLayout(tb_source_row);
+    connect(m_talkback_source_combo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int) {
+                if (!m_alive->load(std::memory_order_acquire) ||
+                    !m_talkback_source_combo)
+                    return;
+                // Only a real operator change reaches here:
+                // replace_combo_items() blocks this combo's signals while it
+                // rebuilds and while it restores the selection.
+                auto s = ZoomPluginSettings::load();
+                s.talkback_source =
+                    m_talkback_source_combo->currentData().toString().toStdString();
+                s.save();
+            });
+
+    // The deferred half of the program/ISO leak guarantee. The structural half
+    // holds unconditionally (a capture callback observes a source and cannot
+    // add it to any mix -- tests/talkback-isolation-test.cpp) and the tap
+    // already logs this at open() time (src/talkback-tap.cpp); this is the
+    // same advisory where the operator is looking, and BEFORE the key rather
+    // than on it.
+    m_talkback_track_label = new QLabel(tb_group);
+    m_talkback_track_label->setObjectName("talkbackTrackWarning");
+    m_talkback_track_label->setWordWrap(true);
+    tb_layout->addWidget(m_talkback_track_label);
+
+    auto *tb_nominate_label = new QLabel(
+        "Nominate talent -- everyone ticked gets a standing channel:", tb_group);
+    tb_nominate_label->setWordWrap(true);
+    tb_layout->addWidget(tb_nominate_label);
+
+    m_talkback_nominee_list = new QListWidget(tb_group);
+    m_talkback_nominee_list->setMaximumHeight(110);
+    m_talkback_nominee_list->setToolTip(
+        "Tick the people you may need to talk to. Zoom allows 16 channels and "
+        "10 people per channel; anyone the budget cannot cover is named below.");
+    tb_layout->addWidget(m_talkback_nominee_list);
+
+    m_talkback_nominate_btn = new QPushButton("Nominate", tb_group);
+    m_talkback_nominate_btn->setProperty("role", "primary");
+    m_talkback_nominate_btn->setEnabled(false);
+    tb_layout->addWidget(m_talkback_nominate_btn);
+    connect(m_talkback_nominate_btn, &QPushButton::clicked,
+            this, [this]() { on_talkback_nominate_clicked(); });
+
+    // The budget outcome, in the operator's own words and with every shortfall
+    // NAMED. This block is the whole reason the nomination reporting chain
+    // exists (src/talkback-plan.h): a count tells the operator that somebody
+    // is short, not who -- and who is the only part they can act on.
+    m_talkback_plan_label = new QLabel(tb_group);
+    m_talkback_plan_label->setObjectName("talkbackPlan");
+    m_talkback_plan_label->setWordWrap(true);
+    tb_layout->addWidget(m_talkback_plan_label);
+
+    m_talkback_latch_cb = new QCheckBox("Latch (tap on, tap off)", tb_group);
+    m_talkback_latch_cb->setChecked(initial_settings.talkback_latch);
+    m_talkback_latch_cb->setToolTip(
+        "Off: hold a key button to talk. On: one press opens the key, the next "
+        "closes it. A latch never survives a reconnect.");
+    tb_layout->addWidget(m_talkback_latch_cb);
+    connect(m_talkback_latch_cb, &QCheckBox::toggled, this, [this](bool on) {
+        if (!m_alive->load(std::memory_order_acquire))
+            return;
+        auto s = ZoomPluginSettings::load();
+        s.talkback_latch = on;
+        s.save();
+    });
+
+    // One button per keyable target, rebuilt from the CONFIRMED plan by
+    // refresh_talkback(). Empty until something is nominated -- there is
+    // nothing to key before that, and an always-present button that always
+    // refuses teaches the operator to ignore refusals.
+    m_talkback_key_row = new QWidget(tb_group);
+    auto *tb_key_layout = new QGridLayout(m_talkback_key_row);
+    tb_key_layout->setContentsMargins(0, 0, 0, 0);
+    tb_key_layout->setSpacing(6);
+    tb_layout->addWidget(m_talkback_key_row);
+
+    m_talkback_tally_label = new QLabel(QStringLiteral("Not keyed."), tb_group);
+    m_talkback_tally_label->setObjectName("talkbackTally");
+    m_talkback_tally_label->setWordWrap(true);
+    tb_layout->addWidget(m_talkback_tally_label);
+
+    // The dock's OWN refusals -- the ones the engine never sees (no source
+    // chosen, the source is not in the current scene, OBS is at a sample rate
+    // the Zoom talkback API will not take). The tally above shows the engine's.
+    m_talkback_notice = new QLabel(tb_group);
+    m_talkback_notice->setObjectName("errorLabel");
+    m_talkback_notice->setWordWrap(true);
+    m_talkback_notice->setVisible(false);
+    tb_layout->addWidget(m_talkback_notice);
+
+    vLayout->addWidget(tb_group);
+
     // -- Talkback probe (Milestone 1 diagnostic) --------------------------------
-    // This is NOT the talkback feature (Milestone 7: talk button, PTT, latch,
-    // tally, level meter). Those are deliberately out of this dock -- the
-    // operator has confirmed it stays config-and-tally-only. This is only the
-    // "can this account even open a channel" probe, exposed here because it
-    // was previously reachable only over the TCP control API, and its
-    // progress otherwise only ever showed up as OBS log lines.
+    // Kept, and kept separate from the Talkback group above: this is the "can
+    // this account even open a channel" probe, which destroys its channel
+    // afterwards and plays an audible tone at the participant. It is a
+    // diagnostic for when talkback does not work at all, not a way to use it.
     auto *talkback_group = new QGroupBox("Talkback (probe)", this);
     auto *talkback_layout = new QVBoxLayout(talkback_group);
     talkback_layout->setSpacing(6);
@@ -1013,6 +1166,18 @@ ZoomDock::~ZoomDock()
 void ZoomDock::prepare_shutdown()
 {
     m_alive->store(false, std::memory_order_release);
+    // Close a key this dock opened before its buttons go away. A destroyed
+    // QPushButton emits no released(), and after this function the refresh
+    // timer that would notice (talkback_dock_release_lost()) is stopped -- so
+    // without this the only thing left to close the key is
+    // TalkbackController::stop() at plugin unload, which is later than it
+    // should be for a key that is on air. key_off() is a no-op if nothing is
+    // open, and a key opened over the control API is not this dock's to close.
+    if (!m_talkback_dock_target.empty()) {
+        TalkbackController::instance().key_off();
+        m_talkback_dock_target.clear();
+        m_talkback_dock_latched = false;
+    }
     if (m_speaker_sensitivity_spin)
         QObject::disconnect(m_speaker_sensitivity_spin, nullptr, this, nullptr);
     if (m_speaker_hold_spin)
@@ -1396,11 +1561,519 @@ void ZoomDock::update_state_indicator()
         m_talkback_status_label->setText(format_talkback_probe_status(
             ZoomEngineClient::instance().talkback_probe_status()));
     }
+
+    // Milestone 7's group, on this same tick rather than a timer of its own --
+    // see refresh_talkback().
+    refresh_talkback();
 }
 
 void ZoomDock::refresh()
 {
     update_state_indicator();
+}
+
+// -- Talkback (Milestone 7) ----------------------------------------------------
+
+// A dynamic property plus a re-polish is how this dock already switches a
+// widget between styled states (see on_join_clicked()'s "error" property on
+// m_meeting_id): the stylesheet rules live in src/cv-style.h, not inline here,
+// so the dock keeps one place that decides colour. No-op when the flag is
+// unchanged -- this runs ten times a second.
+static void set_style_flag(QWidget *widget, const char *name, bool value)
+{
+    if (!widget || widget->property(name).toBool() == value)
+        return;
+    widget->setProperty(name, value);
+    widget->style()->unpolish(widget);
+    widget->style()->polish(widget);
+}
+
+// Every OBS source that can produce audio, by NAME -- which is what
+// TalkbackTap::open() takes (obs_get_source_by_name), and what survives the
+// operator rebuilding a scene collection.
+//
+// CoreVideo's own participant/Zoom audio sources are deliberately NOT filtered
+// out: relaying one participant privately to another is a legitimate thing to
+// key, and the tap cannot tell the difference anyway.
+static std::vector<std::pair<QString, QVariant>> talkback_audio_source_items()
+{
+    std::vector<std::pair<QString, QVariant>> items;
+    items.emplace_back(QStringLiteral("Select audio source"), QVariant(QString()));
+    // obs_enum_sources walks inputs and groups, not scenes (the same fact
+    // zoom-supersource.cpp's background picker relies on); a group has no
+    // audio output flag, so the flag test below is what actually selects.
+    obs_enum_sources(
+        [](void *param, obs_source_t *src) -> bool {
+            auto *out =
+                static_cast<std::vector<std::pair<QString, QVariant>> *>(param);
+            if (!(obs_source_get_output_flags(src) & OBS_SOURCE_AUDIO))
+                return true;
+            const char *name = obs_source_get_name(src);
+            if (!name || !*name)
+                return true;
+            const QString qname = QString::fromUtf8(name);
+            out->emplace_back(qname, QVariant(qname));
+            return true;
+        },
+        &items);
+    return items;
+}
+
+void ZoomDock::refresh_talkback()
+{
+    if (!m_talkback_source_combo)
+        return;
+
+    auto &engine = ZoomEngineClient::instance();
+    const bool engine_running = engine.is_running();
+    const bool in_meeting = engine.state() == MeetingState::InMeeting;
+
+    // -- Source picker ---------------------------------------------------------
+    if (!combo_popup_open(m_talkback_source_combo)) {
+        const QString chosen = m_talkback_source_combo->currentData().toString();
+        auto items = talkback_audio_source_items();
+        // Keep a chosen source that OBS does not currently have in the list, so
+        // a saved choice survives the source being absent (a scene collection
+        // still loading, a mic not plugged in) instead of being silently
+        // replaced by whatever happens to be first.
+        if (!chosen.isEmpty() && !combo_items_contain(items, chosen))
+            items.emplace_back(chosen + " (not in OBS)", QVariant(chosen));
+        replace_combo_items(m_talkback_source_combo, items, QVariant(chosen));
+    }
+
+    const QString source_name = m_talkback_source_combo->currentData().toString();
+
+    // -- Program-track warning -------------------------------------------------
+    QString track_text;
+    bool track_risk = false;
+    bool source_present = false;
+    uint32_t mixers = 0;
+    if (!source_name.isEmpty()) {
+        obs_source_t *src =
+            obs_get_source_by_name(source_name.toUtf8().constData());
+        if (src) {
+            source_present = true;
+            mixers = obs_source_get_audio_mixers(src);
+            obs_source_release(src);
+        }
+    }
+    if (!source_name.isEmpty() && !source_present) {
+        // Do NOT fall through to talkback_dock_track_warning() with mixers = 0
+        // here: that would report "on no OBS track -- talkback only", which is
+        // a safety claim about a source that is not there to be safe.
+        track_text = QString("\"%1\" is not in OBS right now. Pick the source "
+                             "you are actually going to talk through.")
+                         .arg(source_name);
+    } else {
+        const auto warning = talkback_dock_track_warning(
+            source_name.toStdString(), mixers);
+        track_text = QString::fromStdString(warning.text);
+        track_risk = warning.on_air_risk;
+    }
+    if (m_talkback_track_label && m_talkback_track_label->text() != track_text)
+        m_talkback_track_label->setText(track_text);
+    set_style_flag(m_talkback_track_label, "risk", track_risk);
+
+    // -- Nominee list ----------------------------------------------------------
+    // Identity is by display name, never by Zoom user id (ids are
+    // meeting-scoped: one captured now points at nobody after a rejoin and at
+    // the wrong face once ids get recycled). Each row carries its name in
+    // Qt::UserRole, because the row's TEXT can also say "(not in the meeting)".
+    //
+    // A TICKED NAME THAT HAS LEFT THE ROSTER STAYS ON THE LIST. Nominating
+    // somebody who is not here right now is meaningful -- the engine
+    // re-resolves nominations by name on every roster change and invites them
+    // when they arrive (resolve_roster_change(), engine-talkback.cpp) -- so
+    // dropping the row would silently drop them from the next Nominate press,
+    // on the exact path where a talent has just disconnected and the director
+    // is re-nominating to fix something else.
+    const auto roster = engine.roster();
+    std::vector<std::string> checked_names;
+    if (m_talkback_nominee_list) {
+        for (int i = 0; i < m_talkback_nominee_list->count(); ++i) {
+            auto *item = m_talkback_nominee_list->item(i);
+            if (item && item->checkState() == Qt::Checked)
+                checked_names.push_back(
+                    item->data(Qt::UserRole).toString().toStdString());
+        }
+    }
+
+    // (name, present in the meeting right now)
+    std::vector<std::pair<std::string, bool>> rows;
+    const auto row_index = [&rows](const std::string &name) {
+        for (std::size_t i = 0; i < rows.size(); ++i)
+            if (rows[i].first == name) return static_cast<int>(i);
+        return -1;
+    };
+    for (const auto &p : roster) {
+        // Someone with no display name cannot be nominated at all, and is left
+        // out rather than listed as an id that would not resolve.
+        if (p.display_name.empty()) continue;
+        if (row_index(p.display_name) < 0) rows.emplace_back(p.display_name, true);
+    }
+    for (const auto &name : checked_names)
+        if (row_index(name) < 0) rows.emplace_back(name, false);
+
+    // Rebuilt only when those rows change: this runs ten times a second and a
+    // rebuild throws away the tick-boxes the operator is in the middle of
+    // setting. (The roster itself churns constantly -- two of Zoom's five
+    // roster callbacks fire on every mute and camera toggle by anyone.)
+    std::string roster_signature;
+    for (const auto &row : rows) {
+        roster_signature += row.second ? "+" : "-";
+        roster_signature += row.first;
+        roster_signature += '\n';
+    }
+    if (m_talkback_nominee_list &&
+        roster_signature != m_talkback_roster_signature) {
+        m_talkback_nominee_list->clear();
+        for (const auto &row : rows) {
+            const QString name = QString::fromStdString(row.first);
+            auto *item = new QListWidgetItem(
+                row.second ? name : name + " (not in the meeting)");
+            item->setData(Qt::UserRole, name);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+            const bool was_checked =
+                std::find(checked_names.begin(), checked_names.end(), row.first) !=
+                checked_names.end();
+            item->setCheckState(was_checked ? Qt::Checked : Qt::Unchecked);
+            m_talkback_nominee_list->addItem(item);
+        }
+        m_talkback_roster_signature = roster_signature;
+    }
+
+    const int checked_count = static_cast<int>(checked_names.size());
+    if (m_talkback_nominate_btn) {
+        // Both conditions, not just InMeeting: talkback_nominate() is a silent
+        // no-op when the engine pipe is not up, which is why the control API
+        // acks "engine_not_running" separately from "not_in_meeting".
+        m_talkback_nominate_btn->setEnabled(engine_running && in_meeting);
+        // An empty nomination is a deliberate denominate (the engine's
+        // nominate() documents it as such), not a mistake to block -- but it
+        // must not be labelled "Nominate".
+        const QString label = checked_count == 0
+            ? QStringLiteral("Clear all nominations")
+            : QString("Nominate (%1)").arg(checked_count);
+        if (m_talkback_nominate_btn->text() != label)
+            m_talkback_nominate_btn->setText(label);
+    }
+
+    // -- The confirmed plan, and what it cost ----------------------------------
+    const auto plan = engine.talkback_nomination_status();
+    const auto report = talkback_dock_nomination_report(plan);
+    QString plan_text = QString::fromStdString(report.headline);
+    for (const auto &line : report.lines)
+        plan_text += "\n" + QString::fromStdString(line);
+    if (m_talkback_plan_label && m_talkback_plan_label->text() != plan_text)
+        m_talkback_plan_label->setText(plan_text);
+    set_style_flag(m_talkback_plan_label, "warn", report.warn);
+
+    // -- Whose key is open -----------------------------------------------------
+    // Polled and parsed, the same treatment format_talkback_probe_status()
+    // gives the engine's probe line, rather than a new accessor on the
+    // controller. A malformed document would read as "no key open"; the
+    // consequence is bounded, because key_on() refuses a second key itself and
+    // the dock shows that refusal.
+    bool key_open = false;
+    std::string open_target;
+    {
+        const QJsonDocument doc = QJsonDocument::fromJson(
+            QByteArray::fromStdString(
+                TalkbackController::instance().status_json()));
+        if (doc.isObject()) {
+            const QJsonObject obj = doc.object();
+            key_open = obj.value("open").toBool();
+            open_target = obj.value("target").toString().toStdString();
+        }
+    }
+
+    // The controller closes keys the dock never asked it to close: the dead-man
+    // switch, an engine refusal, a Leave, a plugin shutdown. Notice that here
+    // instead of leaving the dock believing it still owns a key.
+    if (!key_open && !m_talkback_dock_target.empty()) {
+        m_talkback_dock_target.clear();
+        m_talkback_dock_latched = false;
+    }
+
+    // The dock's own lost-release backstop -- see talkback_dock_release_lost()
+    // in src/talkback-dock-state.h for why this surface uses the widget's own
+    // state instead of the renewal machinery a socket surface needs.
+    if (!m_talkback_dock_target.empty()) {
+        bool button_down = false;
+        for (auto *button : m_talkback_key_buttons) {
+            if (!button) continue;
+            if (button->property("cvTalkbackTarget").toString().toStdString() ==
+                m_talkback_dock_target) {
+                button_down = button->isDown();
+                break;
+            }
+        }
+        if (talkback_dock_release_lost(true, !m_talkback_dock_latched,
+                                       button_down)) {
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] talkback dock: closing the key to \"%s\" -- "
+                 "its button is no longer held and no release ever arrived",
+                 m_talkback_dock_target.c_str());
+            TalkbackController::instance().key_off();
+            m_talkback_dock_target.clear();
+            m_talkback_dock_latched = false;
+            key_open = false;
+            open_target.clear();
+        }
+    }
+
+    // -- Key buttons -----------------------------------------------------------
+    TalkbackDockKeyContext ctx;
+    ctx.engine_running = engine_running;
+    ctx.in_meeting = in_meeting;
+    ctx.key_open = key_open;
+    ctx.open_target = open_target;
+    const auto buttons = talkback_dock_key_buttons(plan, ctx);
+
+    std::string target_signature;
+    for (const auto &b : buttons) {
+        target_signature += b.target;
+        target_signature += '\n';
+    }
+    // Rebuild only when the SET OF TARGETS changes, and never while this dock
+    // has a key open: deleting the widget the operator is holding loses its
+    // release. Deferring costs little -- the engine refuses a re-nomination
+    // outright while a session is live ("reason":"session_live", nominate() in
+    // engine-talkback.cpp), so the confirmed plan seldom moves mid-press at
+    // all, and when it does (a superseded ladder's terminal invalidating it)
+    // the buttons are rebuilt on the first tick after the key closes.
+    if (target_signature != m_talkback_key_signature &&
+        m_talkback_dock_target.empty()) {
+        rebuild_talkback_key_buttons(buttons);
+        m_talkback_key_signature = target_signature;
+    }
+
+    for (const auto &b : buttons) {
+        for (auto *button : m_talkback_key_buttons) {
+            if (!button ||
+                button->property("cvTalkbackTarget").toString().toStdString() !=
+                    b.target)
+                continue;
+            // NEVER disable a held button. QAbstractButton clears its pressed
+            // state on an EnabledChange without emitting released(), so
+            // disabling one mid-press strands the key open until the backstop
+            // above notices. talkback_dock_key_buttons() already keeps the open
+            // key's own button enabled; this is the second line of defence for
+            // any future caller that forgets.
+            if (!b.enabled && button->isDown())
+                break;
+            button->setEnabled(b.enabled);
+            const QString tip = b.enabled
+                ? QString("Talk to %1.").arg(QString::fromStdString(b.label))
+                : QString::fromStdString(b.reason);
+            if (button->toolTip() != tip)
+                button->setToolTip(tip);
+            break;
+        }
+    }
+
+    // -- Tally -----------------------------------------------------------------
+    const auto session = engine.talkback_session_status();
+    TalkbackDockSessionView view;
+    view.key_open = key_open;
+    view.target = open_target;
+    view.engine_live = session.live;
+    view.engine_reason = session.reason;
+    view.engine_recover = session.recover;
+    view.members_known = session.members_known;
+    view.members_present = session.members_present;
+    view.members_total = session.members_total;
+    const auto tally = talkback_dock_tally(view);
+    const QString tally_text = QString::fromStdString(tally.text);
+    if (m_talkback_tally_label && m_talkback_tally_label->text() != tally_text)
+        m_talkback_tally_label->setText(tally_text);
+    set_style_flag(m_talkback_tally_label, "live", tally.live);
+    set_style_flag(m_talkback_tally_label, "alert", tally.alert);
+
+    if (m_talkback_notice) {
+        if (m_talkback_notice->text() != m_talkback_notice_text)
+            m_talkback_notice->setText(m_talkback_notice_text);
+        m_talkback_notice->setVisible(!m_talkback_notice_text.isEmpty());
+    }
+}
+
+// Takes the button specs its caller already computed rather than recomputing
+// them from a second, thinner context: the two would otherwise disagree for the
+// one tick between the rebuild and the enable pass, which is exactly the window
+// an operator's press lands in.
+void ZoomDock::rebuild_talkback_key_buttons(
+    const std::vector<TalkbackDockKeyButton> &buttons)
+{
+    if (!m_talkback_key_row)
+        return;
+    auto *layout = qobject_cast<QGridLayout *>(m_talkback_key_row->layout());
+    if (!layout)
+        return;
+
+    for (auto *button : m_talkback_key_buttons) {
+        if (!button) continue;
+        layout->removeWidget(button);
+        button->deleteLater();
+    }
+    m_talkback_key_buttons.clear();
+
+    int column = 0, row = 0;
+    for (const auto &spec : buttons) {
+        auto *button = new QPushButton(QString::fromStdString(spec.label),
+                                       m_talkback_key_row);
+        button->setProperty("cvTalkbackTarget",
+                            QString::fromStdString(spec.target));
+        if (spec.all_talent)
+            button->setProperty("role", "primary");
+        button->setEnabled(spec.enabled);
+        button->setToolTip(spec.enabled
+            ? QString("Talk to %1.").arg(QString::fromStdString(spec.label))
+            : QString::fromStdString(spec.reason));
+        // The target is captured by value: the button outlives any particular
+        // plan, and a captured pointer into one would not.
+        const std::string target = spec.target;
+        connect(button, &QPushButton::pressed, this, [this, target]() {
+            talkback_key_pressed(target,
+                m_talkback_latch_cb && m_talkback_latch_cb->isChecked());
+        });
+        connect(button, &QPushButton::released, this, [this, target]() {
+            talkback_key_released(target);
+        });
+        layout->addWidget(button, row, column);
+        m_talkback_key_buttons.push_back(button);
+        if (++column == 3) { column = 0; ++row; }
+    }
+    // No setStyleSheet() here: this dock's own sheet already applies to
+    // descendants created later, and role="primary" is set above before the
+    // button is ever polished.
+}
+
+void ZoomDock::on_talkback_nominate_clicked()
+{
+    if (!m_talkback_nominee_list)
+        return;
+
+    std::vector<std::string> nominees;
+    for (int i = 0; i < m_talkback_nominee_list->count(); ++i) {
+        auto *item = m_talkback_nominee_list->item(i);
+        // Qt::UserRole, not text(): a row for someone who has left says "(not
+        // in the meeting)" in its label, and the engine must be sent the name.
+        if (item && item->checkState() == Qt::Checked)
+            nominees.push_back(item->data(Qt::UserRole).toString().toStdString());
+    }
+
+    // Refused here rather than left to the engine, because the engine's own
+    // refusal reason ("target_name_collision") does not say WHO. A participant
+    // whose display name is "all" (any casing) collides with the all-talent
+    // target, and keying that name would go to the whole panel -- the exact
+    // privacy promise talkback is built on. See talkback-plan.h.
+    const std::string collision = talkback_nominate_sentinel_collision(nominees);
+    if (!collision.empty()) {
+        m_talkback_notice_text = QString(
+            "\"%1\" cannot be nominated: that name is how CoreVideo addresses "
+            "the whole panel. Ask them to change their Zoom display name.")
+            .arg(QString::fromStdString(collision));
+        refresh_talkback();
+        return;
+    }
+
+    auto &engine = ZoomEngineClient::instance();
+    if (!engine.is_running()) {
+        m_talkback_notice_text =
+            QStringLiteral("The Zoom engine is not running -- start it before "
+                           "nominating talkback talent.");
+        refresh_talkback();
+        return;
+    }
+    if (engine.state() != MeetingState::InMeeting) {
+        m_talkback_notice_text =
+            QStringLiteral("Join the meeting before nominating talkback talent.");
+        refresh_talkback();
+        return;
+    }
+
+    m_talkback_notice_text.clear();
+    blog(LOG_INFO,
+         "[obs-zoom-plugin] talkback dock: nominating %d name(s)",
+         static_cast<int>(nominees.size()));
+    // Fire-and-acknowledge: the plan outcome arrives asynchronously and is
+    // polled out of talkback_nomination_status() by refresh_talkback() above.
+    engine.talkback_nominate(nominees);
+    refresh_talkback();
+}
+
+void ZoomDock::talkback_key_pressed(const std::string &target, bool latch)
+{
+    // THREAD NOTE, and the reason it is written here rather than assumed: this
+    // handler runs on the Qt main thread -- Qt delivers QPushButton::pressed
+    // from the widget's own thread -- which is the SAME thread
+    // TalkbackController's QTimer drives evaluate() and key_off() on. So
+    // calling key_on()/key_off() directly, with no dispatch, is correct here,
+    // exactly as it is for ZoomControlServer's socket handlers.
+    //
+    // A NON-Qt-thread keying surface must NOT copy this call shape without
+    // first confirming it lands on that same thread: an OBS hotkey callback is
+    // delivered by libobs, not by Qt, and key_off()'s two-phase close (flip the
+    // flag under m_mtx, then tear the tap down outside it) is only safe against
+    // a concurrent evaluate() because of that thread identity.
+    if (latch && !m_talkback_dock_target.empty() &&
+        m_talkback_dock_target == target) {
+        TalkbackController::instance().key_off();
+        m_talkback_dock_target.clear();
+        m_talkback_dock_latched = false;
+        refresh_talkback();
+        return;
+    }
+
+    const QString source = m_talkback_source_combo
+        ? m_talkback_source_combo->currentData().toString()
+        : QString();
+    if (source.isEmpty()) {
+        m_talkback_notice_text = QStringLiteral(
+            "Choose the OBS audio source you talk through before keying.");
+        refresh_talkback();
+        return;
+    }
+
+    std::string error;
+    // needs_renewal = false. src/talkback-key.h's rule is that a surface whose
+    // release is in-process and reliable does not need the lost-release
+    // backstop, and names the OBS hotkey as the example; a dock button's
+    // release is the same shape -- a Qt signal on the thread the controller
+    // itself runs on, with no transport in between that could drop it. Passing
+    // true instead would demand a heartbeat from this dock's UI-thread timer to
+    // keep a key alive, which would close a genuinely held key whenever the OBS
+    // UI stalls for a second (a scene collection load, a modal dialog). The one
+    // in-process way a release can still vanish -- a held button being disabled
+    // -- is covered by talkback_dock_release_lost() from the refresh tick,
+    // which reads the widget's own state and so cannot false-close during a
+    // stall.
+    const bool ok = TalkbackController::instance().key_on(
+        target, source.toStdString(),
+        latch ? TalkbackKeyMode::Latch : TalkbackKeyMode::PushToTalk,
+        /*needs_renewal=*/false, error);
+    if (!ok) {
+        m_talkback_notice_text = QString::fromStdString(error);
+        refresh_talkback();
+        return;
+    }
+    m_talkback_notice_text.clear();
+    m_talkback_dock_target = target;
+    m_talkback_dock_latched = latch;
+    refresh_talkback();
+}
+
+void ZoomDock::talkback_key_released(const std::string &target)
+{
+    // Latch mode releases nothing: the next PRESS on this target closes it.
+    if (m_talkback_dock_latched)
+        return;
+    if (m_talkback_dock_target != target)
+        return;
+    TalkbackController::instance().key_off();
+    m_talkback_dock_target.clear();
+    m_talkback_dock_latched = false;
+    refresh_talkback();
 }
 
 void ZoomDock::refresh_outputs()

--- a/src/zoom-dock.cpp
+++ b/src/zoom-dock.cpp
@@ -889,6 +889,10 @@ ZoomDock::ZoomDock(QWidget *parent)
                 s.talkback_source =
                     m_talkback_source_combo->currentData().toString().toStdString();
                 s.save();
+                // Force the next tick to rescan rather than waiting out the
+                // 1Hz gate: the operator has just changed the source and the
+                // program-track warning under it is now about the wrong one.
+                m_talkback_source_scan_ms = 0;
             });
 
     // The deferred half of the program/ISO leak guarantee. The structural half
@@ -1619,6 +1623,20 @@ static std::vector<std::pair<QString, QVariant>> talkback_audio_source_items()
     return items;
 }
 
+// The key THIS DOCK is holding, if any -- the single record every dock-side
+// keying decision reads (fix round 1, M1). It carries the mode the key was
+// opened with, which is deliberately not re-read from the Latch checkbox: the
+// checkbox says what the NEXT key would be, this says what the open one IS.
+TalkbackDockOpenKey ZoomDock::dock_open_key() const
+{
+    TalkbackDockOpenKey open;
+    open.open       = !m_talkback_dock_target.empty();
+    open.dock_owned = open.open;
+    open.target     = m_talkback_dock_target;
+    open.latched    = m_talkback_dock_latched;
+    return open;
+}
+
 void ZoomDock::refresh_talkback()
 {
     if (!m_talkback_source_combo)
@@ -1628,8 +1646,31 @@ void ZoomDock::refresh_talkback()
     const bool engine_running = engine.is_running();
     const bool in_meeting = engine.state() == MeetingState::InMeeting;
 
-    // -- Source picker ---------------------------------------------------------
-    if (!combo_popup_open(m_talkback_source_combo)) {
+    // -- Source picker and its program-track warning ---------------------------
+    //
+    // m2: THE ONLY WORK IN THIS FUNCTION THAT WALKS LIBOBS, and the only part
+    // that does not run at 10Hz. obs_enum_sources() holds
+    // obs->data.sources_mutex for the whole walk and addrefs every source (the
+    // constraint is spelled out at zoom-supersource.cpp's
+    // warn_on_multiple_audio_walls()), and this dock already moved its
+    // feed-health sweep to a 1Hz timer for exactly that reason. Source lists
+    // and mixer assignments do not change ten times a second, and nobody is
+    // reading a dock that is not on screen, so: once a second, and only while
+    // visible. Everything else below -- the key state an operator's press
+    // depends on -- stays on the 100ms tick.
+    //
+    // The rendered warning is cached rather than recomputed, so the label does
+    // not blank out on the ticks that skip the scan. A source change forces the
+    // next tick to rescan (the combo's own handler resets the stamp), so the
+    // operator never waits a second to see what they just picked.
+    const uint64_t now_ms_tick = os_gettime_ns() / 1000000ULL;
+    const bool scan_due =
+        isVisible() &&
+        (m_talkback_source_scan_ms == 0 ||
+         talkback_elapsed_ms(now_ms_tick, m_talkback_source_scan_ms) >= 1000);
+    if (scan_due && !combo_popup_open(m_talkback_source_combo)) {
+        m_talkback_source_scan_ms = now_ms_tick;
+
         const QString chosen = m_talkback_source_combo->currentData().toString();
         auto items = talkback_audio_source_items();
         // Keep a chosen source that OBS does not currently have in the list, so
@@ -1639,40 +1680,42 @@ void ZoomDock::refresh_talkback()
         if (!chosen.isEmpty() && !combo_items_contain(items, chosen))
             items.emplace_back(chosen + " (not in OBS)", QVariant(chosen));
         replace_combo_items(m_talkback_source_combo, items, QVariant(chosen));
+
+        const QString scanned = m_talkback_source_combo->currentData().toString();
+        bool source_present = false;
+        uint32_t mixers = 0;
+        if (!scanned.isEmpty()) {
+            obs_source_t *src =
+                obs_get_source_by_name(scanned.toUtf8().constData());
+            if (src) {
+                source_present = true;
+                mixers = obs_source_get_audio_mixers(src);
+                obs_source_release(src);
+            }
+        }
+        if (!scanned.isEmpty() && !source_present) {
+            // Do NOT fall through to talkback_dock_track_warning() with
+            // mixers = 0 here: that would report "on no OBS track -- talkback
+            // only", which is a safety claim about a source that is not there
+            // to be safe.
+            m_talkback_track_text =
+                QString("\"%1\" is not in OBS right now. Pick the source you "
+                        "are actually going to talk through.").arg(scanned);
+            m_talkback_track_risk = false;
+        } else {
+            const auto warning = talkback_dock_track_warning(
+                scanned.toStdString(), mixers);
+            m_talkback_track_text = QString::fromStdString(warning.text);
+            m_talkback_track_risk = warning.on_air_risk;
+        }
     }
 
     const QString source_name = m_talkback_source_combo->currentData().toString();
 
-    // -- Program-track warning -------------------------------------------------
-    QString track_text;
-    bool track_risk = false;
-    bool source_present = false;
-    uint32_t mixers = 0;
-    if (!source_name.isEmpty()) {
-        obs_source_t *src =
-            obs_get_source_by_name(source_name.toUtf8().constData());
-        if (src) {
-            source_present = true;
-            mixers = obs_source_get_audio_mixers(src);
-            obs_source_release(src);
-        }
-    }
-    if (!source_name.isEmpty() && !source_present) {
-        // Do NOT fall through to talkback_dock_track_warning() with mixers = 0
-        // here: that would report "on no OBS track -- talkback only", which is
-        // a safety claim about a source that is not there to be safe.
-        track_text = QString("\"%1\" is not in OBS right now. Pick the source "
-                             "you are actually going to talk through.")
-                         .arg(source_name);
-    } else {
-        const auto warning = talkback_dock_track_warning(
-            source_name.toStdString(), mixers);
-        track_text = QString::fromStdString(warning.text);
-        track_risk = warning.on_air_risk;
-    }
-    if (m_talkback_track_label && m_talkback_track_label->text() != track_text)
-        m_talkback_track_label->setText(track_text);
-    set_style_flag(m_talkback_track_label, "risk", track_risk);
+    if (m_talkback_track_label &&
+        m_talkback_track_label->text() != m_talkback_track_text)
+        m_talkback_track_label->setText(m_talkback_track_text);
+    set_style_flag(m_talkback_track_label, "risk", m_talkback_track_risk);
 
     // -- Nominee list ----------------------------------------------------------
     // Identity is by display name, never by Zoom user id (ids are
@@ -1771,9 +1814,17 @@ void ZoomDock::refresh_talkback()
     // -- Whose key is open -----------------------------------------------------
     // Polled and parsed, the same treatment format_talkback_probe_status()
     // gives the engine's probe line, rather than a new accessor on the
-    // controller. A malformed document would read as "no key open"; the
-    // consequence is bounded, because key_on() refuses a second key itself and
-    // the dock shows that refusal.
+    // controller.
+    //
+    // A DOCUMENT THAT DOES NOT PARSE IS "UNKNOWN", NOT "NO KEY OPEN" (fix round
+    // 1, n7). Treating it as no-key would clear m_talkback_dock_target below --
+    // the dock would forget it owns a live key, its release would find nothing
+    // to close, and the backstop would go dormant, which is the same stranded
+    // director M1 produced. Practically unreachable (status_json() builds the
+    // string with QJsonDocument in this same process), so the fallback is
+    // simply the dock's own record of what it opened, and the ownership-clear
+    // below is skipped for the tick.
+    bool status_parsed = false;
     bool key_open = false;
     std::string open_target;
     {
@@ -1781,35 +1832,48 @@ void ZoomDock::refresh_talkback()
             QByteArray::fromStdString(
                 TalkbackController::instance().status_json()));
         if (doc.isObject()) {
+            status_parsed = true;
             const QJsonObject obj = doc.object();
             key_open = obj.value("open").toBool();
             open_target = obj.value("target").toString().toStdString();
         }
     }
+    if (!status_parsed) {
+        if (!m_talkback_status_parse_logged) {
+            m_talkback_status_parse_logged = true;   // once, not ten times a second
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] talkback dock: could not parse the "
+                 "controller's status; using this dock's own record of the key "
+                 "it opened");
+        }
+        key_open = !m_talkback_dock_target.empty();
+        open_target = m_talkback_dock_target;
+    }
 
     // The controller closes keys the dock never asked it to close: the dead-man
     // switch, an engine refusal, a Leave, a plugin shutdown. Notice that here
     // instead of leaving the dock believing it still owns a key.
-    if (!key_open && !m_talkback_dock_target.empty()) {
+    if (status_parsed && !key_open && !m_talkback_dock_target.empty()) {
         m_talkback_dock_target.clear();
         m_talkback_dock_latched = false;
     }
 
     // The dock's own lost-release backstop -- see talkback_dock_release_lost()
-    // in src/talkback-dock-state.h for why this surface uses the widget's own
-    // state instead of the renewal machinery a socket surface needs.
-    if (!m_talkback_dock_target.empty()) {
+    // in src/talkback-dock-state.h for why this surface reads the widget's own
+    // state instead of the renewal machinery a socket surface needs, and why it
+    // is cause-agnostic rather than aimed at one way a release can vanish.
+    {
+        const TalkbackDockOpenKey dock_key = dock_open_key();
         bool button_down = false;
         for (auto *button : m_talkback_key_buttons) {
             if (!button) continue;
             if (button->property("cvTalkbackTarget").toString().toStdString() ==
-                m_talkback_dock_target) {
+                dock_key.target) {
                 button_down = button->isDown();
                 break;
             }
         }
-        if (talkback_dock_release_lost(true, !m_talkback_dock_latched,
-                                       button_down)) {
+        if (talkback_dock_release_lost(dock_key, button_down)) {
             blog(LOG_WARNING,
                  "[obs-zoom-plugin] talkback dock: closing the key to \"%s\" -- "
                  "its button is no longer held and no release ever arrived",
@@ -1826,8 +1890,16 @@ void ZoomDock::refresh_talkback()
     TalkbackDockKeyContext ctx;
     ctx.engine_running = engine_running;
     ctx.in_meeting = in_meeting;
-    ctx.key_open = key_open;
-    ctx.open_target = open_target;
+    ctx.source_chosen = !source_name.isEmpty();
+    // The dock's own record first -- it is the only thing that knows the MODE
+    // an open key was opened in, which status_json() does not report -- and the
+    // controller's view only for a key the dock does not own.
+    ctx.open = dock_open_key();
+    if (!ctx.open.open && key_open) {
+        ctx.open.open = true;
+        ctx.open.dock_owned = false;
+        ctx.open.target = open_target;
+    }
     const auto buttons = talkback_dock_key_buttons(plan, ctx);
 
     std::string target_signature;
@@ -2016,8 +2088,15 @@ void ZoomDock::talkback_key_pressed(const std::string &target, bool latch)
     // delivered by libobs, not by Qt, and key_off()'s two-phase close (flip the
     // flag under m_mtx, then tear the tap down outside it) is only safe against
     // a concurrent evaluate() because of that thread identity.
-    if (latch && !m_talkback_dock_target.empty() &&
-        m_talkback_dock_target == target) {
+    // Fix round 1 (M1, Major): whether this press CLOSES the open key is
+    // decided from the key itself -- the mode captured when it was opened --
+    // not from the Latch checkbox as it stands now. Unchecking Latch while a
+    // latched key is live used to skip this branch, fall through to key_on()'s
+    // "A talkback key is already open" refusal, and leave the director live to
+    // talent with the dock's only close affordance answering with an error.
+    // `latch` below therefore decides only what a NEW key opens as.
+    if (talkback_dock_press_action(dock_open_key(), target, latch) ==
+        TalkbackDockPressAction::CloseHeldKey) {
         TalkbackController::instance().key_off();
         m_talkback_dock_target.clear();
         m_talkback_dock_latched = false;
@@ -2043,11 +2122,17 @@ void ZoomDock::talkback_key_pressed(const std::string &target, bool latch)
     // itself runs on, with no transport in between that could drop it. Passing
     // true instead would demand a heartbeat from this dock's UI-thread timer to
     // keep a key alive, which would close a genuinely held key whenever the OBS
-    // UI stalls for a second (a scene collection load, a modal dialog). The one
-    // in-process way a release can still vanish -- a held button being disabled
-    // -- is covered by talkback_dock_release_lost() from the refresh tick,
-    // which reads the widget's own state and so cannot false-close during a
-    // stall.
+    // UI stalls for a second (a scene collection load, a modal dialog).
+    //
+    // A release can still go missing in-process -- QAbstractButton drops its
+    // pressed state without emitting released() on an EnabledChange, on a
+    // non-popup focus loss, and anywhere setDown(false) is reached -- so
+    // talkback_dock_release_lost() runs from the refresh tick and asks the
+    // widget whether it is still down, never why it stopped being down. It
+    // covers all of those causes and any Qt adds later, and reading the widget
+    // (rather than a deadline) is what makes it unable to false-close during a
+    // UI stall. Do not delete it on the belief that some particular cause has
+    // been ruled out.
     const bool ok = TalkbackController::instance().key_on(
         target, source.toStdString(),
         latch ? TalkbackKeyMode::Latch : TalkbackKeyMode::PushToTalk,
@@ -2065,10 +2150,11 @@ void ZoomDock::talkback_key_pressed(const std::string &target, bool latch)
 
 void ZoomDock::talkback_key_released(const std::string &target)
 {
-    // Latch mode releases nothing: the next PRESS on this target closes it.
-    if (m_talkback_dock_latched)
-        return;
-    if (m_talkback_dock_target != target)
+    // The same record the press path reads (M1): a latch releases nothing (the
+    // next press on its own target closes it), a stray release for a target
+    // this dock is not holding closes nothing, and a key another surface owns
+    // is not this dock's to close.
+    if (!talkback_dock_release_closes(dock_open_key(), target))
         return;
     TalkbackController::instance().key_off();
     m_talkback_dock_target.clear();

--- a/src/zoom-dock.h
+++ b/src/zoom-dock.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include "talkback-dock-state.h"
+
 #include <QFrame>
 #include <QString>
 #include <QWidget>
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <thread>
+#include <vector>
 
 class QLabel;
 class QLineEdit;
@@ -41,6 +45,20 @@ private:
     void on_launch_sidecar_clicked();
     void on_cancel_recovery_clicked();
     void update_state_indicator();
+    // Milestone 7. Everything the Talkback group polls, driven from the
+    // existing 100ms refresh tick -- deliberately NOT a second timer: this
+    // dock already has three (refresh, health retry, countdown) and the
+    // engine-confirmed talkback state is polled exactly the way
+    // last_error()/roster()/talkback_probe_status() already are.
+    void refresh_talkback();
+    void rebuild_talkback_key_buttons(
+        const std::vector<TalkbackDockKeyButton> &buttons);
+    void on_talkback_nominate_clicked();
+    // `latch` is captured at PRESS time, not read at release: an operator who
+    // toggles the Latch box while holding a button must not have the release
+    // reinterpreted underneath them.
+    void talkback_key_pressed(const std::string &target, bool latch);
+    void talkback_key_released(const std::string &target);
     void apply_speaker_director_settings();
     void update_recovery_panel();
     void update_credentials_banner();
@@ -101,6 +119,41 @@ private:
     QComboBox   *m_talkback_participant_combo = nullptr;
     QPushButton *m_talkback_probe_btn         = nullptr;
     QLabel      *m_talkback_status_label      = nullptr;
+
+    // Talkback (Milestone 7): the operator surface proper -- source choice and
+    // its program-track warning, nomination and its budget outcome, and the
+    // key buttons. Dock keying is a deliberate, owner-approved deviation from
+    // the spec, which locked keying to Companion/control API/hotkey and
+    // explicitly not the dock; see src/talkback-dock-state.h.
+    QComboBox   *m_talkback_source_combo   = nullptr;
+    QLabel      *m_talkback_track_label    = nullptr;
+    QListWidget *m_talkback_nominee_list   = nullptr;
+    QPushButton *m_talkback_nominate_btn   = nullptr;
+    QLabel      *m_talkback_plan_label     = nullptr;
+    QWidget     *m_talkback_key_row        = nullptr;
+    QCheckBox   *m_talkback_latch_cb       = nullptr;
+    QLabel      *m_talkback_tally_label    = nullptr;
+    QLabel      *m_talkback_notice        = nullptr;
+    std::vector<QPushButton *> m_talkback_key_buttons;
+    // What the last rebuild of the key buttons was built from. The buttons are
+    // rebuilt only when this changes: the tick runs ten times a second, and
+    // deleting the widget the operator is holding is not a refresh, it is a
+    // lost release (see talkback_dock_release_lost()).
+    std::string m_talkback_key_signature;
+    // Which roster names the nominee list was last built from, for the same
+    // reason -- a rebuild loses the tick-boxes the operator has just set.
+    std::string m_talkback_roster_signature;
+    // The target THIS dock currently has keyed, empty when it has none. A key
+    // opened over the control API is visible in the tally but is not ours to
+    // close, so the dock's own release/backstop paths key off this rather than
+    // off the controller's "open" flag.
+    std::string m_talkback_dock_target;
+    bool        m_talkback_dock_latched = false;
+    // The dock's own last refusal -- one the engine never sees (no source
+    // chosen, the source is not in the current scene, OBS is at a sample rate
+    // the Zoom talkback API will not take, a nominee named "all"). Cleared by
+    // the next attempt that gets past it.
+    QString     m_talkback_notice_text;
 
     // Recovery status panel (shown only while Recovering)
     QFrame      *m_recovery_frame  = nullptr;

--- a/src/zoom-dock.h
+++ b/src/zoom-dock.h
@@ -46,11 +46,14 @@ private:
     void on_cancel_recovery_clicked();
     void update_state_indicator();
     // Milestone 7. Everything the Talkback group polls, driven from the
-    // existing 100ms refresh tick -- deliberately NOT a second timer: this
-    // dock already has three (refresh, health retry, countdown) and the
-    // engine-confirmed talkback state is polled exactly the way
-    // last_error()/roster()/talkback_probe_status() already are.
+    // existing 100ms refresh tick -- deliberately NOT another timer: this dock
+    // already runs four (refresh, health retry, recovery countdown, pending
+    // OAuth join) and the engine-confirmed talkback state is polled exactly
+    // the way last_error()/roster()/talkback_probe_status() already are. The
+    // one piece of work in there that touches libobs's source list is
+    // self-gated to 1Hz and to the dock being visible -- see the function.
     void refresh_talkback();
+    TalkbackDockOpenKey dock_open_key() const;
     void rebuild_talkback_key_buttons(
         const std::vector<TalkbackDockKeyButton> &buttons);
     void on_talkback_nominate_clicked();
@@ -149,6 +152,18 @@ private:
     // off the controller's "open" flag.
     std::string m_talkback_dock_target;
     bool        m_talkback_dock_latched = false;
+    // m2: the source scan (obs_enum_sources + obs_get_source_by_name) is the
+    // only libobs-walking work on this dock's 100ms tick, and obs_enum_sources
+    // holds obs->data.sources_mutex and addref/releases every source for the
+    // walk. Monotonic ms of the last scan; 0 forces one on the next tick. The
+    // rendered result is cached in the two fields below so the label survives
+    // the ticks that skip the scan.
+    uint64_t    m_talkback_source_scan_ms = 0;
+    QString     m_talkback_track_text;
+    bool        m_talkback_track_risk = false;
+    // Logged once, not ten times a second, if the controller's status ever
+    // fails to parse.
+    bool        m_talkback_status_parse_logged = false;
     // The dock's own last refusal -- one the engine never sees (no source
     // chosen, the source is not in the current scene, OBS is at a sample rate
     // the Zoom talkback API will not take, a nominee named "all"). Cleared by

--- a/src/zoom-engine-client.cpp
+++ b/src/zoom-engine-client.cpp
@@ -1390,6 +1390,35 @@ void ZoomEngineClient::handle_event(const std::string &line)
             return;
         }
         blog(LOG_INFO, "[obs-zoom-plugin] talkback_session: %s", line.c_str());
+        // Milestone 7 (the dock): two of these stage lines carry operator-
+        // facing detail the confirmed-state line above does not have, and the
+        // dock has nowhere else to get it. Everything else on this shape stays
+        // log-only, exactly as before.
+        //
+        // "session_live" carries the keyed target's membership
+        // (members_present/members_total, engine-talkback.cpp's
+        // session_start()); the refusal line carries the engine's own recovery
+        // hint ("recover":"re-nominate" for provisioning_incomplete). Both are
+        // emitted BEFORE the report_session_state() line that sets `live`/
+        // `reason` on the same path, so by the time the dock sees a reason the
+        // hint that goes with it is already stored. Ordering is not relied on
+        // for correctness though: talkback_start() clears this whole struct at
+        // the start of every press, so the worst a re-ordering could do is
+        // show a count one line late.
+        const QString stage = obj.value("stage").toString();
+        if (stage == QLatin1String("session_live")) {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            m_talkback_session_status.members_known = true;
+            m_talkback_session_status.members_present =
+                static_cast<uint32_t>(obj.value("members_present").toInt(0));
+            m_talkback_session_status.members_total =
+                static_cast<uint32_t>(obj.value("members_total").toInt(0));
+        } else if (stage == QLatin1String("session_start") &&
+                   obj.contains("recover")) {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            m_talkback_session_status.recover =
+                obj.value("recover").toString().toStdString();
+        }
         return;
     }
     if (cmd == "talkback_nominate") {

--- a/src/zoom-engine-client.h
+++ b/src/zoom-engine-client.h
@@ -50,6 +50,30 @@ public:
     struct TalkbackSessionStatus {
         bool live = false;
         std::string reason;
+
+        // Milestone 7 (the dock). The three fields below come from the OTHER
+        // shape on this cmd -- report_session()'s stage lines -- not from
+        // report_session_state()'s confirmed-state line above, so they are
+        // written by a different branch of handle_event() and can lag or lead
+        // `live` by one line. All three are cleared with the rest of this
+        // struct at talkback_start(), so nothing here can describe a previous
+        // key.
+        //
+        // members_present/members_total are the keyed target's membership AS
+        // OF THE MOMENT THE KEY OPENED: the engine reports them once, in its
+        // "session_live" stage line, and does not re-report them while the key
+        // is held. A talent who rejoins mid-press is therefore not counted
+        // until the next press. members_known distinguishes "0 of 0" from
+        // "no session_live has arrived", which is not the same thing.
+        bool members_known = false;
+        uint32_t members_present = 0;
+        uint32_t members_total = 0;
+        // The engine's own recovery hint for a refusal, echoed rather than
+        // inferred: session_start's refusal line carries
+        // "recover":"re-nominate" for provisioning_incomplete, and nothing at
+        // all for the other reasons. The plugin never invents a remedy the
+        // engine did not name.
+        std::string recover;
     };
 
     // Task 5: the plugin's own record of the last CONFIRMED talkback_nominate()

--- a/src/zoom-settings.cpp
+++ b/src/zoom-settings.cpp
@@ -406,6 +406,11 @@ ZoomPluginSettings ZoomPluginSettings::load()
         s.iso_record_program =
             config_get_int(cfg, SECTION, "IsoRecordProgram") != 0;
 
+    const char *talkback_source = config_get_string(cfg, SECTION, "TalkbackSource");
+    s.talkback_source = talkback_source ? talkback_source : "";
+    if (config_has_user_value(cfg, SECTION, "TalkbackLatch"))
+        s.talkback_latch = config_get_int(cfg, SECTION, "TalkbackLatch") != 0;
+
     const int speaker_sensitivity =
         config_get_int(cfg, SECTION, "SpeakerSensitivityMs");
     if (config_has_user_value(cfg, SECTION, "SpeakerSensitivityMs") &&
@@ -555,6 +560,8 @@ void ZoomPluginSettings::save() const
     config_set_string(cfg, SECTION, "IsoFfmpegPath",          iso_ffmpeg_path.c_str());
     config_set_string(cfg, SECTION, "IsoVideoEncoder",        iso_video_encoder.c_str());
     config_set_int   (cfg, SECTION, "IsoRecordProgram",       iso_record_program ? 1 : 0);
+    config_set_string(cfg, SECTION, "TalkbackSource",        talkback_source.c_str());
+    config_set_int   (cfg, SECTION, "TalkbackLatch",         talkback_latch ? 1 : 0);
     config_set_int   (cfg, SECTION, "SpeakerSensitivityMs",
                       static_cast<int>(speaker_sensitivity_ms));
     config_set_int   (cfg, SECTION, "SpeakerHoldMs",

--- a/src/zoom-settings.h
+++ b/src/zoom-settings.h
@@ -47,6 +47,18 @@ struct ZoomPluginSettings {
     std::string         iso_video_encoder = "auto";
     bool                iso_record_program = true;
 
+    // Talkback dock (Milestone 7). The OBS audio source the director talks
+    // through, stored BY NAME because that is what TalkbackTap::open() and
+    // obs_get_source_by_name() take -- and because a source uuid does not
+    // survive the operator rebuilding their scene collection, which is the
+    // ordinary way a talkback mic gets re-created between shows.
+    std::string         talkback_source;
+    // Latch (tap on, tap off) instead of push-to-talk. Persisted because it
+    // is a per-operator working preference, not a per-show decision -- but a
+    // latch still never survives a reconnect (src/talkback-key.h); this
+    // remembers the MODE, never an open key.
+    bool                talkback_latch = false;
+
     // Active speaker director defaults.
     uint32_t            speaker_sensitivity_ms = 500;
     uint32_t            speaker_hold_ms = 2000;

--- a/tests/talkback-dock-state-test.cpp
+++ b/tests/talkback-dock-state-test.cpp
@@ -61,7 +61,19 @@ static TalkbackDockKeyContext ready_context()
     TalkbackDockKeyContext ctx;
     ctx.engine_running = true;
     ctx.in_meeting = true;
+    ctx.source_chosen = true;
     return ctx;
+}
+
+// A key this dock opened on `target`, in the given mode.
+static TalkbackDockOpenKey dock_key(const std::string &target, bool latched)
+{
+    TalkbackDockOpenKey open;
+    open.open = true;
+    open.dock_owned = true;
+    open.target = target;
+    open.latched = latched;
+    return open;
 }
 
 int main()
@@ -145,18 +157,48 @@ int main()
             check(!b.enabled, "a key button was live outside a meeting");
 
         ctx = ready_context();
-        ctx.key_open = true;
-        ctx.open_target = "Sarah";
+        ctx.open = dock_key("Sarah", /*latched=*/false);
         const auto buttons = talkback_dock_key_buttons(plan, ctx);
         const auto *sarah = find_button(buttons, "Sarah");
         const auto *luis  = find_button(buttons, "Luis");
-        // The held button must stay enabled: disabling a pressed QPushButton
-        // is how its released() signal gets lost, which would strand the key
-        // open. See talkback_dock_release_lost()'s comment.
+        // The held button must stay enabled: it is the operator's only way to
+        // release a latch, and disabling a pressed QPushButton is itself how a
+        // released() signal gets lost. See talkback_dock_release_lost().
         check(sarah && sarah->enabled,
-              "the button for the currently open key was disabled");
+              "the button for the key this dock is holding was disabled");
         check(luis && !luis->enabled,
               "a second key button was live while a key was already open");
+    }
+
+    // m3: a key held by ANOTHER surface. key_on() refuses a second key
+    // unconditionally and the dock's toggle-off cannot apply to a key it does
+    // not own, so every button must refuse -- including the open target's,
+    // which the dock-owned case deliberately leaves live.
+    {
+        const auto plan = confirmed_plan();
+        auto ctx = ready_context();
+        ctx.open = dock_key("Sarah", /*latched=*/false);
+        ctx.open.dock_owned = false;
+        const auto buttons = talkback_dock_key_buttons(plan, ctx);
+        for (const auto &b : buttons) {
+            check(!b.enabled,
+                  "a key button was live while another surface held the key");
+            check(contains(b.reason, "surface"),
+                  "the reason does not say another surface holds the key");
+        }
+    }
+
+    // m4: no talk source chosen. Every press would reach key_on() and be
+    // refused for want of a tap, so say it on the button instead.
+    {
+        const auto plan = confirmed_plan();
+        auto ctx = ready_context();
+        ctx.source_chosen = false;
+        for (const auto &b : talkback_dock_key_buttons(plan, ctx)) {
+            check(!b.enabled, "a key button was live with no talk source");
+            check(contains(b.reason, "source"),
+                  "the reason does not name the missing source");
+        }
     }
 
     // ── The nomination outcome ────────────────────────────────────────────
@@ -320,17 +362,90 @@ int main()
               "the last key's failure reason was dropped once it closed");
     }
 
+    // ── M1: the mode CAPTURED AT THE PRESS governs closing ────────────────
+    //
+    // The Major this round fixes. Latch on, key Sarah, then uncheck Latch and
+    // press Sarah again to close it: the checkbox now says push-to-talk, but
+    // the key that is open is a latch, and only a press can close a latch. If
+    // this decision reads the checkbox instead of the open key, the press
+    // becomes an open attempt, key_on() refuses it as "already open", and the
+    // director stays LIVE to talent with the dock's only close affordance
+    // answering with an error.
+    {
+        const auto held = dock_key("Sarah", /*latched=*/true);
+        check(talkback_dock_press_action(held, "Sarah", /*latch_selected=*/false) ==
+                  TalkbackDockPressAction::CloseHeldKey,
+              "unchecking Latch while a latched key is live made its own button "
+              "stop closing it");
+        check(talkback_dock_press_action(held, "Sarah", /*latch_selected=*/true) ==
+                  TalkbackDockPressAction::CloseHeldKey,
+              "a latched key's own button did not close it");
+        // A different target is still an open attempt (key_on() refuses it, and
+        // the button is disabled anyway) -- never a close of the wrong key.
+        check(talkback_dock_press_action(held, "Luis", false) ==
+                  TalkbackDockPressAction::OpenPushToTalk,
+              "pressing another target closed the latched key");
+    }
+    {
+        // The reverse interleaving: checking Latch while a PTT key is held must
+        // not turn its button into a toggle -- the release is still coming.
+        const auto held = dock_key("Sarah", /*latched=*/false);
+        check(talkback_dock_press_action(held, "Sarah", /*latch_selected=*/true) !=
+                  TalkbackDockPressAction::CloseHeldKey,
+              "a push-to-talk key was treated as a latch because the checkbox "
+              "changed underneath it");
+    }
+    {
+        TalkbackDockOpenKey none;
+        check(talkback_dock_press_action(none, "Sarah", false) ==
+                  TalkbackDockPressAction::OpenPushToTalk,
+              "a press with nothing open did not open push-to-talk");
+        check(talkback_dock_press_action(none, "Sarah", true) ==
+                  TalkbackDockPressAction::OpenLatch,
+              "a press with Latch selected did not open a latch");
+        // A latched key belonging to another surface is not the dock's to
+        // toggle: key_on() will refuse, which is the honest outcome.
+        auto other = dock_key("Sarah", true);
+        other.dock_owned = false;
+        check(talkback_dock_press_action(other, "Sarah", false) !=
+                  TalkbackDockPressAction::CloseHeldKey,
+              "the dock tried to close a key another surface owns");
+    }
+
+    // ── Release ───────────────────────────────────────────────────────────
+    {
+        check(talkback_dock_release_closes(dock_key("Sarah", false), "Sarah"),
+              "releasing a held push-to-talk key did not close it");
+        check(!talkback_dock_release_closes(dock_key("Sarah", true), "Sarah"),
+              "releasing a latch closed it -- a latch is closed by the next "
+              "press");
+        check(!talkback_dock_release_closes(dock_key("Sarah", false), "Luis"),
+              "a release closed a key on a different target");
+        auto other = dock_key("Sarah", false);
+        other.dock_owned = false;
+        check(!talkback_dock_release_closes(other, "Sarah"),
+              "a release closed a key another surface owns");
+        TalkbackDockOpenKey none;
+        check(!talkback_dock_release_closes(none, "Sarah"),
+              "a stray release closed something with nothing open");
+    }
+
     // ── The dock's lost-release backstop ──────────────────────────────────
     {
-        check(talkback_dock_release_lost(true, true, false),
+        check(talkback_dock_release_lost(dock_key("Sarah", false), false),
               "a held PTT key whose button is no longer down was not closed");
-        check(!talkback_dock_release_lost(true, true, true),
+        check(!talkback_dock_release_lost(dock_key("Sarah", false), true),
               "a genuinely held PTT key was closed");
-        check(!talkback_dock_release_lost(true, false, false),
+        check(!talkback_dock_release_lost(dock_key("Sarah", true), false),
               "a latch was closed for not being held -- nothing is held in "
               "latch mode");
-        check(!talkback_dock_release_lost(false, true, false),
+        TalkbackDockOpenKey other = dock_key("Sarah", false);
+        other.dock_owned = false;
+        check(!talkback_dock_release_lost(other, false),
               "a key this dock does not own was closed by the dock");
+        TalkbackDockOpenKey none;
+        check(!talkback_dock_release_lost(none, false),
+              "the backstop fired with no key open at all");
     }
 
     if (failures == 0) std::cout << "talkback-dock-state-test: all checks passed\n";

--- a/tests/talkback-dock-state-test.cpp
+++ b/tests/talkback-dock-state-test.cpp
@@ -1,0 +1,338 @@
+// tests/talkback-dock-state-test.cpp
+//
+// Milestone 7: the decisions the Talkback dock group makes, pinned away from
+// the QWidget that renders them.
+//
+// Every claim in here is one an operator acts on mid-show -- "this button is
+// safe to press", "this person hears nothing", "this source is on air" -- and
+// none of them could be exercised at all while they lived inside dock code
+// that needs libobs, a Qt event loop and a running engine to construct. The
+// two Majors this milestone has already shipped (F1, N1) both lived in
+// exactly that kind of untestable wiring; see
+// src/talkback-nomination-dispatch.h's header comment.
+//
+// The load-bearing one is the FIRST cluster: a button the dock shows as
+// enabled must be one TalkbackController::key_on() would not refuse on the
+// nomination check. The dock delegates to talkback_target_known_unprovisioned()
+// for that instead of re-deriving the rule, and this drives both against the
+// same plans so a re-derivation would show up as a disagreement here.
+#include "talkback-dock-state.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool ok, const char *message)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+static bool contains(const std::string &haystack, const std::string &needle)
+{
+    return haystack.find(needle) != std::string::npos;
+}
+
+static const TalkbackDockKeyButton *find_button(
+    const std::vector<TalkbackDockKeyButton> &buttons, const std::string &target)
+{
+    for (const auto &b : buttons)
+        if (b.target == target) return &b;
+    return nullptr;
+}
+
+// A plan the engine confirmed: Sarah and Luis nominated, both privately
+// covered.
+static TalkbackNominationPlan confirmed_plan()
+{
+    TalkbackNominationPlan p;
+    p.done = true;
+    p.channels = 3;
+    p.requested = {"Sarah", "Luis"};
+    return p;
+}
+
+static TalkbackDockKeyContext ready_context()
+{
+    TalkbackDockKeyContext ctx;
+    ctx.engine_running = true;
+    ctx.in_meeting = true;
+    return ctx;
+}
+
+int main()
+{
+    // ── Buttons agree with key_on()'s own refusal rule ─────────────────────
+    {
+        const auto plan = confirmed_plan();
+        const auto buttons = talkback_dock_key_buttons(plan, ready_context());
+        check(buttons.size() == 3,
+              "expected one All button plus one per nominee");
+        check(buttons.front().target == kTalkbackAllTalentTarget &&
+                  buttons.front().all_talent,
+              "the all-talent button is not first, or is not flagged as such");
+        for (const auto &b : buttons) {
+            const bool known_unprovisioned = talkback_target_known_unprovisioned(
+                b.target, plan.requested, plan.uncovered_private);
+            check(b.enabled == !known_unprovisioned,
+                  "a button's enabled state disagrees with the predicate "
+                  "key_on() refuses on");
+            check(b.enabled == b.reason.empty(),
+                  "a button carries both an enabled state and a refusal reason");
+        }
+    }
+
+    // A nominee with no private channel: the dock must not offer their button,
+    // and must say the thing that actually works instead (key All).
+    {
+        auto plan = confirmed_plan();
+        plan.uncovered_private = {"Luis"};
+        const auto buttons = talkback_dock_key_buttons(plan, ready_context());
+        const auto *luis = find_button(buttons, "Luis");
+        const auto *all  = find_button(buttons, kTalkbackAllTalentTarget);
+        check(luis && !luis->enabled,
+              "a nominee with no private channel was offered a key button");
+        check(luis && contains(luis->reason, "All"),
+              "the uncovered-nominee reason does not name the way that works");
+        check(all && all->enabled,
+              "all-talent was refused even though someone was nominated");
+    }
+
+    // Unreachable is strictly worse than uncovered and must not be described
+    // as "key All instead" -- All does not reach them either.
+    {
+        auto plan = confirmed_plan();
+        plan.uncovered_private = {"Luis"};
+        plan.unreachable = {"Luis"};
+        plan.all_talent_complete = false;
+        const auto buttons = talkback_dock_key_buttons(plan, ready_context());
+        const auto *luis = find_button(buttons, "Luis");
+        check(luis && !luis->enabled, "an unreachable nominee was keyable");
+        check(luis && contains(luis->reason, "no channel"),
+              "the unreachable reason does not say they are on no channel");
+        check(luis && !contains(luis->reason, "key All"),
+              "an unreachable nominee was told to key All, which does not "
+              "reach them either");
+    }
+
+    // Nothing confirmed yet: every target refused, including all-talent --
+    // the same fail-closed state talkback_nomination_reset() leaves behind.
+    {
+        TalkbackNominationPlan empty;
+        const auto buttons = talkback_dock_key_buttons(empty, ready_context());
+        check(buttons.size() == 1, "an unnominated plan produced nominee buttons");
+        check(!buttons.front().enabled,
+              "all-talent was keyable with nothing nominated");
+        check(contains(buttons.front().reason, "nominated"),
+              "the no-nomination reason does not mention nominating");
+    }
+
+    // Engine/meeting preconditions, and the one-key-at-a-time rule.
+    {
+        const auto plan = confirmed_plan();
+        auto ctx = ready_context();
+        ctx.engine_running = false;
+        for (const auto &b : talkback_dock_key_buttons(plan, ctx))
+            check(!b.enabled, "a key button was live with the engine stopped");
+
+        ctx = ready_context();
+        ctx.in_meeting = false;
+        for (const auto &b : talkback_dock_key_buttons(plan, ctx))
+            check(!b.enabled, "a key button was live outside a meeting");
+
+        ctx = ready_context();
+        ctx.key_open = true;
+        ctx.open_target = "Sarah";
+        const auto buttons = talkback_dock_key_buttons(plan, ctx);
+        const auto *sarah = find_button(buttons, "Sarah");
+        const auto *luis  = find_button(buttons, "Luis");
+        // The held button must stay enabled: disabling a pressed QPushButton
+        // is how its released() signal gets lost, which would strand the key
+        // open. See talkback_dock_release_lost()'s comment.
+        check(sarah && sarah->enabled,
+              "the button for the currently open key was disabled");
+        check(luis && !luis->enabled,
+              "a second key button was live while a key was already open");
+    }
+
+    // ── The nomination outcome ────────────────────────────────────────────
+    {
+        auto plan = confirmed_plan();
+        plan.channels = 3;
+        const auto report = talkback_dock_nomination_report(plan);
+        check(!report.warn, "a fully covered nomination was reported as a problem");
+        check(contains(report.headline, "3 channels"),
+              "the headline does not report the channel count");
+        check(contains(report.headline, "16"),
+              "the headline does not report the channel budget");
+        check(contains(report.headline, "2 nominees"),
+              "the headline does not report the nominee count");
+        bool named_both = false;
+        for (const auto &line : report.lines)
+            if (contains(line, "Sarah") && contains(line, "Luis")) named_both = true;
+        check(named_both, "the private-channel line does not name who has one");
+    }
+
+    // Shortfalls are NAMED. This is the reporting chain's whole purpose: a
+    // count tells the operator that someone is short, not who.
+    {
+        auto plan = confirmed_plan();
+        plan.requested = {"Sarah", "Luis", "Dana"};
+        plan.uncovered_private = {"Dana"};
+        const auto report = talkback_dock_nomination_report(plan);
+        check(report.warn, "a nomination with a shortfall was not flagged");
+        bool named = false;
+        for (const auto &line : report.lines)
+            if (contains(line, "Dana") && contains(line, "All")) named = true;
+        check(named, "the uncovered nominee was not named with their remedy");
+    }
+    {
+        auto plan = confirmed_plan();
+        plan.requested = {"Sarah", "Luis", "Dana"};
+        plan.uncovered_private = {"Dana"};
+        plan.unreachable = {"Dana"};
+        plan.all_talent_complete = false;
+        const auto report = talkback_dock_nomination_report(plan);
+        check(report.warn, "an unreachable nominee was not flagged");
+        bool hears_nothing = false, fanout = false;
+        for (const auto &line : report.lines) {
+            if (contains(line, "Dana") && contains(line, "hear nothing"))
+                hears_nothing = true;
+            if (contains(line, "All talent does not reach everyone"))
+                fanout = true;
+        }
+        check(hears_nothing,
+              "an unreachable nominee was not reported as hearing nothing");
+        check(fanout, "an incomplete all-talent fan-out was not reported");
+    }
+
+    // A refused attempt is diagnostic: it must be SHOWN, and it must not
+    // erase the standing plan's own report (F1's symptom, at the UI).
+    {
+        auto plan = confirmed_plan();
+        talkback_nomination_note_refused(plan, "create_busy");
+        const auto report = talkback_dock_nomination_report(plan);
+        check(report.warn, "a refused nominate attempt was not flagged");
+        bool refused_line = false;
+        for (const auto &line : report.lines)
+            if (contains(line, "create_busy")) refused_line = true;
+        check(refused_line, "the refusal reason was not shown");
+        check(contains(report.headline, "3 channels"),
+              "a refused attempt erased the standing plan from the report");
+    }
+
+    // A ladder that aborted after destroying the standing set, and a
+    // superseded one, both reset `done` while keeping the reason. The report
+    // must show that as "no channels, and here is why", never as silence.
+    {
+        TalkbackNominationPlan plan = confirmed_plan();
+        talkback_nomination_note_failed_after_destroy(plan, "create_rate_limited");
+        const auto report = talkback_dock_nomination_report(plan);
+        check(contains(report.headline, "No talkback channels"),
+              "a destroyed channel set was still reported as provisioned");
+        bool why = false;
+        for (const auto &line : report.lines)
+            if (contains(line, "create_rate_limited")) why = true;
+        check(why, "a destroyed channel set was reported with no reason");
+    }
+
+    // ── The program-track warning ─────────────────────────────────────────
+    {
+        const auto w = talkback_dock_track_warning("Talkback Mic", 0);
+        check(!w.on_air_risk, "a source on no track was flagged as on air");
+        check(w.tracks.empty(), "a source on no track listed tracks");
+        check(contains(w.text, "dedicated"),
+              "the safe-pattern text does not name the safe pattern");
+    }
+    {
+        // Tracks 1 and 3 (bits 0 and 2) -- 1-based numbering, as OBS's
+        // Advanced Audio Properties shows them.
+        const auto w = talkback_dock_track_warning("Host Mic", 0b101u);
+        check(w.on_air_risk, "a source on program tracks was not flagged");
+        check(w.tracks == "1, 3",
+              "the enabled tracks were not listed as OBS numbers them");
+        check(contains(w.text, "Host Mic") && contains(w.text, "1, 3"),
+              "the warning names neither the source nor its tracks");
+    }
+    {
+        const auto w = talkback_dock_track_warning("", 0);
+        check(!w.on_air_risk, "no chosen source was flagged as on air");
+        check(contains(w.text, "No talkback source"),
+              "an unchosen source did not say so");
+    }
+
+    // ── Live tally ────────────────────────────────────────────────────────
+    // The tally follows the ENGINE's confirmed state, never the plugin's
+    // intent -- the spec's own requirement, and the F2 Critical that made it
+    // one.
+    {
+        TalkbackDockSessionView s;
+        s.key_open = true;
+        s.target = "Sarah";
+        const auto t = talkback_dock_tally(s);
+        check(!t.live, "an unconfirmed key was shown as live");
+        check(!t.alert, "waiting for confirmation was shown as a failure");
+        check(contains(t.text, "waiting"), "a pending key did not say so");
+    }
+    {
+        TalkbackDockSessionView s;
+        s.key_open = true;
+        s.target = "Sarah";
+        s.engine_live = true;
+        s.members_known = true;
+        s.members_present = 2;
+        s.members_total = 3;
+        const auto t = talkback_dock_tally(s);
+        check(t.live, "a confirmed key was not shown as live");
+        check(contains(t.text, "Sarah"), "the live tally does not name the target");
+        check(contains(t.text, "2 of 3 present"),
+              "the live tally does not report membership");
+    }
+    {
+        // Refused mid-ladder: the engine's own recovery hint is echoed, not
+        // inferred -- the plugin never invents a remedy the engine did not
+        // name.
+        TalkbackDockSessionView s;
+        s.key_open = true;
+        s.target = "Sarah";
+        s.engine_reason = "provisioning_incomplete";
+        s.engine_recover = "re-nominate";
+        const auto t = talkback_dock_tally(s);
+        check(!t.live, "a refused key was shown as live");
+        check(t.alert, "a refused key was not flagged");
+        check(contains(t.text, "provisioning_incomplete"),
+              "the refusal reason was not shown");
+        check(contains(t.text, "re-nominate"),
+              "the engine's recovery hint was not surfaced");
+    }
+    {
+        // A closed key keeps the last verdict visible, said as history.
+        TalkbackDockSessionView s;
+        s.engine_reason = "channels_destroyed";
+        const auto t = talkback_dock_tally(s);
+        check(!t.live, "a closed key was shown as live");
+        check(contains(t.text, "Not keyed"), "a closed key did not say so");
+        check(contains(t.text, "channels_destroyed"),
+              "the last key's failure reason was dropped once it closed");
+    }
+
+    // ── The dock's lost-release backstop ──────────────────────────────────
+    {
+        check(talkback_dock_release_lost(true, true, false),
+              "a held PTT key whose button is no longer down was not closed");
+        check(!talkback_dock_release_lost(true, true, true),
+              "a genuinely held PTT key was closed");
+        check(!talkback_dock_release_lost(true, false, false),
+              "a latch was closed for not being held -- nothing is held in "
+              "latch mode");
+        check(!talkback_dock_release_lost(false, true, false),
+              "a key this dock does not own was closed by the dock");
+    }
+
+    if (failures == 0) std::cout << "talkback-dock-state-test: all checks passed\n";
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The first in-OBS surface for talkback, in the Zoom Control dock: a talk-source picker with the program-track leak warning (the deferred M7 half of the leak guarantee), checkbox-roster nomination with the honest budget report (who has a private channel, who is uncovered, who is unreachable — named, never counted), PTT + latch key buttons per confirmed nominee plus All-talent, and a tally that follows engine-confirmed state only.

Keying from the dock is a recorded owner-approved deviation from the spec's surface list (spec locked keying to Companion/control API/hotkey).

Reviewed + one fix round: the open key is one record (`TalkbackDockOpenKey`) read by all three dock-side decisions, so unchecking Latch can never strand a live key (the review's one Major — mutation-proved closed along with four others). Source scan gated on visibility at 1 Hz; buttons refuse with reasons when a key is held elsewhere or no source is chosen.

Suite 68/68 (new `CoreVideoTalkbackDockState` target). Not yet driven in a live meeting — that's the next session's first click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159FnPY9jGzKDF75y39WVxc