### PR TITLE
docs: Zoom SDK feature adoption plans (2026-08-29)

### DIFF
--- a/docs/superpowers/plans/2026-08-29-captions-transcription.md
+++ b/docs/superpowers/plans/2026-08-29-captions-transcription.md
@@ -1,0 +1,1173 @@
+# Zoom Live Transcription — Captions Integration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Subscribe to Zoom live transcription in the engine and deliver a per-speaker caption stream (speaker name + text + timestamps) to the plugin, where it drives an operator-named OBS text source, is pollable over the control API, and lands in a sidecar transcript log time-aligned to the ISO recorder's clock.
+
+**Architecture:** The engine acquires `IClosedCaptionController` via `IMeetingService::GetMeetingClosedCaptionController()` (`third_party/zoom-sdk/h/meeting_service_interface.h:1234`), registers an `IClosedCaptionControllerEvent` sink, and forwards every `onLiveTranscriptionMsgInfoReceived` message as one `{"cmd":"caption",...}` line over the existing E2P pipe. Captions are control-rate (a few lines per second at most), so they ride the ordered control path on the pipe reader thread — the `src/media-event-queue.h` lanes are for media only and are not touched. The plugin coalesces partial/final messages per speaker in a pure header-only state machine, updates the caption text source, and — when ISO recording is active — appends finalized lines to one transcript file anchored to the same `os_gettime_ns()` clock every ISO session anchors to.
+
+**Tech Stack:** C++17, Zoom Windows Meeting SDK 7.1.5.43953, CMake + CTest, named-pipe line-JSON IPC, Qt6.
+
+**Spec:** There is no separate spec — this document doubles as the spec. Requirements:
+
+- Engine can start and stop Zoom live transcription on command, and reports every gate it passes or falls off (support, permission, status) as its own stage line — surface gating, never swallow it.
+- Every live transcription message reaches the plugin with speaker name, speaker id, text, operation type, and the SDK's timestamp — plus a plugin-side arrival timestamp on the ISO clock.
+- Partial (`Add`/`Update`) vs final (`Complete`) messages are coalesced per speaker; `Delete` retracts.
+- The operator names an OBS text source (any text source — lower-third scenes just reference it); the plugin keeps it showing the latest caption line as `Name: text`.
+- `captions_status` on the control API returns transcription status and the latest line per speaker.
+- While ISO recording is active, finalized lines are appended to `<output_dir>/transcript-<stamp>.txt`, offsets computed against a recording-start anchor on the same `os_gettime_ns()` clock the ISO sessions use.
+- A repo-wide grep for `closedcaption|caption|transcri` confirms **no existing caption or transcription code exists in `src/` or `engine/src/`** — the only hits are site HTML, talkback docs, and an unrelated test comment. This is a greenfield feature; nothing is being extended or migrated.
+
+**SDK ground truth and one gap, planned around:** everything needed exists in the tracked header `third_party/zoom-sdk/h/meeting_closedcaption_interface.h` — `IClosedCaptionController`, `IClosedCaptionControllerEvent`, `ILiveTranscriptionMessageInfo`, `SDKLiveTranscriptionStatus`, `SDKLiveTranscriptionOperationType`. Unlike talkback's `meeting_service_components/meeting_talkback_ctrl_interface.h` (which only the full-SDK drop supplies, hence the `EXISTS` gate at `CMakeLists.txt:1168`), this header lives in the tracked `h/` root, so **no new `EXISTS` gate is needed**; the engine target's existing SDK-present gate (`CMakeLists.txt:224`) covers it. The gap: `ILiveTranscriptionMessageInfo::GetTimeStamp()` returns `time_t` — whole seconds, epoch basis undocumented. That is useless for aligning to millisecond-accurate ISO recordings, so the wire carries it as `ts` for the record, but **all alignment uses the plugin's arrival `os_gettime_ns()`**, the exact clock `record_video_frame`/`record_audio_frame` timestamps already use. Caption latency (Zoom's ASR runs ~1–3 s behind speech) dominates either way; the transcript documents this in its header line.
+
+## Global Constraints
+
+- Build: `cmake --build build --config Release --parallel 8`. Test: `cd build && ctest -C Release --output-on-failure` — must be N/N green after every task.
+- Tests are plain executables, no framework, `check()`-style, one file per invariant cluster in `tests/`, registered in `CMakeLists.txt` with `add_executable` + `add_test`.
+- Comments state the constraint the code cannot show. When a change is motivated by a live failure, say what happened, with numbers.
+- Participants are addressed by **display name**; never persist a Zoom user id — they are meeting-scoped and get recycled. The wire may carry `speaker_id` for correlation within one meeting, but every table the plugin keeps is keyed by name.
+- Control events stay ordered on the pipe reader thread. Captions are control-rate: they take the ordered path in `ZoomEngineClient::handle_event`, never a media lane.
+- SDK calls initiated by us (`StartLiveTranscription` etc.) run on the engine's command-loop thread, like every other command branch. SDK callbacks arrive on SDK threads and may only build strings and call the serialised `EngineIpc::write` (`engine/src/engine-writer.h`).
+- Never run a second OBS instance while one is testing (pipe/SDK singleton collision, crash loop). Send `{"cmd":"leave"}` before closing OBS.
+- Pure logic is header-only and Qt/OBS/SDK-free so plain-executable tests can pin it (repo pattern: `src/talkback-plan.h`, `src/talkback-nomination.h`).
+
+---
+
+### Task 1: Route the `captions_start` / `captions_stop` commands
+
+The engine identifies commands by exact match on the declared `cmd` field (`src/engine-command.h`), never by substring — a substring dispatch once routed every `unsubscribe` into the `subscribe` branch. Two commands, not one with a boolean payload, matching the `start_media`/`stop_media` shape: the routing test can then pin each token independently.
+
+**Files:**
+- Modify: `src/engine-ipc.h:26` (add tokens after `IPC_CMD_TALKBACK_NOMINATE`)
+- Modify: `src/engine-command.h:49` (enum, after `TalkbackNominate,`), `src/engine-command.h:104` (routing, before `return IpcCommand::Unknown;`)
+- Test: `tests/engine-command-test.cpp`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `IPC_CMD_CAPTIONS_START` (`"captions_start"`), `IPC_CMD_CAPTIONS_STOP` (`"captions_stop"`), `IpcCommand::CaptionsStart`, `IpcCommand::CaptionsStop`. Task 4 branches on the enums; Task 5 emits the literals.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `tests/engine-command-test.cpp`, before the final `if (failures == 0)` block:
+
+```cpp
+    // --- Captions commands route exactly, and do not collide ---
+    check(ipc_command_of(R"({"cmd":"captions_start"})") == IpcCommand::CaptionsStart,
+          "captions_start did not route to IpcCommand::CaptionsStart");
+    check(ipc_command_of(R"({"cmd":"captions_stop"})") == IpcCommand::CaptionsStop,
+          "captions_stop did not route to IpcCommand::CaptionsStop");
+    // A payload containing the token must not route (the substring disease).
+    check(ipc_command_of(R"({"cmd":"join","display_name":"captions_start"})") ==
+              IpcCommand::Join,
+          "a payload containing 'captions_start' hijacked the join branch");
+    check(ipc_command_of(R"({"cmd":"captions_startx"})") == IpcCommand::Unknown,
+          "a longer command starting with captions_start matched it");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cmake --build build --config Release --target CoreVideoEngineCommandTest --parallel 8
+```
+
+Expected: FAIL to compile with `'CaptionsStart' is not a member of 'IpcCommand'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/engine-ipc.h`, after the `IPC_CMD_TALKBACK_NOMINATE` line:
+
+```c
+#define IPC_CMD_CAPTIONS_START "captions_start"
+#define IPC_CMD_CAPTIONS_STOP  "captions_stop"
+```
+
+In `src/engine-command.h`, add to the enum after `TalkbackNominate,`:
+
+```cpp
+    CaptionsStart,
+    CaptionsStop,
+```
+
+and to `ipc_command_of`, before `return IpcCommand::Unknown;`:
+
+```cpp
+    if (cmd == IPC_CMD_CAPTIONS_START) return IpcCommand::CaptionsStart;
+    if (cmd == IPC_CMD_CAPTIONS_STOP)  return IpcCommand::CaptionsStop;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --target CoreVideoEngineCommandTest --parallel 8
+cd build && ctest -C Release -R CoreVideoEngineCommand --output-on-failure
+```
+
+Expected: PASS, `engine-command: all tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/engine-ipc.h src/engine-command.h tests/engine-command-test.cpp
+git commit -m "feat(captions): route the captions_start/captions_stop commands"
+```
+
+---
+
+### Task 2: Caption coalescing state machine
+
+Zoom does not send finished sentences. One utterance arrives as `Add`, then a burst of `Update`s rewriting the same message id, then `Complete` — and sometimes `Delete`, or no `Complete` at all before the speaker's next utterance starts. Something has to decide what "the current caption line" is and when a line is *final* enough for a transcript, and that decision must be pinnable without an engine or a meeting. This is the feature's `talkback-plan.h`: pure, header-only, no Qt/OBS/SDK.
+
+**Files:**
+- Create: `src/caption-stream.h`
+- Test: `tests/caption-stream-test.cpp`
+- Modify: `CMakeLists.txt` (register after the `CoreVideoTileRetry` block, `CMakeLists.txt:1320-1330`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (all in `src/caption-stream.h`; Task 5 feeds `apply()` and reads `latest()`/`display_line()`, Task 6 consumes the returned finals):
+
+```cpp
+enum class CaptionOp { None = 0, Add = 1, Update = 2, Delete = 3, Complete = 4, NotSupported = 5 };
+struct CaptionEvent { std::string msg_id; std::string speaker; uint32_t speaker_id;
+                      std::string text; CaptionOp op; uint64_t arrival_ns; };
+struct CaptionFinal { std::string speaker; std::string text; uint64_t first_seen_ns; };
+class CaptionStream {
+public:
+    std::vector<CaptionFinal> apply(const CaptionEvent &ev);
+    const std::map<std::string, std::string> &latest() const; // speaker -> line
+    std::string display_line() const;                         // "Name: text" or ""
+    void clear();
+};
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/caption-stream-test.cpp`:
+
+```cpp
+// tests/caption-stream-test.cpp
+// Pins the coalescing rules for Zoom live transcription messages. The rule
+// that earns its test: an utterance that never receives Complete must still
+// reach the transcript when its speaker's NEXT utterance begins — otherwise a
+// dropped Complete silently deletes a sentence from the record.
+#include "caption-stream.h"
+#include <iostream>
+
+static int failures = 0;
+static void check(bool ok, const char *message)
+{
+    if (!ok) { std::cerr << "FAIL: " << message << "\n"; ++failures; }
+}
+
+static CaptionEvent ev(const char *id, const char *who, const char *text,
+                       CaptionOp op, uint64_t ns)
+{
+    return CaptionEvent{id, who, 7u, text, op, ns};
+}
+
+int main()
+{
+    CaptionStream s;
+
+    // --- Add then Update rewrites the same line; nothing finalizes yet ---
+    check(s.apply(ev("m1", "Ada", "hel", CaptionOp::Add, 100)).empty(),
+          "Add finalized a line prematurely");
+    check(s.apply(ev("m1", "Ada", "hello there", CaptionOp::Update, 200)).empty(),
+          "Update finalized a line prematurely");
+    check(s.display_line() == "Ada: hello there",
+          "display_line did not show the updated partial");
+
+    // --- Complete finalizes with the FIRST arrival ns (utterance start) ---
+    auto f = s.apply(ev("m1", "Ada", "hello there.", CaptionOp::Complete, 300));
+    check(f.size() == 1 && f[0].text == "hello there." && f[0].speaker == "Ada",
+          "Complete did not finalize the coalesced text");
+    check(!f.empty() && f[0].first_seen_ns == 100,
+          "finalized line lost the utterance-START timestamp; alignment to the "
+          "recording needs when speech began, not when ASR finished");
+
+    // --- A never-Completed utterance finalizes when the same speaker Adds a new id ---
+    s.apply(ev("m2", "Ada", "lost sentence", CaptionOp::Add, 400));
+    auto g = s.apply(ev("m3", "Ada", "next", CaptionOp::Add, 500));
+    check(g.size() == 1 && g[0].text == "lost sentence",
+          "an utterance with no Complete vanished when the next one started");
+
+    // --- Delete retracts: no final, and the speaker's latest line is cleared ---
+    s.apply(ev("m3", "Ada", "oops", CaptionOp::Update, 600));
+    auto h = s.apply(ev("m3", "Ada", "", CaptionOp::Delete, 700));
+    check(h.empty(), "Delete produced a finalized line");
+    check(s.latest().find("Ada") == s.latest().end() ||
+              s.latest().at("Ada").empty(),
+          "Delete left the retracted text on the speaker's latest line");
+
+    // --- An Update for an unseen id behaves as Add (plugin attached mid-utterance) ---
+    auto i = s.apply(ev("m9", "Grace", "mid join", CaptionOp::Update, 800));
+    check(i.empty() && s.display_line() == "Grace: mid join",
+          "an Update for an unknown message id was dropped instead of adopted");
+
+    // --- A Complete for an unseen id still reaches the transcript ---
+    auto j = s.apply(ev("mX", "Ada", "orphan final.", CaptionOp::Complete, 900));
+    check(j.size() == 1 && j[0].text == "orphan final." && j[0].first_seen_ns == 900,
+          "a Complete with no prior Add was dropped");
+
+    // --- clear() empties everything (meeting boundary) ---
+    s.clear();
+    check(s.latest().empty() && s.display_line().empty(),
+          "clear() left state from the previous meeting");
+
+    if (failures == 0) std::cout << "caption-stream: all tests passed\n";
+    return failures == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Add to `CMakeLists.txt` immediately after the `add_test(NAME CoreVideoTileRetry ...)` block:
+
+```cmake
+    # Caption coalescing (Zoom live transcription Add/Update/Delete/Complete).
+    # Pure logic, no Qt/OBS/SDK — see src/caption-stream.h.
+    add_executable(CoreVideoCaptionStreamTest
+        tests/caption-stream-test.cpp
+    )
+    target_include_directories(CoreVideoCaptionStreamTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoCaptionStream
+             COMMAND CoreVideoCaptionStreamTest)
+```
+
+Then:
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target CoreVideoCaptionStreamTest --parallel 8
+```
+
+Expected: FAIL — `Cannot open include file: 'caption-stream.h'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/caption-stream.h`:
+
+```cpp
+#pragma once
+//
+// caption-stream.h — coalesces Zoom live transcription messages into lines.
+//
+// Zoom delivers one utterance as Add, a burst of Updates rewriting the same
+// message id, then (usually) Complete. "Usually" is the point of this file:
+// a Complete can simply not arrive, and a coalescer that only finalizes on
+// Complete silently deletes that sentence from the transcript. The fallback
+// rule — finalize a speaker's pending utterance when their NEXT one begins —
+// is what the test pins hardest.
+//
+// Values of CaptionOp mirror SDKLiveTranscriptionOperationType from
+// meeting_closedcaption_interface.h numerically (None=0 .. NotSupported=5),
+// so the engine can send the raw enum and the plugin static_casts it.
+//
+// Keyed by message id for coalescing, by speaker NAME for the latest-line
+// view: user ids are meeting-scoped and never persisted (project rule).
+// Free of Qt/OBS/SDK so a plain executable can pin it.
+//
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+enum class CaptionOp { None = 0, Add = 1, Update = 2, Delete = 3, Complete = 4, NotSupported = 5 };
+
+struct CaptionEvent {
+    std::string msg_id;
+    std::string speaker;
+    uint32_t speaker_id = 0;   // wire correlation only; never stored past apply()
+    std::string text;
+    CaptionOp op = CaptionOp::None;
+    uint64_t arrival_ns = 0;   // plugin-side os_gettime_ns() at pipe arrival
+};
+
+struct CaptionFinal {
+    std::string speaker;
+    std::string text;
+    uint64_t first_seen_ns = 0; // arrival of the utterance's FIRST message
+};
+
+class CaptionStream {
+public:
+    // Feeds one wire event; returns every line this event finalized (0..2:
+    // a stale pending flushed by a new Add, plus this event's own Complete).
+    std::vector<CaptionFinal> apply(const CaptionEvent &ev)
+    {
+        std::vector<CaptionFinal> out;
+        if (ev.op == CaptionOp::Delete) {
+            m_pending.erase(ev.msg_id);
+            m_latest.erase(ev.speaker);
+            return out;
+        }
+        if (ev.op == CaptionOp::Complete) {
+            auto it = m_pending.find(ev.msg_id);
+            const uint64_t first =
+                it != m_pending.end() ? it->second.first_seen_ns : ev.arrival_ns;
+            m_pending.erase(ev.msg_id);
+            if (!ev.text.empty()) {
+                out.push_back({ev.speaker, ev.text, first});
+                m_latest[ev.speaker] = ev.text;
+                m_display_speaker = ev.speaker;
+            }
+            return out;
+        }
+        if (ev.op != CaptionOp::Add && ev.op != CaptionOp::Update)
+            return out; // None / NotSupported carry no text worth acting on
+
+        // A new Add while the same speaker has a DIFFERENT utterance pending
+        // means its Complete was lost: flush it now or lose it forever.
+        if (ev.op == CaptionOp::Add) {
+            for (auto it = m_pending.begin(); it != m_pending.end();) {
+                if (it->second.speaker == ev.speaker && it->first != ev.msg_id) {
+                    if (!it->second.text.empty())
+                        out.push_back({it->second.speaker, it->second.text,
+                                       it->second.first_seen_ns});
+                    it = m_pending.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+        auto [it, inserted] = m_pending.try_emplace(
+            ev.msg_id, Pending{ev.speaker, ev.text, ev.arrival_ns});
+        if (!inserted)
+            it->second.text = ev.text; // Update: rewrite, keep first_seen_ns
+        m_latest[ev.speaker] = ev.text;
+        m_display_speaker = ev.speaker;
+
+        // Bound the pending table: a peer that streams Adds without ever
+        // completing them must not grow memory without limit. 64 concurrent
+        // half-finished utterances is far past any real meeting.
+        while (m_pending.size() > 64) {
+            auto oldest = m_pending.begin();
+            for (auto p = m_pending.begin(); p != m_pending.end(); ++p)
+                if (p->second.first_seen_ns < oldest->second.first_seen_ns)
+                    oldest = p;
+            if (!oldest->second.text.empty())
+                out.push_back({oldest->second.speaker, oldest->second.text,
+                               oldest->second.first_seen_ns});
+            m_pending.erase(oldest);
+        }
+        return out;
+    }
+
+    const std::map<std::string, std::string> &latest() const { return m_latest; }
+
+    // The line the OBS text source shows: the most recently active speaker.
+    std::string display_line() const
+    {
+        auto it = m_latest.find(m_display_speaker);
+        if (it == m_latest.end() || it->second.empty()) return {};
+        return m_display_speaker + ": " + it->second;
+    }
+
+    void clear()
+    {
+        m_pending.clear();
+        m_latest.clear();
+        m_display_speaker.clear();
+    }
+
+private:
+    struct Pending {
+        std::string speaker;
+        std::string text;
+        uint64_t first_seen_ns = 0;
+    };
+    std::map<std::string, Pending> m_pending;      // by msg_id
+    std::map<std::string, std::string> m_latest;   // by speaker name
+    std::string m_display_speaker;
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --target CoreVideoCaptionStreamTest --parallel 8
+cd build && ctest -C Release -R CoreVideoCaptionStream --output-on-failure
+```
+
+Expected: PASS, `caption-stream: all tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/caption-stream.h tests/caption-stream-test.cpp CMakeLists.txt
+git commit -m "feat(captions): caption coalescing state machine with lost-Complete flush"
+```
+
+---
+
+### Task 3: Transcript line formatter
+
+The sidecar log's whole value is that its timestamps mean something against the ISO files. Every ISO session anchors `started_ns` to `os_gettime_ns()` (`src/zoom-iso-recorder.cpp:491`), so a transcript line's offset from a recording-start anchor on the same clock is directly comparable. The formatting is trivial; the clamp is not — a caption whose utterance began *before* the recording started must clamp to 00:00:00.000, because unsigned subtraction of a later anchor wraps to a ~584-year offset.
+
+**Files:**
+- Create: `src/caption-transcript-log.h`
+- Test: `tests/caption-transcript-log-test.cpp`
+- Modify: `CMakeLists.txt` (register after the `CoreVideoCaptionStream` block from Task 2)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `std::string caption_transcript_line(uint64_t anchor_ns, uint64_t event_ns, const std::string &speaker, const std::string &text)` — Task 6 calls it once per `CaptionFinal`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/caption-transcript-log-test.cpp`:
+
+```cpp
+// tests/caption-transcript-log-test.cpp
+// Pins the sidecar transcript's line format and the pre-anchor clamp: an
+// utterance that began before the recording did must read 00:00:00.000, not
+// wrap uint64 into a ~584-year offset.
+#include "caption-transcript-log.h"
+#include <iostream>
+
+static int failures = 0;
+static void check(bool ok, const char *message)
+{
+    if (!ok) { std::cerr << "FAIL: " << message << "\n"; ++failures; }
+}
+
+int main()
+{
+    // 1h 2m 3s 456ms after the anchor.
+    const uint64_t anchor = 1000000000ull;
+    const uint64_t at = anchor + ((3600ull + 120ull + 3ull) * 1000ull + 456ull) * 1000000ull;
+    check(caption_transcript_line(anchor, at, "Ada", "hello.") ==
+              "[01:02:03.456] Ada: hello.\n",
+          "line format changed — downstream alignment tooling parses this shape");
+
+    // --- Pre-anchor clamps to zero instead of wrapping ---
+    check(caption_transcript_line(anchor, anchor - 5, "Ada", "early") ==
+              "[00:00:00.000] Ada: early\n",
+          "a caption from before the recording start wrapped instead of clamping");
+
+    // --- Embedded newlines flatten: one caption is always exactly one line ---
+    check(caption_transcript_line(anchor, anchor, "Ada", "a\r\nb\nc") ==
+              "[00:00:00.000] Ada: a b c\n",
+          "an embedded newline split one caption across transcript lines");
+
+    if (failures == 0) std::cout << "caption-transcript-log: all tests passed\n";
+    return failures == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Register in `CMakeLists.txt` after the `CoreVideoCaptionStream` block:
+
+```cmake
+    # Sidecar transcript formatting. The clamp is the invariant: unsigned
+    # pre-anchor subtraction wraps to a ~584-year offset.
+    add_executable(CoreVideoCaptionTranscriptLogTest
+        tests/caption-transcript-log-test.cpp
+    )
+    target_include_directories(CoreVideoCaptionTranscriptLogTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoCaptionTranscriptLog
+             COMMAND CoreVideoCaptionTranscriptLogTest)
+```
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target CoreVideoCaptionTranscriptLogTest --parallel 8
+```
+
+Expected: FAIL — `Cannot open include file: 'caption-transcript-log.h'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/caption-transcript-log.h`:
+
+```cpp
+#pragma once
+//
+// caption-transcript-log.h — one finalized caption as one transcript line.
+//
+// Offsets are (event_ns - anchor_ns) on the os_gettime_ns() clock — the SAME
+// clock every ISO session's started_ns uses (src/zoom-iso-recorder.cpp:491),
+// which is the entire alignment story. The SDK's own GetTimeStamp() is time_t
+// seconds with an undocumented basis and is deliberately not used here.
+// Free of Qt/OBS/SDK so a plain executable can pin it.
+//
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+inline std::string caption_transcript_line(uint64_t anchor_ns,
+                                           uint64_t event_ns,
+                                           const std::string &speaker,
+                                           const std::string &text)
+{
+    // Clamp, never wrap: captions can predate the recording start (the
+    // utterance began, then the operator hit record).
+    const uint64_t off_ms =
+        event_ns > anchor_ns ? (event_ns - anchor_ns) / 1000000ull : 0ull;
+    const unsigned hours = static_cast<unsigned>(off_ms / 3600000ull);
+    const unsigned mins  = static_cast<unsigned>((off_ms / 60000ull) % 60ull);
+    const unsigned secs  = static_cast<unsigned>((off_ms / 1000ull) % 60ull);
+    const unsigned ms    = static_cast<unsigned>(off_ms % 1000ull);
+
+    char stamp[24];
+    std::snprintf(stamp, sizeof(stamp), "[%02u:%02u:%02u.%03u] ",
+                  hours, mins, secs, ms);
+
+    // One caption is one line, whatever the ASR put in the text. \r\n first
+    // so it flattens to one space, not two.
+    std::string flat = text;
+    std::size_t pos;
+    while ((pos = flat.find("\r\n")) != std::string::npos)
+        flat.replace(pos, 2, " ");
+    for (char &c : flat)
+        if (c == '\n' || c == '\r' || c == '\t') c = ' ';
+
+    return std::string(stamp) + speaker + ": " + flat + "\n";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --target CoreVideoCaptionTranscriptLogTest --parallel 8
+cd build && ctest -C Release -R CoreVideoCaptionTranscriptLog --output-on-failure
+```
+
+Expected: PASS, `caption-transcript-log: all tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/caption-transcript-log.h tests/caption-transcript-log-test.cpp CMakeLists.txt
+git commit -m "feat(captions): transcript line formatter anchored to the ISO clock"
+```
+
+---
+
+### Task 4: Engine — `EngineCaptions` controller, event sink, and the caption wire
+
+The engine side. `IClosedCaptionController` is acquired the way every other controller is: in `EngineMeetingEvent::onMeetingStatusChanged`'s `MEETING_STATUS_INMEETING` case (`engine/src/main.cpp:1007-1031`, beside `m_participants->attach` and `m_share_engine->attach`), detached on `DISCONNECTING`/`ENDED`. Start/stop run on the command-loop thread; message callbacks arrive on SDK threads and only build a line and call `EngineIpc::write` — which is exactly what `engine/src/engine-writer.h` exists to make safe. Messages are forwarded whenever the sink is attached, not only when *we* started transcription: the host starting captions from the Zoom client must light up our stream too.
+
+No unit test — SDK-bound; verification is Task 7's live pass, the same ruling as talkback Milestone 1 Tasks 3–4. The compile is the check at this stage.
+
+**Files:**
+- Create: `engine/src/engine-captions.h`, `engine/src/engine-captions.cpp`
+- Modify: `engine/src/main.cpp` (EngineMeetingEvent member + attach/detach at `:1007-1031`; `static EngineCaptions captions;` beside `static EngineTalkback talkback;` at `:1290`; command branches beside `IpcCommand::TalkbackNominate` at `:1664`)
+- Modify: `CMakeLists.txt:391-396` (add `engine/src/engine-captions.cpp` to `ENGINE_SOURCES`)
+
+**Interfaces:**
+- Consumes: `IpcCommand::CaptionsStart` / `CaptionsStop` (Task 1); `EngineIpc::write` (`engine/src/engine-writer.h`); `json_escape`/`zchar_to_utf8` (`engine/src/engine-json.h`).
+- Produces: `class EngineCaptions` with `void attach(ZOOMSDK::IClosedCaptionController *ctrl)`, `void detach()`, `void start()`, `void stop()`. Wire lines: `{"cmd":"captions","stage":...}` (control/status reports) and `{"cmd":"caption",...}` (one per transcription message). Task 5 consumes both shapes.
+
+- [ ] **Step 1: Write the header (the shape is the commitment)**
+
+Create `engine/src/engine-captions.h`:
+
+```cpp
+#pragma once
+//
+// engine-captions.h — Zoom live transcription -> E2P caption stream.
+//
+// Every media path in this codebase moves pixels or PCM; this one moves TEXT,
+// which is why it needs none of the SHM machinery: a caption is a few dozen
+// bytes a few times a second, well inside what the line-JSON pipe carries as
+// control traffic. Messages are forwarded whenever the sink is attached —
+// transcription started by the HOST from the Zoom client must reach OBS the
+// same as transcription we started ourselves.
+//
+// Callback threading: onLiveTranscriptionMsgInfoReceived arrives on an SDK
+// thread. It builds one string and calls EngineIpc::write (serialised); it
+// takes no other lock and touches no controller method — the same discipline
+// engine-writer.h's header comment demands of every SDK callback.
+//
+#include "zoom_sdk.h"
+#include "meeting_service_interface.h"
+#include "meeting_closedcaption_interface.h"
+
+#include <atomic>
+
+class EngineCaptions : public ZOOMSDK::IClosedCaptionControllerEvent {
+public:
+    // Meeting lifecycle (command-loop / meeting-event thread).
+    void attach(ZOOMSDK::IClosedCaptionController *ctrl);
+    void detach();
+
+    // Command branches (command-loop thread only, like every SDK call we
+    // initiate). Each reports its gate ladder as "captions" stage lines.
+    void start();
+    void stop();
+
+    // IClosedCaptionControllerEvent — all 13, the SDK interface is abstract.
+    void onAssignedToSendCC(bool bAssigned) override;
+    void onClosedCaptionMsgReceived(const zchar_t *ccMsg, unsigned int sender_id,
+                                    time_t time) override;
+    void onLiveTranscriptionStatus(ZOOMSDK::SDKLiveTranscriptionStatus status) override;
+    void onOriginalLanguageMsgReceived(
+        ZOOMSDK::ILiveTranscriptionMessageInfo *messageInfo) override;
+    void onLiveTranscriptionMsgInfoReceived(
+        ZOOMSDK::ILiveTranscriptionMessageInfo *messageInfo) override;
+    void onLiveTranscriptionMsgError(
+        ZOOMSDK::ILiveTranscriptionLanguage *spokenLanguage,
+        ZOOMSDK::ILiveTranscriptionLanguage *transcriptLanguage) override;
+    void onRequestForLiveTranscriptReceived(unsigned int requester_id,
+                                            bool bAnonymous) override;
+    void onRequestLiveTranscriptionStatusChange(bool bEnabled) override;
+    void onCaptionStatusChanged(bool bEnabled) override;
+    void onStartCaptionsRequestReceived(ZOOMSDK::ICCRequestHandler *handler) override;
+    void onStartCaptionsRequestApproved() override;
+    void onManualCaptionStatusChanged(bool bEnabled) override;
+    void onSpokenLanguageChanged(
+        ZOOMSDK::ILiveTranscriptionLanguage *spokenLanguage) override;
+
+private:
+    void report(const std::string &stage, const std::string &fields);
+    void forward_message(ZOOMSDK::ILiveTranscriptionMessageInfo *info);
+
+    // Written on attach/detach, read by SDK-thread callbacks: atomic so a
+    // late callback racing detach() forwards or drops cleanly, never tears.
+    std::atomic<ZOOMSDK::IClosedCaptionController *> m_ctrl{nullptr};
+};
+```
+
+- [ ] **Step 2: Run the build to verify it fails**
+
+Add `engine/src/engine-captions.cpp` to `ENGINE_SOURCES` (`CMakeLists.txt:391`), then:
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target ZoomObsEngine --parallel 8
+```
+
+Expected: FAIL — `engine-captions.cpp` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `engine/src/engine-captions.cpp`:
+
+```cpp
+#include "engine-captions.h"
+#include "engine-writer.h" // EngineIpc::write — include, never forward-declare
+#include "engine-json.h"   // json_escape / zchar_to_utf8
+
+#include <string>
+
+void EngineCaptions::report(const std::string &stage, const std::string &fields)
+{
+    std::string line = R"({"cmd":"captions","stage":")" + stage + "\"";
+    if (!fields.empty()) line += "," + fields;
+    line += "}";
+    EngineIpc::write(line);
+}
+
+void EngineCaptions::attach(ZOOMSDK::IClosedCaptionController *ctrl)
+{
+    m_ctrl.store(ctrl, std::memory_order_release);
+    if (!ctrl) {
+        report("attach", R"("ok":false,"reason":"null_controller")");
+        return;
+    }
+    const ZOOMSDK::SDKError err = ctrl->SetEvent(this);
+    report("attach", std::string(R"("ok":)") +
+           (err == ZOOMSDK::SDKERR_SUCCESS ? "true" : "false") +
+           R"(,"code":)" + std::to_string(static_cast<int>(err)));
+}
+
+void EngineCaptions::detach()
+{
+    ZOOMSDK::IClosedCaptionController *ctrl =
+        m_ctrl.exchange(nullptr, std::memory_order_acq_rel);
+    if (ctrl) ctrl->SetEvent(nullptr);
+}
+
+void EngineCaptions::start()
+{
+    ZOOMSDK::IClosedCaptionController *ctrl = m_ctrl.load(std::memory_order_acquire);
+    if (!ctrl) {
+        report("start", R"("ok":false,"reason":"no_controller")");
+        return;
+    }
+    // The gate ladder, every rung reported — a captions_start that produces
+    // silence must name which rung it fell off, not leave the operator
+    // guessing between entitlement, permission, and a hang.
+    report("meeting_supported", std::string(R"("supported":)") +
+           (ctrl->IsMeetingSupportCC() ? "true" : "false"));
+    report("feature_enabled", std::string(R"("enabled":)") +
+           (ctrl->IsLiveTranscriptionFeatureEnabled() ? "true" : "false"));
+    report("lt_status", R"("status":)" +
+           std::to_string(static_cast<int>(ctrl->GetLiveTranscriptionStatus())));
+    const bool can = ctrl->CanStartLiveTranscription();
+    report("can_start", std::string(R"("can":)") + (can ? "true" : "false"));
+    // Attempt even when can=false: like the talkback probe's per-user gate,
+    // the contrast between the query and the real outcome is itself data.
+    const ZOOMSDK::SDKError err = ctrl->StartLiveTranscription();
+    report("start", std::string(R"("ok":)") +
+           (err == ZOOMSDK::SDKERR_SUCCESS ? "true" : "false") +
+           R"(,"code":)" + std::to_string(static_cast<int>(err)));
+}
+
+void EngineCaptions::stop()
+{
+    ZOOMSDK::IClosedCaptionController *ctrl = m_ctrl.load(std::memory_order_acquire);
+    if (!ctrl) {
+        report("stop", R"("ok":false,"reason":"no_controller")");
+        return;
+    }
+    const ZOOMSDK::SDKError err = ctrl->StopLiveTranscription();
+    report("stop", std::string(R"("ok":)") +
+           (err == ZOOMSDK::SDKERR_SUCCESS ? "true" : "false") +
+           R"(,"code":)" + std::to_string(static_cast<int>(err)));
+}
+
+void EngineCaptions::forward_message(ZOOMSDK::ILiveTranscriptionMessageInfo *info)
+{
+    if (!info) return;
+    if (!m_ctrl.load(std::memory_order_acquire)) return; // detached: drop
+    // GetTimeStamp() is time_t (whole seconds, basis undocumented) — carried
+    // for the record; the plugin aligns on its own arrival os_gettime_ns().
+    EngineIpc::write(
+        R"({"cmd":"caption","msg_id":")" + json_escape(zchar_to_utf8(info->GetMessageID())) +
+        R"(","speaker_id":)" + std::to_string(info->GetSpeakerID()) +
+        R"(,"speaker":")" + json_escape(zchar_to_utf8(info->GetSpeakerName())) +
+        R"(","text":")" + json_escape(zchar_to_utf8(info->GetMessageContent())) +
+        R"(","op":)" + std::to_string(static_cast<int>(info->GetMessageOperationType())) +
+        R"(,"ts":)" + std::to_string(static_cast<long long>(info->GetTimeStamp())) + "}");
+}
+
+void EngineCaptions::onLiveTranscriptionMsgInfoReceived(
+    ZOOMSDK::ILiveTranscriptionMessageInfo *messageInfo)
+{
+    forward_message(messageInfo);
+}
+
+// Deliberately NOT forwarded: with translation enabled the SDK delivers the
+// same utterance on BOTH this and onLiveTranscriptionMsgInfoReceived, and a
+// duplicated stream would double every transcript line. One channel, chosen
+// once.
+void EngineCaptions::onOriginalLanguageMsgReceived(
+    ZOOMSDK::ILiveTranscriptionMessageInfo *) {}
+
+void EngineCaptions::onLiveTranscriptionStatus(ZOOMSDK::SDKLiveTranscriptionStatus status)
+{
+    report("lt_status", R"("status":)" + std::to_string(static_cast<int>(status)));
+}
+
+void EngineCaptions::onCaptionStatusChanged(bool bEnabled)
+{
+    report("caption_status", std::string(R"("enabled":)") + (bEnabled ? "true" : "false"));
+}
+
+// Observed but out of scope for this feature — logged so a live run that hits
+// them is diagnosable, no action taken.
+void EngineCaptions::onAssignedToSendCC(bool) {}
+void EngineCaptions::onClosedCaptionMsgReceived(const zchar_t *, unsigned int, time_t) {}
+void EngineCaptions::onLiveTranscriptionMsgError(ZOOMSDK::ILiveTranscriptionLanguage *,
+                                                 ZOOMSDK::ILiveTranscriptionLanguage *) {}
+void EngineCaptions::onRequestForLiveTranscriptReceived(unsigned int, bool) {}
+void EngineCaptions::onRequestLiveTranscriptionStatusChange(bool) {}
+void EngineCaptions::onStartCaptionsRequestReceived(ZOOMSDK::ICCRequestHandler *) {}
+void EngineCaptions::onStartCaptionsRequestApproved() {}
+void EngineCaptions::onManualCaptionStatusChanged(bool) {}
+void EngineCaptions::onSpokenLanguageChanged(ZOOMSDK::ILiveTranscriptionLanguage *) {}
+```
+
+- [ ] **Step 3a: Wire `main.cpp`**
+
+Add `#include "engine-captions.h"` with the other engine includes. Beside `static EngineTalkback talkback;` (`engine/src/main.cpp:1290`) add `static EngineCaptions captions;` — static for the same lifetime reason documented there. Give `EngineMeetingEvent` a member `EngineCaptions *m_captions = nullptr;` and a setter `void attach_captions(EngineCaptions *c) { m_captions = c; }` (mirroring `attach_talkback`), call `meeting_event.attach_captions(&captions);` next to `participants.attach_talkback(...)` (`:1297`). In `onMeetingStatusChanged`'s `MEETING_STATUS_INMEETING` case (`:1007-1031`), after the share-controller attach:
+
+```cpp
+            if (m_captions && m_meeting_svc && *m_meeting_svc)
+                m_captions->attach(
+                    (*m_meeting_svc)->GetMeetingClosedCaptionController());
+```
+
+and in the `DISCONNECTING`/`ENDED` case beside `m_participants->detach()` (`:1097`): `if (m_captions) m_captions->detach();`. In the command loop, beside the `IpcCommand::TalkbackNominate` branch (`:1664`):
+
+```cpp
+        } else if (command == IpcCommand::CaptionsStart) {
+            captions.start();
+        } else if (command == IpcCommand::CaptionsStop) {
+            captions.stop();
+```
+
+- [ ] **Step 4: Build and run the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: engine links; full suite green (unchanged count — this task adds no tests but must break none).
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add engine/src/engine-captions.h engine/src/engine-captions.cpp engine/src/main.cpp CMakeLists.txt
+git commit -m "feat(captions): engine live-transcription sink and caption wire"
+```
+
+---
+
+### Task 5: Plugin — caption events, control API, and the OBS text source
+
+The plugin side of the wire. `{"cmd":"caption"}` lines land in `ZoomEngineClient::handle_event` (`src/zoom-engine-client.cpp:1299`) on the pipe reader thread — the ordered control path, which is what a coalescing state machine needs (an `Update` processed before its `Add` would resurrect deleted text). `{"cmd":"captions"}` stage lines are logged verbatim and stashed for status, exactly the `talkback_probe` pattern (`:1351-1366`). The control API gains `captions_start`/`captions_stop` (fire-and-acknowledge, gates reported as stage lines), `captions_configure` (names the text source), and `captions_status` (poll). The text source update runs on the reader thread via `obs_get_source_by_name`/`obs_source_update` — the calls `src/talkback-tap.cpp:20` and `src/zoom-tiles-audio.cpp` already make off the UI thread; never `obs_enum_sources` here (it takes libobs's source mutex per the `zoom-dock.h:155` m2 note), and never while holding `m_mtx`.
+
+No new unit test — the coalescing logic this task wires is already pinned by Task 2, and the rest is Qt/OBS/socket wiring verified live in Task 7 (same ruling as talkback M1 Task 5). If a future round finds a mapping bug here, extract the mapping into a dispatch header first, like `src/talkback-nomination-dispatch.h` — do not test through the socket.
+
+**Files:**
+- Modify: `src/zoom-engine-client.h` (declare methods + members), `src/zoom-engine-client.cpp` (send methods beside `talkback_probe` at `:907`; `handle_event` branches beside `talkback_probe`'s at `:1351`)
+- Modify: `src/zoom-control-server.cpp` (four branches beside `talkback_probe`'s at `:851`)
+
+**Interfaces:**
+- Consumes: `CaptionStream`/`CaptionEvent`/`CaptionOp` (Task 2); wire shapes from Task 4; `ZoomIsoRecorder::record_caption` (Task 6 — until Task 6 lands, guard the call with `#if 0` is **not** allowed; instead Task 6 must merge before this task's sidecar line compiles, so implement Tasks 6's recorder method first if executing out of order, or land this task's step 3 exactly as written which only calls existing API and leaves one clearly-marked call to add in Task 6).
+- Produces: `ZoomEngineClient::captions_start()`, `captions_stop()`, `set_caption_text_source(const std::string&)`, `std::string caption_text_source() const`, `QJsonObject captions_status_json()`; control commands `captions_start`, `captions_stop`, `captions_configure`, `captions_status`.
+
+- [ ] **Step 1: Client members and send methods**
+
+In `src/zoom-engine-client.h`, beside the talkback members, add:
+
+```cpp
+    void captions_start();
+    void captions_stop();
+    void set_caption_text_source(const std::string &name);
+    std::string caption_text_source() const;
+    QJsonObject captions_status_json();
+```
+
+and private state (guarded by the existing `m_mtx`):
+
+```cpp
+    CaptionStream m_caption_stream;
+    std::string m_caption_text_source;   // OBS text source name; "" = disabled
+    std::string m_caption_last_display;  // last text pushed, to skip no-op updates
+    std::string m_captions_status_line;  // latest {"cmd":"captions"} line, verbatim
+```
+
+In `src/zoom-engine-client.cpp`, beside `talkback_probe` (`:907`):
+
+```cpp
+void ZoomEngineClient::captions_start()
+{
+    if (!m_running.load(std::memory_order_acquire)) return;
+    write_json(R"({"cmd":"captions_start"})");
+}
+
+void ZoomEngineClient::captions_stop()
+{
+    if (!m_running.load(std::memory_order_acquire)) return;
+    write_json(R"({"cmd":"captions_stop"})");
+}
+```
+
+- [ ] **Step 2: `handle_event` branches**
+
+In `handle_event`, beside the `talkback_probe` branch (`:1351`), add:
+
+```cpp
+    if (cmd == "captions") {
+        // Gate-ladder stage lines: verbatim to the log, latest stashed for
+        // captions_status — the talkback_probe pattern, same reasons.
+        blog(LOG_INFO, "[obs-zoom-plugin] captions: %s", line.c_str());
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_captions_status_line = line;
+        return;
+    }
+    if (cmd == "caption") {
+        CaptionEvent ev;
+        ev.msg_id     = obj.value("msg_id").toString().toStdString();
+        ev.speaker    = obj.value("speaker").toString().toStdString();
+        ev.speaker_id = static_cast<uint32_t>(obj.value("speaker_id").toInt(0));
+        ev.text       = obj.value("text").toString().toStdString();
+        ev.op         = static_cast<CaptionOp>(obj.value("op").toInt(0));
+        ev.arrival_ns = os_gettime_ns(); // the ISO clock — alignment happens HERE
+        std::vector<CaptionFinal> finals;
+        std::string display;
+        bool display_changed = false;
+        {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            finals = m_caption_stream.apply(ev);
+            display = m_caption_stream.display_line();
+            display_changed = display != m_caption_last_display;
+            if (display_changed) m_caption_last_display = display;
+        }
+        // Sidecar first (finalized lines must not depend on OBS source state).
+        for (const CaptionFinal &f : finals)
+            ZoomIsoRecorder::instance().record_caption(f.speaker, f.text,
+                                                       f.first_seen_ns);
+        // Text source update OUTSIDE m_mtx: obs_source_update can fan out to
+        // source callbacks, and holding our lock across libobs is how audio
+        // paths have deadlocked before. Skip no-op updates — every redundant
+        // update invalidates the text source's texture for nothing.
+        const std::string target = caption_text_source();
+        if (display_changed && !target.empty()) {
+            obs_source_t *src = obs_get_source_by_name(target.c_str());
+            if (src) {
+                obs_data_t *settings = obs_data_create();
+                obs_data_set_string(settings, "text", display.c_str());
+                obs_source_update(src, settings);
+                obs_data_release(settings);
+                obs_source_release(src);
+            }
+        }
+        return;
+    }
+```
+
+with the accessors:
+
+```cpp
+void ZoomEngineClient::set_caption_text_source(const std::string &name)
+{
+    std::lock_guard<std::mutex> lk(m_mtx);
+    m_caption_text_source = name;
+}
+
+std::string ZoomEngineClient::caption_text_source() const
+{
+    std::lock_guard<std::mutex> lk(m_mtx);
+    return m_caption_text_source;
+}
+
+QJsonObject ZoomEngineClient::captions_status_json()
+{
+    std::lock_guard<std::mutex> lk(m_mtx);
+    QJsonObject speakers;
+    for (const auto &entry : m_caption_stream.latest())
+        speakers[QString::fromStdString(entry.first)] =
+            QString::fromStdString(entry.second);
+    return QJsonObject{
+        {"text_source", QString::fromStdString(m_caption_text_source)},
+        {"display", QString::fromStdString(m_caption_stream.display_line())},
+        {"speakers", speakers},
+        {"last_stage", QString::fromStdString(m_captions_status_line)},
+    };
+}
+```
+
+Also add `m_caption_stream.clear(); m_caption_last_display.clear();` inside `handle_event`'s existing `"left"` branch (`:1453`) and in `stop_for_reconnect()` — the two world-reset points the talkback nomination record already uses, and for the same reason: a new meeting's captions must not coalesce against the old meeting's pending utterances.
+
+- [ ] **Step 3: Control API branches**
+
+In `src/zoom-control-server.cpp`, beside `talkback_probe` (`:851`):
+
+```cpp
+    if (cmd == "captions_start" || cmd == "captions_stop") {
+        if (!ZoomEngineClient::instance().is_running()) {
+            write_response(socket, {{"ok", false}, {"error", "engine_not_running"},
+                {"message", "The Zoom engine is not running."}});
+            return;
+        }
+        if (ZoomEngineClient::instance().state() != MeetingState::InMeeting) {
+            write_response(socket, {{"ok", false}, {"error", "not_in_meeting"},
+                {"message", "Join the meeting before toggling live transcription."}});
+            return;
+        }
+        if (cmd == "captions_start")
+            ZoomEngineClient::instance().captions_start();
+        else
+            ZoomEngineClient::instance().captions_stop();
+        write_response(socket, {{"ok", true},
+            {"note", "sent; watch the OBS log for captions stages"}});
+        return;
+    }
+
+    if (cmd == "captions_configure") {
+        // "" is legal and disables the text-source update — do not refuse it;
+        // it is the off switch.
+        const QString source = req.value("text_source").toString();
+        ZoomEngineClient::instance().set_caption_text_source(
+            source.toStdString());
+        write_response(socket, {{"ok", true},
+            {"text_source", source}});
+        return;
+    }
+
+    if (cmd == "captions_status") {
+        write_response(socket, {{"ok", true},
+            {"captions", ZoomEngineClient::instance().captions_status_json()}});
+        return;
+    }
+```
+
+- [ ] **Step 4: Build and run the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: all green. (If Task 6 has not merged yet, the `record_caption` call will not compile — implement Task 6's Step 3 recorder method first; the task ordering here assumes in-order execution.)
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/zoom-engine-client.h src/zoom-engine-client.cpp src/zoom-control-server.cpp
+git commit -m "feat(captions): caption stream, control API surface, and text-source drive"
+```
+
+---
+
+### Task 6: Sidecar transcript in the ISO recorder
+
+One transcript file per ISO run, not per source: captions are a meeting-wide stream, and per-source duplication would write the same sentence eight times. The anchor is `os_gettime_ns()` taken inside `start()`'s locked block (`src/zoom-iso-recorder.cpp:247-262`) — the same clock and the same moment the run's sessions begin anchoring against, so `[00:03:07.210]` in the transcript is directly seekable in any ISO file whose own `started_ns` is known (each session's start is already logged). Writes happen under `m_mtx` with an `fflush` per line: a transcript is tens of bytes per second, and a crash mid-show must not lose the show's transcript to a fat stdio buffer — the mirror image of why the *video* path is never allowed to block there.
+
+**Files:**
+- Modify: `src/zoom-iso-recorder.h` (declare `record_caption` + members)
+- Modify: `src/zoom-iso-recorder.cpp` (open in `start()`, write, close in `stop()`)
+- Test: covered by `tests/caption-transcript-log-test.cpp` (Task 3) for everything pure; the file plumbing below follows the `WavFile` pattern already in this class and is exercised live in Task 7.
+
+**Interfaces:**
+- Consumes: `caption_transcript_line` (Task 3).
+- Produces: `void ZoomIsoRecorder::record_caption(const std::string &speaker, const std::string &text, uint64_t first_seen_ns);` — called from Task 5's `handle_event` caption branch.
+
+- [ ] **Step 1: Declare**
+
+In `src/zoom-iso-recorder.h`, beside `record_audio_frame` (`:49`):
+
+```cpp
+    // Appends one finalized caption line to this run's sidecar transcript.
+    // No-op when not recording. first_seen_ns is on the os_gettime_ns()
+    // clock (the plugin's arrival stamp for the utterance's first message).
+    void record_caption(const std::string &speaker,
+                        const std::string &text,
+                        uint64_t first_seen_ns);
+```
+
+and private members beside `m_completed_sessions` (`:155`):
+
+```cpp
+    FILE *m_transcript = nullptr;
+    uint64_t m_transcript_anchor_ns = 0;
+    QString m_transcript_path;
+    bool m_transcript_write_failed = false;
+```
+
+- [ ] **Step 2: Open on `start()`, close on `stop()`**
+
+In `start()`'s locked block (`src/zoom-iso-recorder.cpp:247-262`), before `m_active.store(true, ...)`:
+
+```cpp
+        // Sidecar transcript: one per run, anchored NOW on the same
+        // os_gettime_ns() clock every session's started_ns uses. A failed
+        // open degrades to no transcript, never to no recording — captions
+        // are additive to the ISO run, not a precondition of it.
+        m_transcript_anchor_ns = os_gettime_ns();
+        m_transcript_write_failed = false;
+        m_transcript_path = dir.absoluteFilePath(
+            "transcript-" + QDateTime::currentDateTimeUtc()
+                                .toString("yyyyMMdd-HHmmss") + ".txt");
+        m_transcript = fopen(m_transcript_path.toUtf8().constData(), "wb");
+        if (m_transcript) {
+            const std::string header =
+                "# CoreVideo transcript. Offsets from recording start "
+                "(os_gettime_ns anchor " + std::to_string(m_transcript_anchor_ns) +
+                "). Caption text lags speech by Zoom's ASR delay (~1-3s).\n";
+            fwrite(header.data(), 1, header.size(), m_transcript);
+        } else {
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] ISO transcript could not be opened: %s",
+                 m_transcript_path.toUtf8().constData());
+        }
+```
+
+In `stop()`, inside the locked block that harvests sessions (`:289-300`):
+
+```cpp
+        if (m_transcript) {
+            fclose(m_transcript);
+            m_transcript = nullptr;
+        }
+```
+
+- [ ] **Step 3: Write lines**
+
+Add to `src/zoom-iso-recorder.cpp` (include `"caption-transcript-log.h"` at the top):
+
+```cpp
+void ZoomIsoRecorder::record_caption(const std::string &speaker,
+                                     const std::string &text,
+                                     uint64_t first_seen_ns)
+{
+    if (!m_active.load(std::memory_order_acquire)) return;
+    std::lock_guard<std::mutex> lock(m_mtx);
+    if (!m_transcript || m_transcript_write_failed) return;
+    const std::string line =
+        caption_transcript_line(m_transcript_anchor_ns, first_seen_ns,
+                                speaker, text);
+    if (fwrite(line.data(), 1, line.size(), m_transcript) != line.size()) {
+        // Report once and stop writing — a full disk mid-show must not turn
+        // every caption into a warning-log storm (the message-storm shape
+        // this codebase has a live incident about).
+        m_transcript_write_failed = true;
+        blog(LOG_WARNING,
+             "[obs-zoom-plugin] ISO transcript write failed; transcript "
+             "abandoned at %s", m_transcript_path.toUtf8().constData());
+        return;
+    }
+    fflush(m_transcript); // tens of bytes/sec; a crash must not eat the show
+}
+```
+
+Also surface it: in `status_overview()` (`:382`), add `obj["transcript_path"] = m_transcript_path;` and `obj["transcript_write_failed"] = m_transcript_write_failed;`.
+
+- [ ] **Step 4: Build and run the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: all green (Tasks 2–3 tests still pin the pure halves; this task adds none).
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/zoom-iso-recorder.h src/zoom-iso-recorder.cpp
+git commit -m "feat(captions): sidecar transcript anchored to the ISO recording clock"
+```
+
+---
+
+### Task 7: Live verification — the gate
+
+The compile proves the API exists; only a meeting proves the account can use it. `StartLiveTranscription()`'s notes say only the host can start it unless multi-language transcription is allowed, and the account-level "Automated captions" setting gates the whole feature — which rung refuses, and with what code, is exactly what this run establishes. Install the matched pair first (both binaries, always — a DLL-only copy is this project's canonical mistake).
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-08-29-captions-live-results.md` (record the actual output)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the go/no-go for shipping captions in the next release.
+
+- [ ] **Step 1: Setup** — a TEST meeting (never a live show), hosted by the entitled account with Automated Captions enabled in Zoom web settings; CoreVideo joined as host or co-host; two participants who will speak. Create an OBS text source named `Captions Lower Third`. Configure and start:
+
+```sh
+printf '{"cmd":"captions_configure","text_source":"Captions Lower Third"}\n' | nc 127.0.0.1 19870
+printf '{"cmd":"captions_start"}\n' | nc 127.0.0.1 19870
+```
+
+- [ ] **Step 2: Read every rung.** Expected in the OBS log on the happy path, in order: `captions` stages `attach ok=true`, `meeting_supported supported=true`, `feature_enabled enabled=true`, `lt_status status=0`, `can_start can=true`, `start ok=true code=0`, then `lt_status status=1` (`SDK_LiveTranscription_Status_Start`) from the async callback, possibly preceded by `status=10` (`Connecting`). Any `ok=false` names its rung; `can=false` followed by `start ok=true` or the reverse is a meaningful contrast — record it, don't discard it.
+
+- [ ] **Step 3: Confirm the stream.** Have both participants speak in turn. Verify: the text source shows `Name: text` updating as they speak, switching speakers; `printf '{"cmd":"captions_status"}\n' | nc 127.0.0.1 19870` returns both speakers under `"speakers"`; speaker NAMES match display names exactly.
+
+- [ ] **Step 4: Confirm the sidecar.** Start an ISO recording via `iso_recording_start`, have someone speak a distinctive sentence roughly 10 s in, stop after ~30 s. Open `transcript-*.txt`: the sentence's `[00:00:0X.xxx]` offset must land within ~1–3 s *after* the word is audible at the same offset in that speaker's ISO MP4 (ASR delay is expected and documented in the file header; an offset *before* the audio, or minutes off, is a clock bug). Confirm `captions_stop` yields `stop ok=true` and the text source stops updating.
+
+- [ ] **Step 5: Repeat Step 2 without co-host** — demote CoreVideo to plain participant, run `captions_start` again, record which rung refuses and with what code. This decides whether the UI must gate on role.
+
+- [ ] **Step 6: Record and commit**
+
+```sh
+git add docs/superpowers/notes/2026-08-29-captions-live-results.md
+git commit -m "docs: captions live verification results"
+```
+
+---
+
+## Self-Review
+
+**Placeholder scan:** none. Every code step contains the actual code. Tasks 4, 5, and 6 declare "no unit test" explicitly for SDK/OBS-bound wiring with a named verification route (Task 7), not as deferred work — the same ruling talkback M1 used, with the dispatch-header escape hatch named for the day it stops being true.
+
+**Type consistency:** `CaptionOp` values mirror `SDKLiveTranscriptionOperationType` numerically (asserted in Task 2's header comment; Task 4 sends the raw int, Task 5 `static_cast`s it). `CaptionEvent`/`CaptionFinal`/`CaptionStream::apply` are defined in Task 2 and consumed in Task 5 with matching fields. `caption_transcript_line(uint64_t, uint64_t, const std::string&, const std::string&)` is defined in Task 3 and called in Task 6 with that exact argument order. `record_caption(const std::string&, const std::string&, uint64_t)` is declared in Task 6 and called in Task 5 with matching types — the one cross-task ordering hazard (5 calls 6's method) is stated in both tasks.
+
+**SDK-name audit:** every SDK identifier used — `IClosedCaptionController`, `IClosedCaptionControllerEvent`, `ILiveTranscriptionMessageInfo` (`GetMessageID`/`GetSpeakerID`/`GetSpeakerName`/`GetMessageContent`/`GetTimeStamp`/`GetMessageOperationType`), `SDKLiveTranscriptionStatus`, `SDKLiveTranscriptionOperationType`, `IsMeetingSupportCC`, `IsLiveTranscriptionFeatureEnabled`, `GetLiveTranscriptionStatus`, `CanStartLiveTranscription`, `StartLiveTranscription`, `StopLiveTranscription`, `SetEvent`, `GetMeetingClosedCaptionController` — appears verbatim in `third_party/zoom-sdk/h/meeting_closedcaption_interface.h` or `meeting_service_interface.h:1234`. All 13 pure-virtual sink methods are overridden in Task 4. Nothing this plan needs is missing from the vendored headers; the only shortfall (seconds-resolution `GetTimeStamp`) is planned around, not worked around silently.

--- a/docs/superpowers/plans/2026-08-29-network-quality-telemetry.md
+++ b/docs/superpowers/plans/2026-08-29-network-quality-telemetry.md
@@ -1,0 +1,977 @@
+# Network-Quality Telemetry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consume the SDK's per-user network-quality callbacks in the engine, keep a per-participant connection-quality table in the plugin, and surface per-source network health in the dock, the logs, and the control API — so an operator can tell "Zoom's link to that participant is dying" apart from "our pipeline is broken" without leaving OBS.
+
+**Architecture:** The engine's existing `EngineMeetingEvent` (already registered as the `IMeetingServiceEvent` sink) fills in two callbacks it currently stubs out — `onUserNetworkStatusChanged` and `onMeetingStatisticsWarningNotification` — and forwards each as a line-JSON event over the existing E2P pipe. The plugin's `ZoomEngineClient::handle_event()` feeds them into a pure, header-only `NetworkQualityTable` (per-user, per-component, uplink/downlink split, staleness, warning latch, log rate-limiting — all decisions testable with no Qt/OBS/SDK). `ZoomOutputManager::outputs()` joins the table against each output's `participant_id` the same way `apply_output_health()` already joins the roster, which makes the fields flow to the dock and to `list_outputs`/`list_audio_sources` for free.
+
+**Tech Stack:** C++17, Zoom Windows Meeting SDK 7.1.5.43953, CMake + CTest, named-pipe line-JSON IPC, Qt6 dock.
+
+**Spec:** this document doubles as the spec. Requirements:
+
+1. Every `onUserNetworkStatusChanged` / `onMeetingStatisticsWarningNotification` delivery reaches the plugin as an E2P event; neither is swallowed silently.
+2. Per-participant quality state is keyed by meeting-scoped `userId`, split by uplink/downlink and component (audio/video/share), with staleness — a reading older than 60 s reads back Unknown, never its last value.
+3. Transitions into/out of "bad" are logged with the participant's DISPLAY NAME (ids are meeting-scoped, never persisted), rate-limited so a flapping link cannot storm the log.
+4. Per-source quality appears in the dock's signal cell (marker + tooltip) and in `list_outputs` / `list_audio_sources` for polling.
+5. The meeting-wide statistics warning is latched, cleared on `Statistics_Warning_None` or after a hold window, and annotates the ISO encoder-demotion log line as context.
+6. **Non-goals, binding:** telemetry INFORMS; it never ACTS. It must not trigger encoder demotion (`iso_demote_encoder()` stays startup-failure-driven — see the CLAUDE.md demotion-chain invariant), and it must not trigger any resubscribe. A quality-driven per-source resubscribe is explicitly DEFERRED: Zoom's transport already renegotiates on a degrading link (that is what `last_quality_stage`/`subscription_downgraded` record), so a plugin-side resubscribe on a dip tears down an adaptation mid-flight and pays full renegotiation to land in the same place — the resubscribe-storm shape live-caught 2026-08-19, self-inflicted. If a future defect proves a helpful case, it goes through the per-source path in `src/shm-resubscribe.h`'s world with its own rate limit and its own plan; `resubscribe_all()` stays engine-crash-recovery-only regardless.
+
+## Global Constraints
+
+- Build: `cmake --build build --config Release --parallel 8`. Test: `cd build && ctest -C Release --output-on-failure` — must be N/N green (63 tests today; 65 when this plan lands).
+- Tests are plain executables, no framework, `check()`-style, one file per invariant cluster in `tests/`, registered in `CMakeLists.txt` with `add_executable` + `add_test`.
+- Comments state the constraint the code cannot show; when a change is motivated by a live failure, say what happened, with numbers.
+- Never call `ZoomOutputManager::resubscribe_all()` from any automatic path. Never run a second OBS instance while one is testing.
+- SDK names verified against `third_party/zoom-sdk/h/meeting_service_interface.h`: `enum ConnectionQuality` (line 477: `Conn_Quality_Unknown`, `Conn_Quality_Very_Bad`, `Conn_Quality_Bad`, `Conn_Quality_Not_Good`, `Conn_Quality_Normal`, `Conn_Quality_Good`, `Conn_Quality_Excellent`), `enum MeetingComponentType` (line 499: `MeetingComponentType_Def = 0`, `_AUDIO`, `_VIDEO`, `_SHARE`), `enum StatisticsWarningType` (line 794: `Statistics_Warning_None`, `Statistics_Warning_Network_Quality_Bad`, `Statistics_Warning_Busy_System`). Both callbacks live on `IMeetingServiceEvent` itself (`onMeetingStatisticsWarningNotification(StatisticsWarningType)` at line 855, `onUserNetworkStatusChanged(MeetingComponentType, ConnectionQuality, unsigned int, bool)` at line 895) — no secondary event sink to register; `EngineMeetingEvent` (`engine/src/main.cpp:739`) already overrides both as empty stubs (`engine/src/main.cpp:1118`, `:1124`), so no new `SetEvent` wiring is needed anywhere.
+- Direction semantics, stated once: the SDK's `uplink=true` means **that user's** uplink toward Zoom. For a remote participant feeding one of our sources, THEIR uplink is what degrades the media WE receive — so the dock marker keys on the worst of both directions rather than making the operator know that.
+
+---
+
+### Task 1: The pure quality table — `src/network-quality.h`
+
+Every decision that could be wrong in an interesting way — staleness, the bad/ok boundary, log rate-limiting, the warning latch — goes into one Qt/OBS/SDK-free header, in the `src/talkback-plan.h` pattern, pinned by a host test with no engine and no meeting. The header mirrors the three SDK enums as plain `int` constants instead of including SDK headers: the plugin must compile without the SDK and the wire carries integers anyway.
+
+**Files:**
+- Create: `src/network-quality.h`
+- Create: `tests/network-quality-test.cpp`
+- Modify: `CMakeLists.txt` (register after the `CoreVideoTalkbackDockStateTest` block, `CMakeLists.txt:1136-1143`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `class NetworkQualityTable` with `NetQualityUpdate update(uint32_t user_id, int component, int quality, bool uplink, uint64_t now_ms)`, `int worst(uint32_t user_id, bool uplink, uint64_t now_ms) const`, `void note_stats_warning(int type, uint64_t now_ms)`, `bool stats_warning_active(uint64_t now_ms) const`, `void clear()`; free helpers `const char *network_quality_name(int q)`, `bool network_quality_is_bad(int q)`; constants `kNetQuality*`, `kNetComponent*`, `kStatsWarning*`, `kNetQualityStaleMs`, `kNetLogMinIntervalMs`, `kStatsWarningHoldMs`. Tasks 2–5 consume these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/network-quality-test.cpp`:
+
+```cpp
+// tests/network-quality-test.cpp
+// The per-participant network-quality table. Staleness, the bad/ok
+// boundary, and log rate-limiting are what a flapping link exercises
+// hardest, and none are visible in any integration path.
+#include "network-quality.h"
+
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+static void check(bool ok, const char *message)
+{
+    if (!ok) { std::cerr << "FAIL: " << message << "\n"; ++failures; }
+}
+
+int main()
+{
+    NetworkQualityTable t;
+
+    check(t.worst(42, true, 1000) == kNetQualityUnknown,
+          "a never-seen user did not read back Unknown");
+
+    // worst() is the minimum across components, per direction.
+    t.update(42, kNetComponentVideo, kNetQualityGood, true, 1000);
+    t.update(42, kNetComponentAudio, kNetQualityBad, true, 1000);
+    t.update(42, kNetComponentVideo, kNetQualityExcellent, false, 1000);
+    check(t.worst(42, true, 1000) == kNetQualityBad,
+          "uplink worst did not pick the bad audio cell");
+    check(t.worst(42, false, 1000) == kNetQualityExcellent,
+          "downlink read a cell only ever reported uplink");
+
+    // Staleness: an old reading is Unknown, never its last value.
+    check(t.worst(42, true, 1000 + kNetQualityStaleMs + 1) == kNetQualityUnknown,
+          "a reading older than kNetQualityStaleMs still read back Bad");
+
+    // Unknown reports never mask a real reading.
+    t.update(7, kNetComponentVideo, kNetQualityNormal, true, 2000);
+    t.update(7, kNetComponentAudio, kNetQualityUnknown, true, 2000);
+    check(t.worst(7, true, 2000) == kNetQualityNormal,
+          "an Unknown cell was treated as worse than a real reading");
+
+    // The bad boundary: Very_Bad and Bad only.
+    check(network_quality_is_bad(kNetQualityVeryBad), "Very_Bad not bad");
+    check(network_quality_is_bad(kNetQualityBad), "Bad not bad");
+    check(!network_quality_is_bad(kNetQualityNotGood), "Not_Good graded bad");
+    check(!network_quality_is_bad(kNetQualityUnknown), "Unknown graded bad");
+
+    // Log gating: entering bad always logs; wobbles are rate-limited;
+    // a fresh re-entry into bad is NOT (bad news is never delayed).
+    NetworkQualityTable g;
+    check(g.update(9, kNetComponentVideo, kNetQualityVeryBad, true, 5000).should_log,
+          "the transition INTO bad was not flagged for logging");
+    check(!g.update(9, kNetComponentVideo, kNetQualityBad, true, 5100).should_log,
+          "a same-side wobble 100ms later logged again (storm shape)");
+    check(!g.update(9, kNetComponentVideo, kNetQualityNormal, true, 5200).should_log,
+          "recovery 200ms after the bad log was not rate-limited");
+    check(g.update(9, kNetComponentVideo, kNetQualityVeryBad, true, 5300).should_log,
+          "a re-entry into bad was rate-limited away");
+    check(g.update(9, kNetComponentVideo, kNetQualityNormal, true,
+                   5300 + kNetLogMinIntervalMs + 1).should_log,
+          "recovery after the window did not log its all-clear");
+
+    // Warning latch: held, expired by the hold window, cleared by None.
+    t.note_stats_warning(kStatsWarningNetworkQualityBad, 10000);
+    check(t.stats_warning_active(10000 + kStatsWarningHoldMs - 1),
+          "the warning did not hold inside the window");
+    check(!t.stats_warning_active(10000 + kStatsWarningHoldMs + 1),
+          "the warning outlived its hold window with no re-report");
+    t.note_stats_warning(kStatsWarningNetworkQualityBad, 20000);
+    t.note_stats_warning(kStatsWarningNone, 20001);
+    check(!t.stats_warning_active(20002),
+          "Statistics_Warning_None did not clear the latch immediately");
+
+    // clear(): ids are meeting-scoped; a new meeting starts from nothing.
+    t.clear();
+    check(t.worst(42, true, 1000) == kNetQualityUnknown,
+          "clear() left a previous meeting's user id readable");
+    check(!t.stats_warning_active(20000), "clear() left the warning latched");
+
+    // Names for the wire and the tooltip; out-of-range degrades to unknown.
+    check(std::string(network_quality_name(kNetQualityVeryBad)) == "very_bad",
+          "name mapping wrong for Very_Bad");
+    check(std::string(network_quality_name(99)) == "unknown",
+          "an out-of-range quality did not degrade to unknown");
+
+    if (failures == 0)
+        std::cout << "network-quality: all tests passed\n";
+    return failures == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Add to `CMakeLists.txt` immediately after the `add_test(NAME CoreVideoTalkbackDockState ...)` block (`CMakeLists.txt:1142-1143`):
+
+```cmake
+    # The per-participant network-quality table. Pure and header-only so the
+    # staleness, bad-boundary, rate-limit and warning-latch decisions are
+    # pinned with no engine and no meeting. See src/network-quality.h.
+    add_executable(CoreVideoNetworkQualityTest
+        tests/network-quality-test.cpp
+    )
+    target_include_directories(CoreVideoNetworkQualityTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoNetworkQuality
+             COMMAND CoreVideoNetworkQualityTest)
+```
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target CoreVideoNetworkQualityTest --parallel 8
+```
+
+Expected: FAIL — `Cannot open include file: 'network-quality.h'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/network-quality.h`:
+
+```cpp
+#pragma once
+//
+// network-quality.h — per-participant connection-quality state.
+//
+// Exists so that when a source goes stale or an ISO encoder dies, the
+// operator can tell "Zoom's link to that participant is dying" apart from
+// "our pipeline is broken" — the 2026-08-19 stale-recovery incident burned
+// hours on exactly that ambiguity.
+//
+// TELEMETRY INFORMS, IT NEVER ACTS. Nothing here may drive encoder
+// demotion (startup-failure-driven by invariant) or any resubscribe
+// (Zoom's transport already adapts; resubscribing on a dip tears the
+// adaptation down mid-flight — the 2026-08-19 resubscribe-storm shape).
+//
+// SDK enums mirrored as plain ints, values pinned to
+// meeting_service_interface.h (ConnectionQuality :477,
+// MeetingComponentType :499, StatisticsWarningType :794): this header must
+// compile plugin-side with no SDK, and the pipe carries integers anyway.
+// Keyed by meeting-scoped userId; cleared at every meeting boundary; never
+// persisted — display names are joined in only at render/log time.
+//
+// Free of Qt / OBS / Zoom SDK so every decision is pinned by
+// tests/network-quality-test.cpp.
+//
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+
+// ConnectionQuality, meeting_service_interface.h:477.
+constexpr int kNetQualityUnknown   = 0; // Conn_Quality_Unknown
+constexpr int kNetQualityVeryBad   = 1; // Conn_Quality_Very_Bad
+constexpr int kNetQualityBad       = 2; // Conn_Quality_Bad
+constexpr int kNetQualityNotGood   = 3; // Conn_Quality_Not_Good
+constexpr int kNetQualityNormal    = 4; // Conn_Quality_Normal
+constexpr int kNetQualityGood      = 5; // Conn_Quality_Good
+constexpr int kNetQualityExcellent = 6; // Conn_Quality_Excellent
+
+// MeetingComponentType, meeting_service_interface.h:499.
+constexpr int kNetComponentDef   = 0;
+constexpr int kNetComponentAudio = 1;
+constexpr int kNetComponentVideo = 2;
+constexpr int kNetComponentShare = 3;
+constexpr int kNetComponentCount = 4;
+
+// StatisticsWarningType, meeting_service_interface.h:794.
+constexpr int kStatsWarningNone              = 0;
+constexpr int kStatsWarningNetworkQualityBad = 1;
+constexpr int kStatsWarningBusySystem        = 2;
+
+// A reading Zoom has not refreshed in this long reads back Unknown. The SDK
+// fires on CHANGE, so a stable link goes quiet — but so does a participant
+// who LEFT, and their last reading must not describe whoever recycles the
+// id. The roster join at render time is the identity guard; this is the
+// backstop.
+constexpr uint64_t kNetQualityStaleMs = 60000;
+
+// Per-user log floor. Entering bad ALWAYS logs; everything else is
+// suppressed inside this window so a link flapping at callback rate cannot
+// storm the log — the message-storm shape this codebase has a live
+// incident about.
+constexpr uint64_t kNetLogMinIntervalMs = 5000;
+
+// How long a statistics warning stays latched with no further report.
+// Statistics_Warning_None clears immediately; the window is the backstop
+// for when Zoom never sends one.
+constexpr uint64_t kStatsWarningHoldMs = 30000;
+
+inline const char *network_quality_name(int q)
+{
+    switch (q) {
+    case kNetQualityVeryBad:   return "very_bad";
+    case kNetQualityBad:       return "bad";
+    case kNetQualityNotGood:   return "not_good";
+    case kNetQualityNormal:    return "normal";
+    case kNetQualityGood:      return "good";
+    case kNetQualityExcellent: return "excellent";
+    default:                   return "unknown";
+    }
+}
+
+// The operator-facing boundary. Not_Good is deliberately NOT bad: Zoom
+// reports it routinely on links delivering flawless 720p, and a marker
+// that cries wolf trains the operator to ignore the marker.
+inline bool network_quality_is_bad(int q)
+{
+    return q == kNetQualityVeryBad || q == kNetQualityBad;
+}
+
+struct NetQualityUpdate {
+    bool changed = false;
+    bool should_log = false; // one rate-limited log line owed for this
+    int  previous = kNetQualityUnknown;
+};
+
+class NetworkQualityTable {
+public:
+    NetQualityUpdate update(uint32_t user_id, int component, int quality,
+                            bool uplink, uint64_t now_ms)
+    {
+        NetQualityUpdate r;
+        if (component < 0 || component >= kNetComponentCount ||
+            quality < kNetQualityUnknown || quality > kNetQualityExcellent)
+            return r; // unrecognised wire values update nothing
+        Entry &e = m_users[user_id];
+        Cell &c = e.cells[component][uplink ? 0 : 1];
+        r.previous = c.quality;
+        r.changed = c.quality != quality;
+        const bool was_bad = network_quality_is_bad(c.quality);
+        const bool is_bad = network_quality_is_bad(quality);
+        c.quality = quality;
+        c.updated_ms = now_ms;
+        if (!r.changed)
+            return r;
+        if (is_bad && !was_bad) {
+            r.should_log = true; // entering bad: always, immediately
+            e.last_log_ms = now_ms;
+        } else if (was_bad != is_bad &&
+                   now_ms - e.last_log_ms >= kNetLogMinIntervalMs) {
+            r.should_log = true; // recovery: rate-limited
+            e.last_log_ms = now_ms;
+        }
+        return r;
+    }
+
+    // Worst non-stale, non-Unknown reading across components for one
+    // direction; kNetQualityUnknown when nothing usable is known.
+    int worst(uint32_t user_id, bool uplink, uint64_t now_ms) const
+    {
+        const auto it = m_users.find(user_id);
+        if (it == m_users.end())
+            return kNetQualityUnknown;
+        int w = kNetQualityUnknown;
+        for (int comp = 0; comp < kNetComponentCount; ++comp) {
+            const Cell &c = it->second.cells[comp][uplink ? 0 : 1];
+            if (c.quality == kNetQualityUnknown)
+                continue;
+            if (now_ms - c.updated_ms > kNetQualityStaleMs)
+                continue;
+            if (w == kNetQualityUnknown || c.quality < w)
+                w = c.quality;
+        }
+        return w;
+    }
+
+    void note_stats_warning(int type, uint64_t now_ms)
+    {
+        m_warning_type = type;
+        m_warning_ms = now_ms;
+    }
+
+    bool stats_warning_active(uint64_t now_ms) const
+    {
+        if (m_warning_type == kStatsWarningNone)
+            return false;
+        return now_ms - m_warning_ms <= kStatsWarningHoldMs;
+    }
+
+    int last_stats_warning() const { return m_warning_type; }
+
+    // Meeting boundary: ids are meeting-scoped, so every reading and the
+    // latch die with the meeting.
+    void clear()
+    {
+        m_users.clear();
+        m_warning_type = kStatsWarningNone;
+        m_warning_ms = 0;
+    }
+
+    std::size_t user_count() const { return m_users.size(); }
+
+private:
+    struct Cell {
+        int quality = kNetQualityUnknown;
+        uint64_t updated_ms = 0;
+    };
+    struct Entry {
+        Cell cells[kNetComponentCount][2]; // [component][0=up,1=down]
+        uint64_t last_log_ms = 0;
+    };
+    std::unordered_map<uint32_t, Entry> m_users;
+    int m_warning_type = kStatsWarningNone;
+    uint64_t m_warning_ms = 0;
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --target CoreVideoNetworkQualityTest --parallel 8
+cd build && ctest -C Release -R CoreVideoNetworkQuality --output-on-failure
+```
+
+Expected: PASS, `network-quality: all tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/network-quality.h tests/network-quality-test.cpp CMakeLists.txt
+git commit -m "feat(net-telemetry): pure per-participant network-quality table"
+```
+
+---
+
+### Task 2: Engine — forward the two callbacks over E2P
+
+Both callbacks are already overridden as empty stubs on `EngineMeetingEvent` (`engine/src/main.cpp:1118`, `:1124`), which is registered as the `IMeetingServiceEvent` sink — so this is filling two bodies, not wiring an event interface. They ride the pipe as control events, ordered on the plugin's reader thread per the media-dispatch-lanes invariant. The SDK fires on change, but "on change" from a flapping link is still a storm and pipe storms have a live incident here — so identical consecutive values per (user, component, direction) are deduped engine-side before they cost a pipe write.
+
+**Files:**
+- Modify: `engine/src/main.cpp:1118` and `:1124-1126` (the two stubs), plus one member map on `EngineMeetingEvent` and one `.clear()` in the `MEETING_STATUS_DISCONNECTING`/`ENDED` branch (beside the existing `m_participants->detach()`, `engine/src/main.cpp:1058` region).
+
+**Interfaces:**
+- Consumes: `EngineIpc::write` (`engine/src/engine-writer.h`).
+- Produces: E2P events `{"cmd":"network_status","component":<int>,"quality":<int>,"participant_id":<uint>,"uplink":<bool>}` and `{"cmd":"stats_warning","type":<int>}` — raw SDK enum values, which Task 1's constants mirror. Task 3 parses both.
+
+- [ ] **Step 1: Write the failing check**
+
+No unit test — SDK-callback-bound code in `main.cpp`, the same posture as the talkback plan's Task 3: the compile is the check, Task 3's dispatch test pins the exact wire shape emitted here (its test JSON is copied from this task's format strings), and Task 5 Step 4 proves the path live.
+
+- [ ] **Step 2: Implement**
+
+Replace the stub at `engine/src/main.cpp:1118`:
+
+```cpp
+    void onMeetingStatisticsWarningNotification(ZOOMSDK::StatisticsWarningType type) override
+    {
+        // Meeting-wide, not per-user. Forwarded raw; the plugin latches it
+        // (kStatsWarningHoldMs) because Zoom does not reliably send
+        // Statistics_Warning_None to clear it.
+        EngineIpc::write(R"({"cmd":"stats_warning","type":)" +
+                         std::to_string(static_cast<int>(type)) + "}");
+    }
+```
+
+and the stub at `:1124`:
+
+```cpp
+    void onUserNetworkStatusChanged(ZOOMSDK::MeetingComponentType type,
+                                    ZOOMSDK::ConnectionQuality level,
+                                    unsigned int userId, bool uplink) override
+    {
+        // Dedupe identical consecutive values per (user, component,
+        // direction): a link flapping between adjacent levels re-reports at
+        // callback rate, and pipe storms have a live incident here. State,
+        // not history, is what the plugin needs.
+        const uint64_t key = (static_cast<uint64_t>(userId) << 3) |
+                             (static_cast<uint64_t>(type) << 1) |
+                             (uplink ? 1u : 0u);
+        const auto it = m_net_last.find(key);
+        if (it != m_net_last.end() && it->second == static_cast<int>(level))
+            return;
+        m_net_last[key] = static_cast<int>(level);
+        EngineIpc::write(
+            R"({"cmd":"network_status","component":)" +
+            std::to_string(static_cast<int>(type)) +
+            R"(,"quality":)" + std::to_string(static_cast<int>(level)) +
+            R"(,"participant_id":)" + std::to_string(userId) +
+            R"(,"uplink":)" + (uplink ? "true" : "false") + "}");
+    }
+```
+
+Add the member beside the other `EngineMeetingEvent` state (`m_raw_media_active` etc.), with `#include <unordered_map>` if the build asks for it:
+
+```cpp
+    // Last forwarded quality per (user<<3 | component<<1 | uplink). Cleared
+    // at the meeting boundary: ids are meeting-scoped, and a stale entry
+    // would suppress the first report for whoever recycles the id.
+    std::unordered_map<uint64_t, int> m_net_last;
+```
+
+In `onMeetingStatusChanged`'s `MEETING_STATUS_DISCONNECTING`/`MEETING_STATUS_ENDED` branch, beside `if (m_participants) m_participants->detach();`:
+
+```cpp
+            m_net_last.clear();
+```
+
+- [ ] **Step 3: Build and run the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: engine links clean; 64/64 green (63 existing plus `CoreVideoNetworkQuality`).
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add engine/src/main.cpp
+git commit -m "feat(net-telemetry): forward SDK network-status and stats-warning events over E2P"
+```
+
+---
+
+### Task 3: Plugin — dispatch into the table, log transitions by name
+
+The talkback feature shipped two Majors in WIRING no header-only test could reach (`handle_event`'s report-shape-to-transition mapping); the fix was a Qt-JSON-only dispatch header (`src/talkback-nomination-dispatch.h`). Same lesson applied from the start: the event-shape-to-table mapping goes into `src/network-quality-dispatch.h`, driven by a test with the exact JSON Task 2 emits. `handle_event()` then only locks, delegates, and logs — and the log line joins the roster to print a display name, because a log full of meeting-scoped ids identifies nobody after the meeting ends.
+
+**Files:**
+- Create: `src/network-quality-dispatch.h`, `tests/network-quality-dispatch-test.cpp`
+- Modify: `src/zoom-engine-client.h` — accessor beside `roster()` (`:268`), member beside `m_roster` (`:388`)
+- Modify: `src/zoom-engine-client.cpp` — two branches in `handle_event()` (insert after the `active_speaker` branch, `:1625-1636`, before the `frame`/`audio` gate at `:1638`); world-reset in the `"left"` branch (`:1453`)
+- Modify: `CMakeLists.txt` (register after Task 1's block)
+
+**Interfaces:**
+- Consumes: `NetworkQualityTable` (Task 1); wire shapes (Task 2).
+- Produces: `NetworkEventResult network_quality_apply_event(NetworkQualityTable &table, const QString &cmd, const QJsonObject &obj, uint64_t now_ms)`; `NetworkQualityTable ZoomEngineClient::network_quality_table() const` — a by-value snapshot under `m_mtx` (the table is a few dozen small entries; a copy means no caller carries `m_mtx` into Qt paint or JSON code). Tasks 4–5 consume the accessor.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/network-quality-dispatch-test.cpp` (Qt-JSON-only, the `tests/zoom-control-parse-test.cpp` bar):
+
+```cpp
+// tests/network-quality-dispatch-test.cpp
+// The wire-shape-to-table mapping, pinned separately from the table because
+// both talkback Majors lived in exactly this seam: correct state machines
+// wired to the wrong report shape.
+#include "network-quality-dispatch.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <iostream>
+
+static int failures = 0;
+static void check(bool ok, const char *message)
+{
+    if (!ok) { std::cerr << "FAIL: " << message << "\n"; ++failures; }
+}
+static QJsonObject parse(const char *json)
+{
+    return QJsonDocument::fromJson(QByteArray(json)).object();
+}
+
+int main()
+{
+    NetworkQualityTable t;
+
+    // The exact shape engine/src/main.cpp emits routes into the table.
+    const NetworkEventResult r1 = network_quality_apply_event(
+        t, "network_status",
+        parse(R"({"cmd":"network_status","component":2,"quality":1,)"
+              R"("participant_id":123,"uplink":true})"),
+        1000);
+    check(r1.handled, "network_status was not handled");
+    check(r1.user_id == 123 && r1.quality == kNetQualityVeryBad && r1.uplink,
+          "network_status fields did not decode");
+    check(r1.should_log, "the first drop into Very_Bad was not flagged to log");
+    check(t.worst(123, true, 1000) == kNetQualityVeryBad,
+          "the table did not record the update");
+
+    // stats_warning latches.
+    const NetworkEventResult r2 = network_quality_apply_event(
+        t, "stats_warning", parse(R"({"cmd":"stats_warning","type":1})"), 2000);
+    check(r2.handled && r2.is_warning &&
+              r2.warning_type == kStatsWarningNetworkQualityBad,
+          "stats_warning did not decode");
+    check(t.stats_warning_active(2000), "the warning did not latch");
+
+    // Unrelated commands pass through untouched.
+    check(!network_quality_apply_event(
+              t, "participants", parse(R"({"cmd":"participants"})"), 3000).handled,
+          "an unrelated cmd was claimed by the network dispatcher");
+
+    // Missing fields degrade to no-op, never to a bogus user-0 entry.
+    const NetworkEventResult r4 = network_quality_apply_event(
+        t, "network_status", parse(R"({"cmd":"network_status"})"), 4000);
+    check(r4.handled && !r4.should_log,
+          "a field-less network_status line asked to be logged");
+    check(t.worst(0, true, 4000) == kNetQualityUnknown,
+          "a field-less line created a user-0 reading");
+
+    if (failures == 0)
+        std::cout << "network-quality-dispatch: all tests passed\n";
+    return failures == 0 ? 0 : 1;
+}
+```
+
+Register in `CMakeLists.txt` after Task 1's block, copying the `Qt6::Core` link line from the `tests/zoom-control-parse-test.cpp` block (the existing Qt-JSON-only precedent):
+
+```cmake
+    # The E2P-event-to-table mapping. Separate from the table test because
+    # both talkback Majors lived in this seam. Qt JSON only, no OBS.
+    add_executable(CoreVideoNetworkQualityDispatchTest
+        tests/network-quality-dispatch-test.cpp
+    )
+    target_include_directories(CoreVideoNetworkQualityDispatchTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    target_link_libraries(CoreVideoNetworkQualityDispatchTest PRIVATE Qt6::Core)
+    add_test(NAME CoreVideoNetworkQualityDispatch
+             COMMAND CoreVideoNetworkQualityDispatchTest)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target CoreVideoNetworkQualityDispatchTest --parallel 8
+```
+
+Expected: FAIL — `Cannot open include file: 'network-quality-dispatch.h'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/network-quality-dispatch.h`:
+
+```cpp
+#pragma once
+//
+// network-quality-dispatch.h — maps E2P network events onto the table.
+// Qt-JSON-only, no OBS/socket/thread dependency, in the pattern of
+// talkback-nomination-dispatch.h and for the same reason: wiring bugs
+// inlined in handle_event() are unreachable by host tests.
+//
+#include "network-quality.h"
+
+#include <QJsonObject>
+#include <QString>
+
+struct NetworkEventResult {
+    bool handled = false;
+    bool should_log = false; // the table's rate-limited verdict
+    bool is_warning = false;
+    uint32_t user_id = 0;
+    int component = kNetComponentDef;
+    int quality = kNetQualityUnknown;
+    bool uplink = false;
+    int warning_type = kStatsWarningNone;
+    int previous = kNetQualityUnknown;
+};
+
+inline NetworkEventResult network_quality_apply_event(NetworkQualityTable &table,
+                                                      const QString &cmd,
+                                                      const QJsonObject &obj,
+                                                      uint64_t now_ms)
+{
+    NetworkEventResult r;
+    if (cmd == QStringLiteral("network_status")) {
+        r.handled = true;
+        r.user_id = static_cast<uint32_t>(obj.value("participant_id").toInt(0));
+        if (r.user_id == 0)
+            return r; // a garbled line must not mint a user-0 entry
+        r.component = obj.value("component").toInt(kNetComponentDef);
+        r.quality = obj.value("quality").toInt(kNetQualityUnknown);
+        r.uplink = obj.value("uplink").toBool(false);
+        const NetQualityUpdate u =
+            table.update(r.user_id, r.component, r.quality, r.uplink, now_ms);
+        r.should_log = u.should_log;
+        r.previous = u.previous;
+        return r;
+    }
+    if (cmd == QStringLiteral("stats_warning")) {
+        r.handled = true;
+        r.is_warning = true;
+        r.warning_type = obj.value("type").toInt(kStatsWarningNone);
+        table.note_stats_warning(r.warning_type, now_ms);
+        // Warnings are meeting-wide and rare; the caller logs every one.
+        r.should_log = r.warning_type != kStatsWarningNone;
+        return r;
+    }
+    return r;
+}
+```
+
+In `src/zoom-engine-client.h` (add `#include "network-quality.h"`), declare beside `roster()` (`:268`) and add the member beside `m_roster` (`:388`):
+
+```cpp
+    // Snapshot by value: the table is small, and a copy means no caller
+    // carries m_mtx into paint/JSON code.
+    NetworkQualityTable network_quality_table() const;
+```
+
+```cpp
+    NetworkQualityTable m_network_quality;
+```
+
+In `src/zoom-engine-client.cpp` (add `#include "network-quality-dispatch.h"`), insert after the `active_speaker` branch (`:1636`), before the `if (cmd != "frame" && cmd != "audio") return;` gate:
+
+```cpp
+    if (cmd == "network_status" || cmd == "stats_warning") {
+        // Control event, reader thread, ordered — deliberately NOT a media
+        // lane: rare and cheap, and ordering against "participants"/"left"
+        // is what keeps the table's ids meaningful.
+        const uint64_t now_ms = os_gettime_ns() / 1000000ULL;
+        NetworkEventResult r;
+        std::string who;
+        {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            r = network_quality_apply_event(m_network_quality, cmd, obj, now_ms);
+            for (const auto &p : m_roster)
+                if (p.user_id == r.user_id) { who = p.display_name; break; }
+        }
+        if (r.should_log && r.is_warning) {
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] Zoom meeting statistics warning: %s",
+                 r.warning_type == kStatsWarningNetworkQualityBad
+                     ? "network quality bad" : "system busy");
+        } else if (r.should_log) {
+            // Named, never id-only: ids are meeting-scoped and identify
+            // nobody once the log is read after the meeting.
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] Network quality for %s (id %u): %s -> %s "
+                 "(%s, %s)",
+                 who.empty() ? "<not in roster>" : who.c_str(), r.user_id,
+                 network_quality_name(r.previous),
+                 network_quality_name(r.quality),
+                 r.component == kNetComponentAudio ? "audio"
+                 : r.component == kNetComponentVideo ? "video"
+                 : r.component == kNetComponentShare ? "share" : "default",
+                 r.uplink ? "their uplink" : "their downlink");
+        }
+        return;
+    }
+```
+
+In the `"left"` branch (`:1453`), inside the same `m_mtx` scope its other world-resets use:
+
+```cpp
+        m_network_quality.clear(); // ids are meeting-scoped; see network-quality.h
+```
+
+Implement the accessor beside `roster()`'s definition:
+
+```cpp
+NetworkQualityTable ZoomEngineClient::network_quality_table() const
+{
+    std::lock_guard<std::mutex> lk(m_mtx);
+    return m_network_quality;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: 65/65 green, `network-quality-dispatch: all tests passed` among them.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/network-quality-dispatch.h src/zoom-engine-client.h src/zoom-engine-client.cpp tests/network-quality-dispatch-test.cpp CMakeLists.txt
+git commit -m "feat(net-telemetry): dispatch network events into the table and log transitions by name"
+```
+
+---
+
+### Task 4: Join quality onto per-source info and the control API
+
+`ZoomOutputManager::outputs()` already runs every snapshot through `apply_output_health(out, roster, raw_media_active)` (`src/zoom-output-manager.cpp:174`); network quality joins the identical way, keyed by `participant_id`, as a sibling function in the same header so the same test file pins it. The fields are NEW fields, never a new `ZoomOutputHealthReason`: health reasons gate recovery actions and dock states, and telemetry informs, it never acts — a `ParticipantVideoOff` must not be displaced by "their network is bad".
+
+**Files:**
+- Modify: `src/zoom-output-manager.h` — two fields on `ZoomOutputInfo` (after `last_quality_stage`, `:55`)
+- Modify: `src/zoom-output-health.h` — `apply_network_quality()` beside `apply_output_health()` (`:8`)
+- Modify: `src/zoom-output-manager.cpp:174-176` — call it in `outputs()`
+- Modify: `src/zoom-control-server.cpp` — fields in `output_to_json` (`:187`) and the `list_audio_sources` loop (`:598-620`)
+- Test: `tests/output-health-test.cpp` (extend — same invariant cluster: per-source health grading from a snapshot)
+
+**Interfaces:**
+- Consumes: `NetworkQualityTable`, `network_quality_name` (Task 1); `ZoomEngineClient::network_quality_table()` (Task 3).
+- Produces: `ZoomOutputInfo::net_quality_uplink` / `net_quality_downlink` (`int`, `kNetQualityUnknown` when unknown); `void apply_network_quality(std::vector<ZoomOutputInfo> &outputs, const NetworkQualityTable &net, uint64_t now_ms)`; JSON fields `network_uplink` / `network_downlink` (quality-name string, or null when unreported — the `av_offset_us` null convention) on both list responses. Task 5 reads the struct fields.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `tests/output-health-test.cpp` before its final pass/fail block (reuse its existing `check` helper; add `#include "network-quality.h"`):
+
+```cpp
+    // --- Network quality joins by participant_id and never touches
+    //     health_reason: telemetry informs, it never acts ---
+    {
+        NetworkQualityTable net;
+        net.update(77, kNetComponentVideo, kNetQualityVeryBad, true, 5000);
+        std::vector<ZoomOutputInfo> outs(2);
+        outs[0].participant_id = 77;
+        outs[0].health_reason = ZoomOutputHealthReason::ParticipantVideoOff;
+        outs[1].participant_id = 0; // unassigned: must stay unknown
+        apply_network_quality(outs, net, 5000);
+        check(outs[0].net_quality_uplink == kNetQualityVeryBad,
+              "uplink quality did not join onto the assigned output");
+        check(outs[0].net_quality_downlink == kNetQualityUnknown,
+              "a direction never reported read back non-unknown");
+        check(outs[0].health_reason == ZoomOutputHealthReason::ParticipantVideoOff,
+              "apply_network_quality displaced an existing health reason");
+        check(outs[1].net_quality_uplink == kNetQualityUnknown,
+              "an unassigned output (participant_id 0) got a reading");
+        apply_network_quality(outs, net, 5000 + kNetQualityStaleMs + 1);
+        check(outs[0].net_quality_uplink == kNetQualityUnknown,
+              "a stale reading survived the join");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cmake --build build --config Release --target CoreVideoOutputHealthTest --parallel 8
+```
+
+Expected: FAIL to compile — `'net_quality_uplink': is not a member` / `'apply_network_quality': identifier not found`. (If the executable target is named differently, take the name from the `tests/output-health-test.cpp` block in `CMakeLists.txt` — the test file, not the target name, is the anchor.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/zoom-output-manager.h`, after `std::string last_quality_stage;` (`:55`):
+
+```cpp
+    // Zoom's own report of this participant's link, joined in by
+    // apply_network_quality() (src/zoom-output-health.h). kNetQualityUnknown
+    // when unassigned, unreported, or stale. INFORMATIONAL ONLY: nothing
+    // may branch a demotion or resubscribe on these — see network-quality.h.
+    int net_quality_uplink = 0;   // kNetQualityUnknown
+    int net_quality_downlink = 0; // kNetQualityUnknown
+```
+
+In `src/zoom-output-health.h`, add `#include "network-quality.h"` and, after `apply_output_health`:
+
+```cpp
+// Joins Zoom's per-participant link quality onto the snapshot, keyed by
+// participant_id like apply_output_health's roster join. Writes ONLY the
+// two net_quality_* fields — a health_reason gates recovery actions, and
+// "their network is bad" must inform, not displace ParticipantVideoOff.
+inline void apply_network_quality(std::vector<ZoomOutputInfo> &outputs,
+                                  const NetworkQualityTable &net,
+                                  uint64_t now_ms)
+{
+    for (auto &out : outputs) {
+        out.net_quality_uplink = kNetQualityUnknown;
+        out.net_quality_downlink = kNetQualityUnknown;
+        if (out.participant_id == 0)
+            continue;
+        // A remote participant's UPLINK is what degrades the media we
+        // receive from them; both directions are surfaced so the dock can
+        // key on the worst.
+        out.net_quality_uplink = net.worst(out.participant_id, true, now_ms);
+        out.net_quality_downlink = net.worst(out.participant_id, false, now_ms);
+    }
+}
+```
+
+In `src/zoom-output-manager.cpp`, after the `apply_output_health(...)` call (`:174-175`):
+
+```cpp
+    apply_network_quality(out, ZoomEngineClient::instance().network_quality_table(),
+                          os_gettime_ns() / 1000000ULL);
+```
+
+In `src/zoom-control-server.cpp` (add `#include "network-quality.h"`), in `output_to_json` (`:187`) beside the existing quality fields:
+
+```cpp
+    // Null means NOT REPORTED (unknown/stale) — the av_offset_us convention.
+    obj["network_uplink"] = o.net_quality_uplink == kNetQualityUnknown
+        ? QJsonValue(QJsonValue::Null)
+        : QJsonValue(QString::fromUtf8(network_quality_name(o.net_quality_uplink)));
+    obj["network_downlink"] = o.net_quality_downlink == kNetQualityUnknown
+        ? QJsonValue(QJsonValue::Null)
+        : QJsonValue(QString::fromUtf8(network_quality_name(o.net_quality_downlink)));
+```
+
+In the `list_audio_sources` handler (`:598`) — a `CoreVideoAudioSourceInfo` is not a `ZoomOutputInfo`, so the join happens here — hoist one snapshot above the loop:
+
+```cpp
+        const NetworkQualityTable net =
+            ZoomEngineClient::instance().network_quality_table();
+        const uint64_t now_ms = os_gettime_ns() / 1000000ULL;
+```
+
+and inside the loop, beside `obj["overrun_slots"]`:
+
+```cpp
+            const int up = net.worst(a.participant_id, true, now_ms);
+            const int down = net.worst(a.participant_id, false, now_ms);
+            obj["network_uplink"] = up == kNetQualityUnknown
+                ? QJsonValue(QJsonValue::Null)
+                : QJsonValue(QString::fromUtf8(network_quality_name(up)));
+            obj["network_downlink"] = down == kNetQualityUnknown
+                ? QJsonValue(QJsonValue::Null)
+                : QJsonValue(QString::fromUtf8(network_quality_name(down)));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: 65/65 green.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/zoom-output-manager.h src/zoom-output-health.h src/zoom-output-manager.cpp src/zoom-control-server.cpp tests/output-health-test.cpp
+git commit -m "feat(net-telemetry): join link quality onto outputs and the control API"
+```
+
+---
+
+### Task 5: Dock surface, demotion-log context, live check
+
+The operator surface: a marker in the dock's per-source signal cell when Zoom itself says the link is bad, a tooltip line naming which direction, and one annotation on the ISO demotion log line so a demotion during a meeting-wide network warning reads as "the box was fighting the network too", not just "the encoder died". Rides the existing 100 ms refresh (`m_refresh_timer`, `src/zoom-dock.cpp:1111-1117`) — `refresh_outputs()` already re-reads `ZoomOutputManager::instance().outputs()`, which Task 4 populated, so no new timer and no new data path.
+
+**Files:**
+- Modify: `src/zoom-dock.cpp` — `signal_label` (`:391`), `signal_tooltip` (`:430`), plus `#include "network-quality.h"`
+- Modify: `src/zoom-iso-recorder.cpp` — the encoder-demotion `blog` (`:901-905`), plus includes
+- Test: none new — the display strings are Qt formatting over fields Task 4's test pins, the same posture as every other `signal_label` branch; the demotion annotation is verified by Step 3's read-through and Step 4 live.
+
+**Interfaces:**
+- Consumes: `ZoomOutputInfo::net_quality_uplink`/`net_quality_downlink` (Task 4); `network_quality_is_bad`, `network_quality_name` (Task 1); `ZoomEngineClient::network_quality_table().stats_warning_active()` (Task 3).
+- Produces: operator-visible strings only.
+
+- [ ] **Step 1: Dock marker and tooltip**
+
+In `signal_label` (`src/zoom-dock.cpp:391`), compute a suffix at the top:
+
+```cpp
+    // Zoom's own verdict on the participant's link. A suffix, never a
+    // health_reason: it must coexist with (and explain) Waiting/Stale, not
+    // replace them. Worst of both directions — their uplink is what
+    // degrades what we receive, but the operator shouldn't need to know.
+    const QString net_suffix =
+        (network_quality_is_bad(output.net_quality_uplink) ||
+         network_quality_is_bad(output.net_quality_downlink))
+            ? QStringLiteral("\n! network")
+            : QString();
+```
+
+and append `+ net_suffix` to the four live-signal returns in the function's tail — `Waiting`, `! Stale`, `%1%2x%3\n%4 fps`, and `%1%2x%3` (the health-reason early returns above them already name a dominating problem). E.g. the fps return becomes:
+
+```cpp
+        return QString("%1%2x%3\n%4 fps")
+            .arg(prefix)
+            .arg(output.observed_width)
+            .arg(output.observed_height)
+            .arg(output.observed_fps, 0, 'f', 1) + net_suffix;
+```
+
+In `signal_tooltip` (`:430`), build once at the top —
+
+```cpp
+    QString net_line;
+    if (output.net_quality_uplink != kNetQualityUnknown ||
+        output.net_quality_downlink != kNetQualityUnknown) {
+        net_line = QString("\nZoom link quality for this participant: "
+                           "uplink %1, downlink %2 (their side).")
+            .arg(QString::fromUtf8(network_quality_name(output.net_quality_uplink)))
+            .arg(QString::fromUtf8(network_quality_name(output.net_quality_downlink)));
+    }
+```
+
+— and append `+ net_line` to EVERY return in the function, including the health-reason early returns: a tooltip has room, and "Participant video off" plus "uplink very_bad" together is precisely the diagnosis this feature exists to put in front of the operator.
+
+- [ ] **Step 2: ISO demotion log context**
+
+In `src/zoom-iso-recorder.cpp` at the demotion warning (`:901-905`), add `#include "network-quality.h"` and `#include "zoom-engine-client.h"` (if not already present) and extend the existing `blog` — the demotion DECISION is untouched, per the demotion-chain invariant; only the sentence changes (`now_ns` already exists in scope, `:894`):
+
+```cpp
+            const bool net_warn =
+                ZoomEngineClient::instance().network_quality_table()
+                    .stats_warning_active(now_ns / 1000000ULL);
+            blog(LOG_WARNING,
+                 "[obs-zoom-plugin] ISO encoder %s failed at startup for "
+                 "%s; retrying with %s%s",
+                 session.video_encoder.c_str(),
+                 session.source_name.c_str(), next.c_str(),
+                 net_warn ? " (Zoom meeting network warning active)" : "");
+```
+
+- [ ] **Step 3: Build, full suite, self-read**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: 65/65 green. Re-read both dock functions end to end and confirm every return path carries its suffix/line — a missed return is silent and this step is the only unit-level check they get.
+
+- [ ] **Step 4: Live check against a real meeting**
+
+Not a hard gate (the interfaces are verified in the vendored headers and already registered), but the callbacks' real firing rate and value distribution are assumptions until watched once. Install the matched pair (both binaries, SHA256-verified — a DLL-only copy is this project's canonical mistake), join a test meeting with two participants, then:
+
+```sh
+printf '{"cmd":"list_outputs"}\n' | nc 127.0.0.1 19870
+```
+
+- `network_uplink`/`network_downlink` are null before any callback fires and become quality names after (throttle a participant's connection, or wait — real links report transitions within minutes).
+- The log shows `Network quality for <name> (id N): ...` with display names, and a bad patch produces ONE line, not a stream.
+- The dock cell shows `! network` for the degraded participant; the tooltip names the direction.
+- Send `{"cmd":"leave"}` before closing OBS.
+
+Record what fired and how often in `docs/superpowers/notes/2026-08-29-network-telemetry-live-notes.md` — the dedupe and rate-limit constants were chosen on assumptions this run confirms or corrects.
+
+- [ ] **Step 5: Update CLAUDE.md and commit**
+
+Add a short invariants entry to CLAUDE.md (telemetry informs / never acts; the fields; null-means-unreported) — docs-updated is part of done.
+
+```sh
+git add src/zoom-dock.cpp src/zoom-iso-recorder.cpp CLAUDE.md docs/superpowers/notes/2026-08-29-network-telemetry-live-notes.md
+git commit -m "feat(net-telemetry): dock network markers and demotion-log context"
+```
+
+---
+
+## Self-Review
+
+**Placeholder scan:** none. Every code step contains the actual code; Task 2's "no unit test" and Task 5's "no new test" are explicit statements about SDK-bound and Qt-formatting code with named verification routes (Task 3's dispatch test pins the wire shape; Task 4's test pins the fields; Task 5 Step 4 is the live check), not deferred work.
+
+**SDK ground truth:** both callbacks verified on `IMeetingServiceEvent` (`meeting_service_interface.h:855`, `:895`); all three enums quoted member-by-member from lines 477/499/794 and mirrored as pinned int constants in Task 1. No SDK interface this plan needs is missing from the vendored headers. (`GetVideoConnQuality`/`GetAudioConnQuality`/`GetSharingConnQuality`, `:1066-1085`, poll only OUR OWN connection and are deliberately unused — they cannot answer per-remote-participant questions.)
+
+**Type consistency:** `NetworkQualityTable::update(uint32_t, int, int, bool, uint64_t)` (Task 1) is called by `network_quality_apply_event` (Task 3) with those types; `worst(uint32_t, bool, uint64_t)` is called in Tasks 1, 3 (test), and 4 (twice); `net_quality_uplink`/`net_quality_downlink` are `int` in Task 4's struct and read as `int` in Task 5; `network_quality_table()` returns `NetworkQualityTable` by value in Task 3 and is consumed by value in Tasks 4 and 5. The wire field `participant_id` (Task 2) matches the key Task 3 reads and the existing `DebugEvent.participant_id` naming.
+
+**Invariant compliance:** no `resubscribe_all` anywhere; the demotion chain's guard and decision are untouched (Task 5 changes one format string); control events stay ordered on the reader thread; ids are meeting-scoped — cleared engine-side at the meeting boundary (Task 2), plugin-side in the `"left"` world-reset (Task 3), and never persisted or logged without a name join.

--- a/docs/superpowers/plans/2026-08-29-obf-token-audit.md
+++ b/docs/superpowers/plans/2026-08-29-obf-token-audit.md
@@ -1,0 +1,601 @@
+# Zoom OBF / App-Privilege Token — March 2026 Compliance Audit & Gap-Close Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove (with tests) that CoreVideo's existing join path already carries Zoom's on-behalf / ZAK / app-privilege tokens end-to-end, then close the four verified gaps — a named client-side error for the cross-account-without-token rejection, per-profile token persistence, operator docs, and a live gate against a meeting on another account — before Zoom's March 2, 2026 enforcement date.
+
+**Architecture:** Two processes: the OBS plugin (`src/`) collects tokens from three inlets (dock combo+field, join-URL query params, control-API JSON) into `ZoomJoinAuthTokens`, and the engine (`engine/src/main.cpp`) copies them into `ZOOMSDK::JoinParam4WithoutLogin` verbatim. All new decision logic goes into the existing pure, SDK-free header `src/zoom-join-decision.h` so it is unit-testable without a live meeting; only thin wiring touches Qt/engine code.
+
+**Tech Stack:** C++17, Zoom Windows Meeting SDK 7.1.5.43953, CMake + CTest, named-pipe line-JSON IPC, Qt6.
+
+**Policy background (Zoom marketplace policy, NOT an SDK-header fact):** Zoom announced that from **March 2, 2026**, Meeting-SDK apps joining meetings hosted OUTSIDE the app's own account must supply an app privilege token (OBF) — or a ZAK / on-behalf token establishing user context — in the join parameters. Joins into cross-account meetings without one will be rejected **server-side**; the SDK headers ship the fields and the `MEETING_FAIL_*` codes but say nothing about the enforcement date. The client cannot ask Zoom "is this meeting on my account?" before joining (see audit finding A7), so client-side detection has to key off the rejection code plus what we know we sent.
+
+**Spec:** This document doubles as the spec.
+
+**Requirements — what already exists, verbatim from the audit (do not re-implement any of this):**
+
+- **A1 — Engine join plumbing is complete.** `engine/src/main.cpp:1444-1446` parses `on_behalf_token`, `user_zak`, `app_privilege_token` from the join JSON; `1448-1454` acks presence booleans (`has_on_behalf_token`, `has_user_zak`, `has_app_privilege_token` — never values); `1465-1467` copies into persistent globals `g_wide_on_behalf_token` / `g_wide_user_zak` / `g_wide_app_privilege_token` (declared ~1317-1327, wide on Windows) so the `JoinParam` raw pointers outlive the async `Join()`; `1487-1489` sets `p.onBehalfToken`, `p.userZAK`, `p.app_privilege_token` (nullptr when empty). A host-start fallback (`main.cpp:831-859`) re-joins as host with `p.userZAK = m_host_start_zak.c_str()` when code 63 arrives and a ZAK was supplied (`1101-1107`, `try_host_start_after_external_join_failure`).
+- **A2 — The SDK struct has the fields.** `third_party/zoom-sdk/h/meeting_service_interface.h:250-290`, `tagJoinParam4WithoutLogin`: `meetingNumber`, `vanityID`, `userName`, `psw`, `app_privilege_token` (doc comment: "app_privilege_token."), `userZAK` ("ZOOM access token."), `customer_key`, `webinarToken`, `isVideoOff`, `isAudioOff`, `join_token` ("Join token."), `onBehalfToken` ("On behalf token."), `isMyVoiceInMix`, `hDirectShareAppWnd`/`isDirectShareDesktop` (WIN32), `isAudioRawDataStereo`, `eAudioRawdataSamplingRate`, `eVideoRawdataColorspace`. Note `tagJoinParam4NormalUser` (296-333) has `app_privilege_token` and `join_token` but **no** `onBehalfToken`/`userZAK` — the engine always joins `SDK_UT_WITHOUT_LOGIN` (`main.cpp:1482`), which is the union arm that has all three.
+- **A3 — MeetingFailCode candidates** (`meeting_service_interface.h:117-148`): `MEETING_FAIL_FORBID_TO_JOIN_INTERNAL_MEETING = 60`, `MEETING_FAIL_HOST_DISALLOW_OUTSIDE_USER_JOIN = 62`, `MEETING_FAIL_UNABLE_TO_JOIN_EXTERNAL_MEETING = 63`, `MEETING_FAIL_BLOCKED_BY_ACCOUNT_ADMIN = 64`, `MEETING_FAIL_APP_PRIVILEGE_TOKEN_ERROR = 500`, `MEETING_FAIL_AUTHORIZED_USER_NOT_INMEETING = 501`, `MEETING_FAIL_ON_BEHALF_TOKEN_CONFLICT_LOGIN_ERROR = 502`, `MEETING_FAIL_USER_LEVEL_TOKEN_NOT_HAVE_HOST_ZAK_OBF = 503`, `MEETING_FAIL_APP_CAN_NOT_ANONYMOUS_JOIN_MEETING = 504`, `MEETING_FAIL_ON_BEHALF_TOKEN_INVALID = 505`, `MEETING_FAIL_ON_BEHALF_TOKEN_NOT_MATCH_MEETING = 506`, `MEETING_FAIL_JMAK_USER_EMAIL_NOT_MATCH = 1143`. Which of these the server actually sends for "cross-account, no token" is **unknown until the Task 6 live gate** — 63 is the working hypothesis (the engine already special-cases it for host-start retry).
+- **A4 — URL parser extracts all three tokens.** `src/obs-utils.h:6-11` (`ParsedJoin` carries `on_behalf_token`, `user_zak`, `app_privilege_token`); `src/obs-utils.cpp:134-143` accepts query keys `obf`/`on_behalf_token`/`onbehalftoken`, `zak`/`user_zak`/`userzak`, `app_privilege_token`/`appprivilegetoken`/`apptoken`/`app_token`.
+- **A5 — Both operator inlets accept tokens.** Dock: token-type combo (`src/zoom-dock.cpp:753-756`: "Zoom sign-in"/`auto_zak`, "User ZAK"/`user_zak`, "App privilege token"/`app_privilege_token`) + password-mode `m_join_token` field (762-768); join click maps typed token by type into `ZoomJoinAuthTokens` (2564-2586) and refuses a manual type with an empty field. Control API: `src/zoom-control-server.cpp:735-741` accepts `on_behalf_token`/`user_zak`/`app_privilege_token` request fields, falling back to the URL-parsed values.
+- **A6 — A pure join-decision unit exists** (`src/zoom-join-decision.h`, pinned by `tests/join-decision-test.cpp`, 63 checks): `plan_join()` reasons about `token_type`, ZAK sourcing, and sign-in blocking errors; `classify_meeting_fail()` already maps 500/502/503/505/506 → `OnBehalfTokenInvalid`, 60/62/63/64 → `MissingApproval`, 504/82/23 → `NeedsSignIn`. `zoom_error_message()` (`src/zoom-engine-client.cpp:82`, `meeting_failed` branch at 116) hand-writes messages for 63/504/505/506.
+- **A7 — What does NOT exist (the gaps this plan closes):** (G1) Nothing distinguishes "cross-account join attempted with **no** token" from a generic approval failure — code 63 without any token yields the app-approval message, which sends the operator to the Marketplace instead of to the token field; nothing refuses or warns **before** the SDK round-trip, and nothing can (the SDK's `IAuthService::GetLoginStatus()`/`GetAccountInfo()` (`auth_service_interface.h:328-334`) reflect SDK login, which this app never uses — there is no pre-join "whose meeting is this" query). (G2) The typed token and token type are **not persisted** — only `last_meeting_id`/`last_display_name`/`last_was_webinar` are saved on join (`zoom-dock.cpp:2754-2758`; `ZoomPluginSettings` in `src/zoom-settings.h` has no join-token fields) — yet the repo already has DPAPI secret storage (`protect_secret`/`unprotect_secret`, `src/zoom-settings.cpp:176/206`, used for OAuth tokens at 349-352), so persisting the token there is consistent with what exists. (G3) Operator docs: `README.md:343` describes the automatic ZAK flow only; neither README nor `wiki/Support.md` documents the token combo, OBF URLs, or the March 2026 policy. (G4) No live verification that a cross-account join with a token succeeds and without one fails with the code we classify.
+- **A8 — `sidecar/` is not a broker.** It is `CoreVideoSidecar`, a Qt6 Widgets companion UI (layout templates, look library, scenes/macros panels, an OBS websocket client). Nothing in it mints or brokers tokens; no integration is planned here.
+
+## Global Constraints
+
+- Build: `cmake --build build --config Release --parallel 8`. Test: `cd build && ctest -C Release --output-on-failure` — must be **N/N green** (63 tests before this plan; each task states the expected count after it).
+- Tests are plain executables, no framework, `check()`-style, one file per invariant cluster in `tests/`, registered in `CMakeLists.txt` with `add_executable` + `add_test`.
+- **Never log a token VALUE.** Log presence booleans only — the engine already acks `has_app_privilege_token`; every new log line and IPC field follows that rule. `zoom_join::redacted_tail()` exists for identifiers that must appear at all; join tokens do not even get a tail.
+- Comments state the constraint the code cannot show; when a change is motivated by a live failure, say what happened, with numbers.
+- Never run a second OBS instance while one is testing (pipe/SDK singleton collision, crash loop). Send `{"cmd":"leave"}` before closing OBS.
+- Task 1 is an AUDIT pin: its tests are expected to pass immediately. A Task 1 test that FAILS is an audit finding — stop, report it, do not "fix" the test.
+
+---
+
+### Task 1: Pin the existing plumbing — SDK fields, fail codes, URL parser, decision unit
+
+The whole point of this plan being an audit first: the March 2026 requirement is already mostly met, and the riskiest way to "comply" would be to rebuild working plumbing. This task converts audit findings A2-A6 into compiled assertions so an SDK upgrade that renames `app_privilege_token`, renumbers `MEETING_FAIL_APP_PRIVILEGE_TOKEN_ERROR`, or a refactor that drops a URL query alias fails CI instead of failing a show. The SDK-header pin gets its own executable because it is the only test that includes `meeting_service_interface.h`.
+
+**Files:**
+- Create: `tests/obf-join-fields-test.cpp`
+- Modify: `tests/join-input-test.cpp` (append checks before the final pass/fail block), `CMakeLists.txt` (register `CoreVideoObfJoinFieldsTest` next to `CoreVideoJoinInputTest`, ~line 616)
+- Test: both of the above
+
+**Interfaces:**
+- Consumes: `ZOOMSDK::JoinParam4WithoutLogin`, `ZOOMSDK::MeetingFailCode` (`third_party/zoom-sdk/h/meeting_service_interface.h`), `zoom_join_utils::parse_join_input` (`src/obs-utils.h`).
+- Produces: nothing new — pins only. Task 2 relies on the pinned numeric codes.
+
+- [ ] **Step 1: Write the pin tests (expected to PASS — a failure is an audit finding)**
+
+`tests/obf-join-fields-test.cpp`:
+
+```cpp
+// Pins audit findings A2/A3 (docs/superpowers/plans/2026-08-29-obf-token-audit.md):
+// the Meeting SDK struct fields and fail codes the March 2026 OBF requirement
+// rides on. If an SDK upgrade renames or renumbers any of these, this fails at
+// build/test time instead of at join time on a live show.
+#include "meeting_service_interface.h"
+#include <cstdio>
+#include <string>
+
+static int failures = 0;
+static void check(bool cond, const std::string &name)
+{
+    if (!cond) { ++failures; std::printf("FAIL: %s\n", name.c_str()); }
+}
+
+int main()
+{
+    // Field-name pin: assignability is the compile-time assertion. The engine
+    // joins SDK_UT_WITHOUT_LOGIN only (engine/src/main.cpp:1482) -- the union
+    // arm that carries all three token fields (NormalUser lacks onBehalfToken
+    // and userZAK entirely).
+    ZOOMSDK::JoinParam4WithoutLogin p{};
+    p.app_privilege_token = nullptr;
+    p.userZAK             = nullptr;
+    p.onBehalfToken       = nullptr;
+    p.join_token          = nullptr;
+    check(p.app_privilege_token == nullptr, "JoinParam4WithoutLogin token fields exist");
+
+    // Numeric pins for every code classify_meeting_fail() and the engine's
+    // meeting_fail_name() switch on. These are wire values from Zoom's server;
+    // the classifiers hold ints so they stay SDK-header-free.
+    check(ZOOMSDK::MEETING_FAIL_FORBID_TO_JOIN_INTERNAL_MEETING == 60,  "code 60");
+    check(ZOOMSDK::MEETING_FAIL_HOST_DISALLOW_OUTSIDE_USER_JOIN == 62,  "code 62");
+    check(ZOOMSDK::MEETING_FAIL_UNABLE_TO_JOIN_EXTERNAL_MEETING == 63,  "code 63");
+    check(ZOOMSDK::MEETING_FAIL_BLOCKED_BY_ACCOUNT_ADMIN == 64,         "code 64");
+    check(ZOOMSDK::MEETING_FAIL_APP_PRIVILEGE_TOKEN_ERROR == 500,       "code 500");
+    check(ZOOMSDK::MEETING_FAIL_AUTHORIZED_USER_NOT_INMEETING == 501,   "code 501");
+    check(ZOOMSDK::MEETING_FAIL_ON_BEHALF_TOKEN_CONFLICT_LOGIN_ERROR == 502, "code 502");
+    check(ZOOMSDK::MEETING_FAIL_USER_LEVEL_TOKEN_NOT_HAVE_HOST_ZAK_OBF == 503, "code 503");
+    check(ZOOMSDK::MEETING_FAIL_APP_CAN_NOT_ANONYMOUS_JOIN_MEETING == 504, "code 504");
+    check(ZOOMSDK::MEETING_FAIL_ON_BEHALF_TOKEN_INVALID == 505,         "code 505");
+    check(ZOOMSDK::MEETING_FAIL_ON_BEHALF_TOKEN_NOT_MATCH_MEETING == 506, "code 506");
+    check(ZOOMSDK::MEETING_FAIL_JMAK_USER_EMAIL_NOT_MATCH == 1143,      "code 1143");
+
+    if (failures == 0) { std::printf("obf-join-fields: all checks passed\n"); return 0; }
+    return 1;
+}
+```
+
+Append inside `main()` in `tests/join-input-test.cpp`, before its final pass/fail block:
+
+```cpp
+    // --- Audit pin A4: every documented token query-key alias still parses ---
+    {
+        const auto p = zoom_join_utils::parse_join_input(
+            "https://zoom.us/j/123456789?pwd=abc&obf=OBF_T1&zak=ZAK_T1&apptoken=APT_T1");
+        check(p.meeting_id == "123456789",       "token url: id");
+        check(p.passcode == "abc",               "token url: passcode");
+        check(p.on_behalf_token == "OBF_T1",     "token url: obf -> on_behalf_token");
+        check(p.user_zak == "ZAK_T1",            "token url: zak -> user_zak");
+        check(p.app_privilege_token == "APT_T1", "token url: apptoken -> app_privilege_token");
+    }
+    {
+        const auto p = zoom_join_utils::parse_join_input(
+            "https://us02web.zoom.us/j/987654321?onbehalftoken=OB2&userzak=Z2&app_privilege_token=A2");
+        check(p.on_behalf_token == "OB2",     "token url long keys: on_behalf");
+        check(p.user_zak == "Z2",             "token url long keys: zak");
+        check(p.app_privilege_token == "A2",  "token url long keys: app_privilege");
+    }
+```
+
+CMakeLists.txt, after the `CoreVideoJoinInput` registration (~line 624):
+
+```cmake
+    add_executable(CoreVideoObfJoinFieldsTest
+        tests/obf-join-fields-test.cpp
+    )
+    target_include_directories(CoreVideoObfJoinFieldsTest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/zoom-sdk/h)
+    add_test(NAME CoreVideoObfJoinFields
+             COMMAND CoreVideoObfJoinFieldsTest)
+```
+
+- [ ] **Step 2: Build and run**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: **64/64 green** (63 existing + `CoreVideoObfJoinFields`). Every new check passes on first run. If any fails, STOP: that is a real divergence between this plan's audit and the tree — report it before continuing.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add tests/obf-join-fields-test.cpp tests/join-input-test.cpp CMakeLists.txt
+git commit -m "test(obf): pin SDK join-token fields, MEETING_FAIL codes, and URL token aliases"
+```
+
+---
+
+### Task 2: Name the cross-account-without-token failure in the pure decision unit
+
+Today a March-2026 rejection surfaces as whatever `classify_meeting_fail(63)` says — `MissingApproval`, whose guidance sends the operator to Marketplace app publication. That is the right message when a token WAS sent and Zoom still refused; it is the wrong message when no cross-account token was sent at all, where the fix is "paste the OBF token" and takes thirty seconds. The distinction needs exactly one bit the classifier doesn't have: did the join carry an on-behalf or app-privilege token? Keep the fix in `src/zoom-join-decision.h` — pure, SDK-free, already the single home for join error taxonomy (its own header comment says so) — and follow its existing id/guidance/classifier pattern exactly.
+
+**Files:**
+- Modify: `src/zoom-join-decision.h` (enum `ZoomJoinError` ~line 68, `join_error_id` ~84, `join_error_guidance` ~104, new classifier next to `classify_meeting_fail` ~188)
+- Test: `tests/join-decision-test.cpp` (append checks)
+
+**Interfaces:**
+- Consumes: `zoom_join::classify_meeting_fail(int code)` (existing).
+- Produces: `zoom_join::ZoomJoinError::CrossAccountTokenRequired`; `inline ZoomJoinError zoom_join::classify_meeting_fail_with_tokens(int code, bool had_cross_account_token)`. Task 3 wires both into `zoom_error_message()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `tests/join-decision-test.cpp`:
+
+```cpp
+    // --- March 2026 OBF policy: cross-account rejection without a token gets
+    // --- its own named, actionable category (gap G1 in the 2026-08-29 plan).
+    {
+        using zoom_join::classify_meeting_fail_with_tokens;
+        // No cross-account token sent: 63 and 504 mean "you needed one".
+        check(classify_meeting_fail_with_tokens(63, false) ==
+                  ZoomJoinError::CrossAccountTokenRequired,
+              "obf: 63 without token -> cross_account_token_required");
+        check(classify_meeting_fail_with_tokens(504, false) ==
+                  ZoomJoinError::CrossAccountTokenRequired,
+              "obf: 504 without token -> cross_account_token_required");
+        // A token WAS sent: same codes keep their existing meaning.
+        check(classify_meeting_fail_with_tokens(63, true) ==
+                  ZoomJoinError::MissingApproval,
+              "obf: 63 with token -> unchanged (missing approval)");
+        check(classify_meeting_fail_with_tokens(505, false) ==
+                  ZoomJoinError::OnBehalfTokenInvalid,
+              "obf: token-shaped codes unaffected by the flag");
+        check(std::string(zoom_join::join_error_id(
+                  ZoomJoinError::CrossAccountTokenRequired)) ==
+                  "cross_account_token_required",
+              "obf: stable error id");
+        check(std::string(zoom_join::join_error_guidance(
+                  ZoomJoinError::CrossAccountTokenRequired)).find("app privilege") !=
+                  std::string::npos,
+              "obf: guidance names the app privilege token");
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```sh
+cmake --build build --config Release --parallel 8
+```
+
+Expected: **compile failure** in `join-decision-test.cpp` — `classify_meeting_fail_with_tokens` and `CrossAccountTokenRequired` do not exist yet.
+
+- [ ] **Step 3: Minimal implementation**
+
+In `src/zoom-join-decision.h` — add the enum value after `OnBehalfTokenInvalid` (line 79), and the id/guidance arms in the matching switches:
+
+```cpp
+    CrossAccountTokenRequired, // cross-account meeting, no OBF/on-behalf token sent
+```
+
+```cpp
+    case ZoomJoinError::CrossAccountTokenRequired:
+        return "cross_account_token_required";
+```
+
+```cpp
+    case ZoomJoinError::CrossAccountTokenRequired:
+        return "Zoom refused this join because the meeting is hosted on a "
+               "different Zoom account and no app privilege (OBF) or on-behalf "
+               "token was sent. Since March 2, 2026 Zoom requires one for "
+               "cross-account joins. Get an app privilege token from the "
+               "meeting's host account (Marketplace app or ISV flow), select "
+               "'App privilege token' in the dock and paste it, or append "
+               "?obf=<token> to the join URL, then retry.";
+```
+
+And the classifier, directly below `classify_meeting_fail()`:
+
+```cpp
+// March 2026 marketplace policy (not an SDK-header fact): joins into meetings
+// hosted OUTSIDE this app's account are rejected server-side unless the join
+// carried an OBF / on-behalf / app-privilege token. The rejection code is the
+// SAME one an unapproved app gets (63; 504 for the anonymous variant), so the
+// only way to tell "get approved" apart from "paste the token" is whether we
+// sent one. The caller passes presence, never the token itself.
+inline ZoomJoinError classify_meeting_fail_with_tokens(int code,
+                                                       bool had_cross_account_token)
+{
+    if (!had_cross_account_token &&
+        (code == 63 ||   // MEETING_FAIL_UNABLE_TO_JOIN_EXTERNAL_MEETING
+         code == 504))   // MEETING_FAIL_APP_CAN_NOT_ANONYMOUS_JOIN_MEETING
+        return ZoomJoinError::CrossAccountTokenRequired;
+    return classify_meeting_fail(code);
+}
+```
+
+- [ ] **Step 4: Run again**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: **64/64 green** (`CoreVideoJoinDecision` now includes the six new checks).
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/zoom-join-decision.h tests/join-decision-test.cpp
+git commit -m "feat(obf): classify cross-account-without-token joins as their own named error"
+```
+
+---### Task 3: Surface the named error in the dock and control API
+
+The classifier is useless until the wiring feeds it the token bit. `zoom_error_message()` (`src/zoom-engine-client.cpp:82`) is a static free function fed only the engine's JSON — it cannot know what the join carried, so `ZoomEngineClient::join()` must record presence (booleans only, mirroring the engine's `has_*` ack) and pass it through. This is exactly the wiring-vs-pure split that bit the talkback feature twice (CLAUDE.md, Task 5 fix rounds: "both Majors lived in wiring no test could reach"), so the presence-to-flag mapping itself goes through a tiny pure helper that a host test can drive.
+
+**Files:**
+- Modify: `src/zoom-engine-client.h` (member near the other join-state fields; helper declaration), `src/zoom-engine-client.cpp` (`join()` records presence; `zoom_error_message()` gains the flag parameter and consults `classify_meeting_fail_with_tokens` FIRST in its `meeting_failed` branch, before the hand-written per-code strings at lines 117-135)
+- Modify: `src/zoom-join-decision.h` (pure helper `join_tokens_carry_cross_account_context`)
+- Test: `tests/join-decision-test.cpp` (append)
+
+**Interfaces:**
+- Consumes: `ZoomJoinAuthTokens` (`src/zoom-types.h:25`), `bool ZoomEngineClient::join(const std::string &meeting_id, const std::string &passcode, const std::string &display_name, MeetingKind kind, const ZoomJoinAuthTokens &tokens)` (`src/zoom-engine-client.h:142-145`), Task 2's classifier.
+- Produces: `inline bool zoom_join::join_tokens_carry_cross_account_context(bool has_on_behalf, bool has_app_privilege)`; `std::atomic<bool> ZoomEngineClient::m_last_join_cross_account_token`. The operator-facing message for `cross_account_token_required` flows through the existing error pipeline: `zoom_error_message()` feeds the same string the dock shows in its failure QMessageBox and the control API surfaces in its error events, so both surfaces get the named error from this one change.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `tests/join-decision-test.cpp`:
+
+```cpp
+    // --- G1 wiring rule: which token kinds satisfy the cross-account
+    // --- requirement. A user ZAK is the SIGNED-IN account's token -- it
+    // --- establishes user context but Zoom still rejects it for a foreign
+    // --- account's meeting when app-level privilege is what's missing, and
+    // --- the auto_zak path always sends one. Counting it would make the
+    // --- named error unreachable on the exact path (sign-in + external
+    // --- meeting) the policy is about.
+    check(!zoom_join::join_tokens_carry_cross_account_context(false, false),
+          "obf wiring: nothing sent -> no cross-account context");
+    check(zoom_join::join_tokens_carry_cross_account_context(true, false),
+          "obf wiring: on-behalf token counts");
+    check(zoom_join::join_tokens_carry_cross_account_context(false, true),
+          "obf wiring: app privilege token counts");
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```sh
+cmake --build build --config Release --parallel 8
+```
+
+Expected: compile failure — `join_tokens_carry_cross_account_context` does not exist.
+
+- [ ] **Step 3: Minimal implementation**
+
+`src/zoom-join-decision.h`, next to `classify_meeting_fail_with_tokens()`:
+
+```cpp
+// Which token kinds count as "we sent cross-account context". Deliberately
+// NOT the user ZAK: auto_zak sends one on every signed-in join, so counting
+// it would route every real March-2026 rejection back to the generic
+// approval message. Presence booleans only -- callers never pass values.
+inline bool join_tokens_carry_cross_account_context(bool has_on_behalf,
+                                                    bool has_app_privilege)
+{
+    return has_on_behalf || has_app_privilege;
+}
+```
+
+`src/zoom-engine-client.h` — add near the other join bookkeeping members:
+
+```cpp
+    // Presence only, mirroring the engine's has_on_behalf_token /
+    // has_app_privilege_token ack -- token VALUES never live here. Read by
+    // zoom_error_message() wiring when a meeting_failed event arrives, which
+    // is on the pipe reader thread while join() runs elsewhere: atomic.
+    std::atomic<bool> m_last_join_cross_account_token{false};
+```
+
+`src/zoom-engine-client.cpp` — in `join()`, before writing the join command:
+
+```cpp
+    m_last_join_cross_account_token.store(
+        zoom_join::join_tokens_carry_cross_account_context(
+            !tokens.on_behalf_token.empty(),
+            !tokens.app_privilege_token.empty()),
+        std::memory_order_release);
+```
+
+`zoom_error_message()` becomes `static std::string zoom_error_message(const QJsonObject &obj, bool last_join_cross_account_token)` (update both call sites), and the TOP of its `meeting_failed` branch (line 116) — before the existing hand-written 63/504/505/506 strings, which stay as-is for the token-was-sent cases — gains:
+
+```cpp
+    if (msg == "meeting_failed") {
+        const zoom_join::ZoomJoinError category =
+            zoom_join::classify_meeting_fail_with_tokens(
+                code, last_join_cross_account_token);
+        if (category == zoom_join::ZoomJoinError::CrossAccountTokenRequired) {
+            std::string out = zoom_join::join_error_guidance(category);
+            out += " (code " + std::to_string(code) + ", id=";
+            out += zoom_join::join_error_id(category);
+            out += ")";
+            return out;
+        }
+        // ... existing per-code messages unchanged below ...
+```
+
+- [ ] **Step 4: Run again**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: **64/64 green**, plugin compiles with the new parameter at every `zoom_error_message` call site.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/zoom-join-decision.h src/zoom-engine-client.h src/zoom-engine-client.cpp tests/join-decision-test.cpp
+git commit -m "feat(obf): surface cross_account_token_required through the engine-client error pipeline"
+```
+
+---
+
+### Task 4: Persist the join token and token type, DPAPI-protected
+
+An operator who pastes an OBF token today loses it on OBS restart (gap G2) — and for a standing weekly show on a client's Zoom account, re-obtaining the token every session is exactly the friction that gets a show run without one. The repo already made the storage-safety decision for us: OAuth access/refresh tokens are stored in `global.ini` DPAPI-encrypted via `protect_secret()`/`unprotect_secret()` (`src/zoom-settings.cpp:176/206`, entangled with the machine+user; macOS uses the Keychain, other platforms refuse loudly at lines 51-63). The join token is the same class of secret and uses the same mechanism; the token TYPE is not a secret and stores plain. What is testable without libobs's config API is the persistence DECISION — what to store and when to clear — so that lives in a pure header, following `src/talkback-dock-state.h`'s precedent for dock wiring.
+
+**Files:**
+- Create: `src/join-token-persistence.h`, `tests/join-token-persistence-test.cpp`
+- Modify: `src/zoom-settings.h` (fields `join_token_type` / `join_token`), `src/zoom-settings.cpp` (load: `unprotect_secret(config_get_string(cfg, SECTION, "JoinToken"), "JoinToken")`, plain `JoinTokenType`; save: mirror lines 349-352's OAuth pattern with `protect_secret`), `src/zoom-dock.cpp` (seed combo+field from settings at construction ~753; persist via the decision helper in the existing save-on-successful-join block at 2754-2758), `CMakeLists.txt` (register test)
+- Test: `tests/join-token-persistence-test.cpp`
+
+**Interfaces:**
+- Consumes: `ZoomPluginSettings::load()/save()`, `protect_secret`/`unprotect_secret` (file-static in zoom-settings.cpp — the new fields ride the existing save/load functions, no new linkage).
+- Produces: `struct zoom_join::JoinTokenPersistDecision { std::string token_type; std::string token_value; }` and `inline JoinTokenPersistDecision join_token_persist_decision(const std::string &token_type, const std::string &typed_token)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/join-token-persistence-test.cpp`:
+
+```cpp
+// Pins the join-token persistence DECISION (gap G2, 2026-08-29 OBF plan).
+// The rules the dock wiring cannot show: auto_zak mode must CLEAR any stored
+// token (a stale OBF from last week's client silently riding along on an
+// own-account join is a support nightmare), and a manual mode with an empty
+// field keeps the stored token (the operator relying on persistence is the
+// feature working, not a clear request).
+#include "join-token-persistence.h"
+#include <cstdio>
+#include <string>
+
+static int failures = 0;
+static void check(bool cond, const std::string &name)
+{
+    if (!cond) { ++failures; std::printf("FAIL: %s\n", name.c_str()); }
+}
+
+int main()
+{
+    using zoom_join::join_token_persist_decision;
+    {
+        const auto d = join_token_persist_decision("app_privilege_token", "TOK_A");
+        check(d.token_type == "app_privilege_token", "manual+typed: type stored");
+        check(d.token_value == "TOK_A",              "manual+typed: value stored");
+        check(d.keep_stored_value == false,          "manual+typed: overwrites");
+    }
+    {
+        const auto d = join_token_persist_decision("user_zak", "");
+        check(d.token_type == "user_zak",   "manual+empty: type stored");
+        check(d.keep_stored_value == true,  "manual+empty: stored token kept");
+    }
+    {
+        const auto d = join_token_persist_decision("auto_zak", "");
+        check(d.token_type == "auto_zak",   "auto: type stored");
+        check(d.token_value.empty(),        "auto: value cleared");
+        check(d.keep_stored_value == false, "auto: stored token NOT kept");
+    }
+    {
+        const auto d = join_token_persist_decision("", "ignored");
+        check(d.token_type == "auto_zak",   "empty type: normalized to auto_zak");
+        check(d.keep_stored_value == false, "empty type: clears like auto");
+    }
+    if (failures == 0) { std::printf("join-token-persistence: all checks passed\n"); return 0; }
+    return 1;
+}
+```
+
+CMakeLists.txt, next to the `CoreVideoJoinInput` block:
+
+```cmake
+    add_executable(CoreVideoJoinTokenPersistenceTest
+        tests/join-token-persistence-test.cpp
+    )
+    target_include_directories(CoreVideoJoinTokenPersistenceTest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    add_test(NAME CoreVideoJoinTokenPersistence
+             COMMAND CoreVideoJoinTokenPersistenceTest)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```sh
+cmake --build build --config Release --parallel 8
+```
+
+Expected: compile failure — `join-token-persistence.h` does not exist.
+
+- [ ] **Step 3: Minimal implementation**
+
+`src/join-token-persistence.h`:
+
+```cpp
+#pragma once
+// Join-token persistence decision (gap G2, 2026-08-29 OBF plan). Pure and
+// Qt/OBS-free so tests/join-token-persistence-test.cpp can pin the rules;
+// the dock and ZoomPluginSettings only execute what this decides. The token
+// VALUE passes through here on its way to DPAPI storage and must never be
+// logged -- there is deliberately no formatter in this header.
+#include <string>
+
+namespace zoom_join {
+
+struct JoinTokenPersistDecision {
+    std::string token_type;         // normalized; always persisted (not a secret)
+    std::string token_value;        // value to store when !keep_stored_value
+    bool        keep_stored_value = false; // true: leave the stored secret alone
+};
+
+inline JoinTokenPersistDecision
+join_token_persist_decision(const std::string &token_type,
+                            const std::string &typed_token)
+{
+    JoinTokenPersistDecision d;
+    d.token_type = token_type.empty() ? "auto_zak" : token_type;
+    if (d.token_type == "auto_zak") {
+        // Auto mode clears: a stale cross-account token must not survive a
+        // return to own-account joins. token_value stays empty -> store "".
+        return d;
+    }
+    if (typed_token.empty()) {
+        d.keep_stored_value = true; // operator is USING persistence, not clearing
+        return d;
+    }
+    d.token_value = typed_token;
+    return d;
+}
+
+} // namespace zoom_join
+```
+
+Then the wiring (no new decisions, just execution): `ZoomPluginSettings` gains `std::string join_token_type = "auto_zak";` and `std::string join_token;` loaded/saved beside the OAuth tokens (`JoinToken` via `protect_secret`/`unprotect_secret` with account `"JoinToken"`, `JoinTokenType` plain); the dock constructor seeds `m_join_token_type` (find by `currentData`) and `m_join_token` from settings; the successful-join save block (`zoom-dock.cpp:2754-2758`) applies the decision:
+
+```cpp
+                const auto persist = zoom_join::join_token_persist_decision(
+                    token_type.toStdString(), typed_token);
+                saved.join_token_type = persist.token_type;
+                if (!persist.keep_stored_value)
+                    saved.join_token = persist.token_value;
+                saved.save();
+```
+
+(`token_type` and `typed_token` are already captured at `zoom-dock.cpp:2564-2567`; capture them into the join thread's lambda alongside the existing `tokens`.)
+
+- [ ] **Step 4: Run again**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: **65/65 green**.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/join-token-persistence.h tests/join-token-persistence-test.cpp src/zoom-settings.h src/zoom-settings.cpp src/zoom-dock.cpp CMakeLists.txt
+git commit -m "feat(obf): persist join token type + DPAPI-protected token across OBS restarts"
+```
+
+---
+
+### Task 5: Operator documentation — README, wiki, CLAUDE.md
+
+Gap G3: `README.md:343` documents only the automatic signed-in-ZAK flow; nothing tells an operator that joining a client's meeting after March 2, 2026 needs a token, where to get one, or that the dock combo / `?obf=` URL / control-API fields already accept it. Docs are part of done in this repo (standing directive), and the March deadline makes this the rare docs task with a compliance date attached.
+
+**Files:**
+- Modify: `README.md` (new subsection "Joining meetings on another Zoom account (OBF / app privilege tokens)" adjacent to the OAuth flow description at line 343), `wiki/Support.md` (troubleshooting entry keyed to the exact error id), `CLAUDE.md` (one paragraph in "Live testing" noting the control-API token fields and the `cross_account_token_required` id)
+- Test: none (docs)
+
+**Interfaces:**
+- Consumes: the shipped behavior of Tasks 2-4 (error id `cross_account_token_required`, persistence semantics, existing URL aliases from A4).
+- Produces: operator-facing prose only.
+
+- [ ] **Step 1: Write the README subsection.** It must state, in this order: the March 2, 2026 Zoom policy (labelled as Zoom marketplace policy); that joins to meetings on the app's own account are unaffected; the three ways to supply a token (dock: select "App privilege token", paste — persisted DPAPI-encrypted until the type is switched back to "Zoom sign-in"; URL: `?obf=<token>` / `?zak=<zak>` / `?app_privilege_token=<token>`; control API: `"on_behalf_token"` / `"user_zak"` / `"app_privilege_token"` fields on `{"cmd":"join"}`); what the `cross_account_token_required` error means and its thirty-second fix; and that token values never appear in logs (presence booleans only).
+- [ ] **Step 2: Write the wiki/Support.md entry.** Symptom-first: "Join fails with 'cross-account token required' (code 63/504)" → cause → the three supply paths → where the token comes from (the host account's Marketplace app / ISV flow — link Zoom's app privilege token docs).
+- [ ] **Step 3: Update CLAUDE.md** "Live testing" with the token fields on `join` and the error id, per the keep-CLAUDE.md-current directive.
+- [ ] **Step 4: Verify no token-shaped example strings look real** (use `<token>` placeholders in prose, never plausible base64), then commit:
+
+```sh
+git add README.md wiki/Support.md CLAUDE.md
+git commit -m "docs(obf): operator instructions for March 2026 cross-account join tokens"
+```
+
+---
+
+### Task 6: Live gate — cross-account join with and without a token
+
+The classifier's central assumption — that Zoom's server answers a token-less cross-account join with code 63 (or 504) — is a hypothesis until a real Zoom server says so (A3). This repo's plans end in live gates for exactly this reason (milestone-1 plan, Task 6). This gate needs a meeting hosted on a Zoom account that is NOT the signed-in CoreVideo account, and an app privilege token minted for it; the owner must provide both. Record verdicts in a notes file; do not touch code in this task.
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-08-29-obf-live-gate.md` (verdict record)
+- Test: live, via the control API (TCP line-JSON, `127.0.0.1:19870`) and the dock
+
+**Interfaces:**
+- Consumes: everything shipped in Tasks 1-5.
+- Produces: the recorded `MeetingFailCode` for the no-token case. **If it is not 63 or 504, reopen Task 2**: add the observed code to `classify_meeting_fail_with_tokens` with a comment citing this gate's log line, and re-run the suite.
+
+- [ ] **Step 1: Leg A — no token, expect the named error.** With OBS running (never a second instance) and Zoom signed in, send over the control API, one JSON object per line:
+
+```json
+{"cmd":"join","meeting_id":"<external-account meeting URL>","display_name":"CoreVideo Gate"}
+```
+
+Expected: join is accepted (`ok:true` — the ZAK fetch succeeds; the rejection is server-side), then the meeting fails. Record from the OBS log: the engine's `{"cmd":"error","msg":"meeting_failed","code":<N>,"reason":"MEETING_FAIL_..."}` line, and the plugin's operator message — it MUST contain `id=cross_account_token_required`. Record N.
+- [ ] **Step 2: Leg B — same meeting, token supplied.** Send:
+
+```json
+{"cmd":"join","meeting_id":"<same URL>","display_name":"CoreVideo Gate","app_privilege_token":"<token from host account>"}
+{"cmd":"start_engine"}
+{"cmd":"start_engine"}
+{"cmd":"list_outputs"}
+{"cmd":"leave"}
+```
+
+(`start_engine` twice — the second grants record rights, per CLAUDE.md.) Expected: the join reaches `MEETING_STATUS_INMEETING`, the engine ack shows `"has_app_privilege_token":true`, `list_outputs` returns a roster, and no log line anywhere contains the token value (grep the OBS log for the token's last 8 characters — zero hits required).
+- [ ] **Step 3: Leg C — dock parity.** Repeat leg A from the dock Join button (the join watchdog only arms on the dock path — control-API joins never set `m_join_started_ms`, so leg A proved nothing about it): expect the failure QMessageBox to show the Task 2 guidance text, and after selecting "App privilege token" + pasting, a successful join; restart OBS and confirm the type and token survived (field populated, joins without re-pasting).
+- [ ] **Step 4: Record and commit** the verdict file with: date, meeting account relationship, the observed fail code and reason string for leg A, pass/fail per leg, and the log-grep result for token leakage.
+
+```sh
+git add docs/superpowers/notes/2026-08-29-obf-live-gate.md
+git commit -m "docs(obf): live gate verdicts for cross-account join with and without token"
+```
+
+**Gate rule:** this plan is not done until all three legs pass. A leg-A code other than 63/504 is not a failure of the gate — it is the gate doing its job; loop it back into Task 2 and re-run legs A and C.

--- a/docs/superpowers/plans/2026-08-29-production-control-surface.md
+++ b/docs/superpowers/plans/2026-08-29-production-control-surface.md
@@ -1,0 +1,1048 @@
+# Production Control Surface: Push-Control of the Meeting
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the production side push control INTO the meeting — mute a participant, ask them to unmute, rename them, mute everyone, lower all hands — through one new `meeting_control` engine command exposed on the control API, the dock's participant list, and Companion actions.
+
+**Architecture:** One new fire-and-acknowledge IPC command (`meeting_control`) carries an action plus a participant *display name*; the engine resolves the name to a meeting-scoped id at execution time, gates the action through a pure decision header (`src/meeting-control-plan.h`, mirroring `src/talkback-plan.h`), calls the SDK controller, and reports the `SDKError` verdict asynchronously as a `"cmd":"meeting_control"` E2P line. The plugin logs that line verbatim and stashes it for polling; the control API, dock context menu, and Companion actions are thin senders over the same path.
+
+**Tech Stack:** C++17, Zoom Windows Meeting SDK 7.1.5.43953, CMake + CTest, named-pipe line-JSON IPC, Qt6, TypeScript Companion module.
+
+**Spec:** This document doubles as the spec.
+
+Requirements:
+
+1. Actions: `mute` (one participant), `ask_unmute` (one participant), `mute_all`, `rename` (one participant, new name), `lower_all_hands`. All addressed by display name, resolved to a user id only at the moment the SDK call is made.
+2. Every action's outcome is reported asynchronously — the control API/dock/Companion ack only confirms the trigger was accepted (the repo's `talkback_probe` shape). The engine's result line carries the raw `SDKError` code and a named reason; a refusal is never silent.
+3. A request the engine can already prove will fail (not host/co-host, name not in roster, two participants sharing the name) is refused with a named reason *before* any SDK call, by pure logic pinned by a host test.
+4. **Spotlight and pin are OUT OF SCOPE — the vendored SDK headers cannot express them.** `third_party/zoom-sdk/h/meeting_video_interface.h` is a slim vendored stub: `IMeetingVideoController` declares ONLY `SetEvent(IMeetingVideoCtrlEvent*)` (line 40). There is no `SpotlightVideo`, `UnSpotlightVideo`, `UnSpotlightAllVideos`, `PinVideo`, or any `CanSpotlight`/`CanPin` check anywhere under `third_party/zoom-sdk/h` (verified by grep; the only spotlight symbols are the *receive-side* callback `onSpotlightedUserListChangeNotification` and the self-facing settings toggles `EnableSpotlightSelf`/`IsSpotlightSelfEnabled` in `setting_service_interface.h:1197-1203`). The honest alternative shipped by this plan: nothing pretends to spotlight. The existing receive-side spotlight-slot outputs (`subscribe` with `"mode":"spotlight"`) remain the production lever for following what the *host inside Zoom* spotlights. Pushing spotlight/pin becomes possible only when a fuller `meeting_video_interface.h` is vendored — at which point it slots into this same `meeting_control` action namespace.
+5. **`ask_unmute` is a request, not a force.** The vendored `meeting_audio_interface.h:184-189` documents `UnMuteAudio(unsigned int userid)` only as "Unmutes the assigned user" — the doc comment does not state consent semantics. On the live SDK, unmuting *another* user does not force their mic hot: the target receives the host's start-audio request (`IMeetingAudioCtrlEvent::onHostRequestStartAudio`, same header lines 125-128, with the `IRequestStartAudioHandler` Accept/Ignore/Cancel flow at lines 50-75) and must consent. So the action is *named* `ask_unmute`, its success means "request delivered", and the actual unmute is observed the way everything else is: the roster's `is_muted` flag flips when `onUserAudioStatusChange` fires. `IMeetingParticipantsController::AskAllToUnmute()` (`meeting_participants_ctrl_interface.h:674`) exists for the all-hands variant but is not wired in this plan; `ask_unmute` per person covers the production need.
+
+SDK ground truth (exact signatures from `third_party/zoom-sdk/h`):
+
+- `meeting_audio_interface.h:181` — `virtual SDKError MuteAudio(unsigned int userid, bool allowUnmuteBySelf = true) = 0;` — doc: "ZERO(0) indicates to mute all the participants." Mute-all is `MuteAudio(0, allowUnmuteBySelf)`; there is no separate mute-all call.
+- `meeting_audio_interface.h:189` — `virtual SDKError UnMuteAudio(unsigned int userid) = 0;`
+- `meeting_audio_interface.h:218` — `virtual bool IsMuteOnEntryEnabled() = 0;` (not wired here; noted as the adjacent knob).
+- `meeting_participants_ctrl_interface.h:580` — `virtual SDKError ChangeUserName(const unsigned int userid, const zchar_t* userName, bool bSaveUserName) = 0;` — doc: "Only the host or co-host can change the others' name."
+- `meeting_participants_ctrl_interface.h:570` — `virtual SDKError LowerAllHands(bool forWebinarAttendees) = 0;`
+- `meeting_participants_ctrl_interface.h:95,164` — `IUserInfo::IsHost()`, `IUserInfo::GetUserRole()` returning `UserRole` (`USERROLE_HOST`, `USERROLE_COHOST`, ... lines 18-32); `GetMySelfUser()` at line 526. `MakeHost(unsigned int)` (603) and `AssignCoHost(unsigned int)` (619) exist but are deliberately not exposed — handing off host from a control surface is a show-ending misclick.
+
+## Global Constraints
+
+- Build: `cmake --build build --config Release --parallel 8`. Test: `cd build && ctest -C Release --output-on-failure` — must be N/N green (the suite gains one executable, `CoreVideoMeetingControlPlanTest`).
+- Tests are plain executables, no framework, `check()`-style, one file per invariant cluster, registered in `CMakeLists.txt` (mirror the `CoreVideoTalkbackPlan` block at `CMakeLists.txt:1104-1111`).
+- Commands are routed by EXACT match on the declared `cmd` field (`src/engine-command.h`), never substring, and every new command is pinned in `tests/engine-command-test.cpp` with its verbatim wire line (that file doubles as the wire-format record).
+- Participants are addressed by display name everywhere; names resolve to meeting-scoped ids only at use time, engine-side. Ids are never stored on a button, in a config, or across a rejoin.
+- Companion: `companion/manifest.json` `runtime.apiVersion` must stay schema-valid, the build must emit ESM, and the version must be bumped on every rebuild you intend to install (Companion refuses to overwrite a version already on disk). Dropdown choices are baked at `buildActions()` time and are already rebuilt on roster change (`index.ts:203`).
+- Comments state the constraint the code cannot show — when a decision is motivated by a doc-comment or a live behavior, cite it.
+- Never run a second OBS instance while testing (pipe/SDK singleton collision, crash loop). Send `{"cmd":"leave"}` before closing OBS.
+
+---
+
+### Task 1: Route the `meeting_control` command
+
+The engine identifies commands by exact match on the declared `cmd` field — a substring dispatch once routed every `unsubscribe` into the `subscribe` branch. A new command must be added to the token list, the enum, and the routing function together, and pinned by the existing routing test (this mirrors Task 1 of `docs/superpowers/plans/2026-08-24-zoom-talkback-milestone-1.md` exactly).
+
+**Files:**
+- Modify: `src/engine-ipc.h:26` (add token after `IPC_CMD_TALKBACK_NOMINATE`)
+- Modify: `src/engine-command.h:32-50` (enum), `src/engine-command.h:86-106` (routing)
+- Test: `tests/engine-command-test.cpp`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `IPC_CMD_MEETING_CONTROL` (string literal `"meeting_control"`), `IpcCommand::MeetingControl`. Task 3 branches on the enum; Task 4 emits the literal.
+
+- [ ] **Step 1: Write the failing test.** Append inside `main()` in `tests/engine-command-test.cpp`, before the final `if (g_failures > 0)` block:
+
+```cpp
+    // ── Meeting control (production push-control) routes exactly ───────────
+    routes(R"({"cmd":"meeting_control","action":"mute","participant":"Sarah Muller"})",
+           IpcCommand::MeetingControl,
+           "meeting_control did not route to IpcCommand::MeetingControl");
+    // A payload containing the token must not route (the substring disease).
+    routes(R"({"cmd":"join","display_name":"meeting_control"})",
+           IpcCommand::Join,
+           "a payload containing 'meeting_control' hijacked the join branch");
+    routes(R"({"cmd":"meeting_control_extra"})", IpcCommand::Unknown,
+           "a longer command starting with meeting_control matched it");
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+```sh
+cmake --build build --config Release --target CoreVideoEngineCommandTest --parallel 8
+```
+
+Expected: compile FAILURE, `'MeetingControl' is not a member of 'IpcCommand'`.
+
+- [ ] **Step 3: Minimal implementation.** In `src/engine-ipc.h` after `#define IPC_CMD_TALKBACK_NOMINATE "talkback_nominate"`:
+
+```c
+#define IPC_CMD_MEETING_CONTROL "meeting_control"
+```
+
+In `src/engine-command.h`, add to the enum after `TalkbackNominate,`:
+
+```cpp
+    MeetingControl,
+```
+
+and in `ipc_command_of()`, before `return IpcCommand::Unknown;`:
+
+```cpp
+    if (cmd == IPC_CMD_MEETING_CONTROL) return IpcCommand::MeetingControl;
+```
+
+- [ ] **Step 4: Run to verify it passes.**
+
+```sh
+cmake --build build --config Release --target CoreVideoEngineCommandTest --parallel 8
+cd build && ctest -C Release -R CoreVideoEngineCommand --output-on-failure
+```
+
+Expected: PASS, `engine-command: all tests passed`.
+
+- [ ] **Step 5: Commit.**
+
+```sh
+git add src/engine-ipc.h src/engine-command.h tests/engine-command-test.cpp
+git commit -m "feat(prod-control): route the meeting_control command"
+```
+
+---
+
+### Task 2: The decision header — `src/meeting-control-plan.h`
+
+Every Major this repo's talkback feature shipped lived in wiring no test could reach; the standing rule is that pure decision logic goes in a Qt/OBS/SDK-free header pinned by a host test (`src/talkback-plan.h` is the model). The decisions here: which string names which action, whether a requested action + our role + the resolved target is allowed or refused-with-a-named-reason, how a display name resolves against a roster that can contain duplicates, and the exact shape of the engine's result report. A non-privileged refusal must be a NAMED reason (`not_host_or_cohost`), never silent and never a bare SDK integer.
+
+**Files:**
+- Create: `src/meeting-control-plan.h`
+- Create: `tests/meeting-control-plan-test.cpp`
+- Modify: `CMakeLists.txt` (new test block after the `CoreVideoTalkbackPlan` block at `CMakeLists.txt:1104-1111`)
+
+**Interfaces:**
+- Consumes: nothing (header is dependency-free by design).
+- Produces (all `inline`, all consumed by Tasks 3, 5, 6):
+
+```cpp
+enum class MeetingControlAction { Unknown, Mute, AskUnmute, MuteAll, Rename, LowerAllHands };
+MeetingControlAction meeting_control_action_of(const std::string &s);
+struct MeetingControlTarget { uint32_t user_id; bool found; bool ambiguous; bool is_self; };
+MeetingControlTarget meeting_control_resolve(
+    const std::vector<std::pair<std::string, uint32_t>> &roster,
+    const std::string &name, uint32_t self_id);
+struct MeetingControlVerdict { bool allowed; std::string reason; };
+MeetingControlVerdict meeting_control_decide(MeetingControlAction action,
+    bool self_is_host_or_cohost, const MeetingControlTarget &target);
+std::string meeting_control_validate(MeetingControlAction action,
+    const std::string &participant, const std::string &new_name);
+std::string meeting_control_report(const std::string &action, bool ok,
+    int sdk_code, const std::string &reason);
+```
+
+- [ ] **Step 1: Write the failing test.** Create `tests/meeting-control-plan-test.cpp`:
+
+```cpp
+// Pins the production-control decision logic: action naming, name→id
+// resolution against a duplicate-bearing roster, the privilege gate, and the
+// report line shape. Free of Qt/OBS/SDK so it runs with no engine and no
+// meeting — the layer this repo's tests can never reach is the one these
+// decisions must therefore not live in.
+#include "meeting-control-plan.h"
+#include <iostream>
+
+static int g_failures = 0;
+static void check(bool ok, const char *what)
+{
+    if (!ok) { std::cerr << "FAIL: " << what << "\n"; ++g_failures; }
+}
+
+int main()
+{
+    // ── Action naming fails closed ──────────────────────────────────────────
+    check(meeting_control_action_of("mute") == MeetingControlAction::Mute, "mute names Mute");
+    check(meeting_control_action_of("ask_unmute") == MeetingControlAction::AskUnmute, "ask_unmute names AskUnmute");
+    check(meeting_control_action_of("mute_all") == MeetingControlAction::MuteAll, "mute_all names MuteAll");
+    check(meeting_control_action_of("rename") == MeetingControlAction::Rename, "rename names Rename");
+    check(meeting_control_action_of("lower_all_hands") == MeetingControlAction::LowerAllHands, "lower_all_hands names LowerAllHands");
+    check(meeting_control_action_of("unmute") == MeetingControlAction::Unknown,
+          "'unmute' must NOT map to anything — the action is a request and is named ask_unmute");
+    check(meeting_control_action_of("") == MeetingControlAction::Unknown, "empty action is Unknown");
+
+    // ── Resolution: by exact name, duplicates are AMBIGUOUS not first-wins ──
+    const std::vector<std::pair<std::string, uint32_t>> roster = {
+        {"Sarah Muller", 101}, {"Luis Ortiz", 102}, {"Guest", 103}, {"Guest", 104}, {"OBS", 105},
+    };
+    auto t = meeting_control_resolve(roster, "Sarah Muller", 105);
+    check(t.found && !t.ambiguous && t.user_id == 101 && !t.is_self, "unique name resolves");
+    t = meeting_control_resolve(roster, "Guest", 105);
+    check(t.found && t.ambiguous, "duplicate display name is ambiguous, never first-match");
+    t = meeting_control_resolve(roster, "Nobody Here", 105);
+    check(!t.found, "absent name is not found");
+    t = meeting_control_resolve(roster, "sarah muller", 105);
+    check(!t.found, "names match EXACTLY — case variants are different people (talkback-plan.h rule)");
+    t = meeting_control_resolve(roster, "OBS", 105);
+    check(t.found && t.is_self, "self is flagged so the privilege gate can wave self-actions through");
+
+    // ── The privilege gate: refusals are NAMED ─────────────────────────────
+    MeetingControlTarget hit{101, true, false, false};
+    check(meeting_control_decide(MeetingControlAction::Mute, true, hit).allowed, "host mutes");
+    auto v = meeting_control_decide(MeetingControlAction::Mute, false, hit);
+    check(!v.allowed && v.reason == "not_host_or_cohost", "non-privileged mute is refused BY NAME");
+    v = meeting_control_decide(MeetingControlAction::MuteAll, false, MeetingControlTarget{});
+    check(!v.allowed && v.reason == "not_host_or_cohost", "mute_all needs host/co-host");
+    v = meeting_control_decide(MeetingControlAction::LowerAllHands, false, MeetingControlTarget{});
+    check(!v.allowed && v.reason == "not_host_or_cohost", "lower_all_hands needs host/co-host");
+    v = meeting_control_decide(MeetingControlAction::Rename, false, hit);
+    check(!v.allowed && v.reason == "not_host_or_cohost",
+          "rename of another needs host/co-host (ChangeUserName doc comment)");
+    MeetingControlTarget self_hit{105, true, false, true};
+    check(meeting_control_decide(MeetingControlAction::Rename, false, self_hit).allowed,
+          "renaming SELF needs no privilege — the doc restricts only others' names");
+    check(meeting_control_decide(MeetingControlAction::Mute, false, self_hit).allowed,
+          "muting self needs no privilege");
+    v = meeting_control_decide(MeetingControlAction::Mute, true, MeetingControlTarget{0, false, false, false});
+    check(!v.allowed && v.reason == "participant_not_found", "absent target refused by name");
+    v = meeting_control_decide(MeetingControlAction::Mute, true, MeetingControlTarget{0, true, true, false});
+    check(!v.allowed && v.reason == "ambiguous_name",
+          "two people sharing the name: refuse — muting the wrong face is worse than refusing");
+    v = meeting_control_decide(MeetingControlAction::Unknown, true, hit);
+    check(!v.allowed && v.reason == "unknown_action", "unknown action fails closed even for the host");
+
+    // ── Control-API request validation (Task 5 consumes this) ──────────────
+    check(meeting_control_validate(MeetingControlAction::Mute, "", "") == "participant_required",
+          "mute without a participant is invalid");
+    check(meeting_control_validate(MeetingControlAction::Rename, "Sarah Muller", "") == "new_name_required",
+          "rename without a new name is invalid");
+    check(meeting_control_validate(MeetingControlAction::MuteAll, "", "").empty(),
+          "mute_all needs no participant");
+    check(meeting_control_validate(MeetingControlAction::Unknown, "x", "y") == "invalid_action",
+          "unknown action is invalid at the API edge too");
+    check(meeting_control_validate(MeetingControlAction::AskUnmute, "Sarah Muller", "").empty(),
+          "well-formed ask_unmute validates clean");
+
+    // ── The report line the engine emits (Task 3 consumes this) ────────────
+    check(meeting_control_report("mute", true, 0, "") ==
+              R"({"cmd":"meeting_control","action":"mute","ok":true,"code":0})",
+          "success report carries the SDK code and no reason field");
+    check(meeting_control_report("rename", false, 12, "sdk_error") ==
+              R"({"cmd":"meeting_control","action":"rename","ok":false,"code":12,"reason":"sdk_error"})",
+          "failure report names the reason and keeps the raw SDKError code");
+
+    if (g_failures > 0) {
+        std::cerr << "meeting-control-plan: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "meeting-control-plan: all tests passed\n";
+    return 0;
+}
+```
+
+Register it in `CMakeLists.txt` directly after the `CoreVideoTalkbackPlan` block (line 1111):
+
+```cmake
+    # Production push-control decisions: who may do what to whom, and how the
+    # verdict is reported. Pure logic — see src/meeting-control-plan.h.
+    add_executable(CoreVideoMeetingControlPlanTest
+        tests/meeting-control-plan-test.cpp
+    )
+    target_include_directories(CoreVideoMeetingControlPlanTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoMeetingControlPlan
+             COMMAND CoreVideoMeetingControlPlanTest)
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+```sh
+cmake --build build --config Release --target CoreVideoMeetingControlPlanTest --parallel 8
+```
+
+Expected: compile FAILURE, `Cannot open include file: 'meeting-control-plan.h'`.
+
+- [ ] **Step 3: Minimal implementation.** Create `src/meeting-control-plan.h`:
+
+```cpp
+#pragma once
+//
+// meeting-control-plan.h — the production-control decisions: which string
+// names which push action, how a display name resolves against a roster that
+// can contain duplicates, whether our role permits the action, and the exact
+// result line the engine reports.
+//
+// Free of Qt / OBS / Zoom SDK dependencies so every decision can be pinned by
+// a test with no engine and no meeting (src/talkback-plan.h's reason for
+// existing; both of that feature's shipped Majors lived in wiring no test
+// could reach).
+//
+// Names are compared EXACTLY, and a duplicate is refused as ambiguous rather
+// than first-match resolved: muting the wrong person on air is strictly worse
+// than refusing and making the operator disambiguate in Zoom itself.
+//
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+enum class MeetingControlAction { Unknown, Mute, AskUnmute, MuteAll, Rename, LowerAllHands };
+
+// Fails closed: anything unrecognised — including "unmute", which does not
+// exist because UnMuteAudio on another user is a consent REQUEST, not a
+// force (see the plan's SDK-ground-truth notes) — is Unknown.
+inline MeetingControlAction meeting_control_action_of(const std::string &s)
+{
+    if (s == "mute")            return MeetingControlAction::Mute;
+    if (s == "ask_unmute")      return MeetingControlAction::AskUnmute;
+    if (s == "mute_all")        return MeetingControlAction::MuteAll;
+    if (s == "rename")          return MeetingControlAction::Rename;
+    if (s == "lower_all_hands") return MeetingControlAction::LowerAllHands;
+    return MeetingControlAction::Unknown;
+}
+
+struct MeetingControlTarget {
+    uint32_t user_id  = 0;
+    bool found        = false;
+    bool ambiguous    = false; // two or more roster entries share the name
+    bool is_self      = false;
+};
+
+// Resolve at USE time only — ids are meeting-scoped and recycled, so nothing
+// upstream of this call ever stores one. Exact comparison, deliberately: two
+// people can differ only in case and both be real (talkback-plan.h's rule).
+inline MeetingControlTarget meeting_control_resolve(
+    const std::vector<std::pair<std::string, uint32_t>> &roster,
+    const std::string &name, uint32_t self_id)
+{
+    MeetingControlTarget t;
+    for (const auto &entry : roster) {
+        if (entry.first != name) continue;
+        if (t.found) { t.ambiguous = true; return t; }
+        t.found = true;
+        t.user_id = entry.second;
+    }
+    if (t.found) t.is_self = (t.user_id == self_id);
+    return t;
+}
+
+struct MeetingControlVerdict {
+    bool allowed = false;
+    std::string reason; // empty iff allowed
+};
+
+// The pre-SDK gate. This can only ever prove "known bad" — the SDK's own
+// verdict is still final and still reported (Task 3) — but a refusal here is
+// NAMED, where the SDK would return a bare integer mid-show. Self-targeted
+// mute/ask_unmute/rename skip the privilege check: ChangeUserName's doc
+// restricts only "the others' name", and muting/unmuting yourself is any
+// participant's right.
+inline MeetingControlVerdict meeting_control_decide(MeetingControlAction action,
+    bool self_is_host_or_cohost, const MeetingControlTarget &target)
+{
+    if (action == MeetingControlAction::Unknown)
+        return {false, "unknown_action"};
+    const bool needs_target = action == MeetingControlAction::Mute ||
+                              action == MeetingControlAction::AskUnmute ||
+                              action == MeetingControlAction::Rename;
+    if (needs_target) {
+        if (target.ambiguous) return {false, "ambiguous_name"};
+        if (!target.found)    return {false, "participant_not_found"};
+        if (target.is_self)   return {true, {}};
+    }
+    if (!self_is_host_or_cohost) return {false, "not_host_or_cohost"};
+    return {true, {}};
+}
+
+// Control-API edge validation (Task 5): shape errors are caught before the
+// command crosses the pipe, so the socket ack can refuse them synchronously
+// with a machine-readable token instead of acking a command the engine will
+// drop on the floor.
+inline std::string meeting_control_validate(MeetingControlAction action,
+    const std::string &participant, const std::string &new_name)
+{
+    if (action == MeetingControlAction::Unknown) return "invalid_action";
+    const bool needs_target = action == MeetingControlAction::Mute ||
+                              action == MeetingControlAction::AskUnmute ||
+                              action == MeetingControlAction::Rename;
+    if (needs_target && participant.empty()) return "participant_required";
+    if (action == MeetingControlAction::Rename && new_name.empty())
+        return "new_name_required";
+    return {};
+}
+
+// The one report shape (Task 3 emits it, the plugin's handle_event logs and
+// stashes it verbatim). `code` is the raw SDKError integer (-1 when no SDK
+// call was made); `reason` is present only on failure so a success line stays
+// grep-clean. `action` is caller-supplied and never participant-controlled,
+// so no escaping is needed — keep it that way.
+inline std::string meeting_control_report(const std::string &action, bool ok,
+    int sdk_code, const std::string &reason)
+{
+    std::string line = R"({"cmd":"meeting_control","action":")" + action +
+        R"(","ok":)" + (ok ? "true" : "false") +
+        R"(,"code":)" + std::to_string(sdk_code);
+    if (!ok) line += R"(,"reason":")" + reason + "\"";
+    line += "}";
+    return line;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes.**
+
+```sh
+cmake --build build --config Release --target CoreVideoMeetingControlPlanTest --parallel 8
+cd build && ctest -C Release -R CoreVideoMeetingControlPlan --output-on-failure
+```
+
+Expected: PASS, `meeting-control-plan: all tests passed`.
+
+- [ ] **Step 5: Commit.**
+
+```sh
+git add src/meeting-control-plan.h tests/meeting-control-plan-test.cpp CMakeLists.txt
+git commit -m "feat(prod-control): decision header — action naming, name resolution, privilege gate, report shape"
+```
+
+---
+
+### Task 3: The engine branch — resolve, gate, call the SDK, report
+
+The engine's command loop (`engine/src/main.cpp`) gains a `MeetingControl` branch after the `TalkbackNominate` branch (`engine/src/main.cpp:1664`). It gathers context from the SDK (roster pairs and self-role, via the same `GetMeetingParticipantsController()` the `INMEETING` handler uses at `main.cpp:1011`), runs `meeting_control_decide()`, makes exactly one SDK call, and reports through `meeting_control_report()` via `EngineIpc::write()` (`engine/src/engine-writer.h:48` — serialised, safe from this thread). The branch is thin wiring by design: every decision it makes is already pinned by Task 2's test, which is the only way this layer's logic gets tested at all (the SDK controllers cannot be faked cheaply — `IMeetingParticipantsController` has ~60 pure virtuals).
+
+**Files:**
+- Modify: `engine/src/main.cpp` (include near the other `src/` includes at the top; branch after line 1664's `TalkbackNominate` block closes)
+- Test: covered by `tests/meeting-control-plan-test.cpp` (Task 2) for every decision, and by `tests/engine-command-test.cpp` (Task 1) for routing; this task's verification is the full suite staying green plus a clean engine build.
+
+**Interfaces:**
+- Consumes: `IpcCommand::MeetingControl` (Task 1); `meeting_control_action_of` / `meeting_control_resolve` / `meeting_control_decide` / `meeting_control_report` (Task 2); `json_str` (`engine/src/engine-json.h`), `to_zstr` and `zchar_to_utf8` (already used by the Join branch and `user_to_info` at `main.cpp:587`).
+- Produces: the `{"cmd":"meeting_control",...}` E2P report line (Task 4 consumes it).
+
+- [ ] **Step 1: Write the failing check.** Add to `tests/engine-command-test.cpp` the verbatim line the engine branch will parse — with `rename`'s extra fields — pinning the wire format before the branch exists:
+
+```cpp
+    routes(R"({"cmd":"meeting_control","action":"rename","participant":"Sarah Muller","new_name":"Sarah M (Panel)"})",
+           IpcCommand::MeetingControl, "meeting_control rename routes with its payload fields");
+    // allow_unmute rides mute/mute_all; absent means true (see the engine
+    // branch: absence-of-":false" parsing, same style as video_only).
+    routes(R"({"cmd":"meeting_control","action":"mute_all","allow_unmute":false})",
+           IpcCommand::MeetingControl, "meeting_control mute_all routes with allow_unmute");
+```
+
+- [ ] **Step 2: Run to verify state.**
+
+```sh
+cmake --build build --config Release --target CoreVideoEngineCommandTest --parallel 8
+cd build && ctest -C Release -R CoreVideoEngineCommand --output-on-failure
+```
+
+Expected: PASS (routing already exists from Task 1 — these lines extend the wire-format record; the failing half of this task is the engine build below, which does not compile until the branch's include is added correctly).
+
+- [ ] **Step 3: Implement the branch.** In `engine/src/main.cpp`, add `#include "../../src/meeting-control-plan.h"` beside the existing `#include "../../src/engine-command.h"`, then after the `TalkbackNominate` branch:
+
+```cpp
+        } else if (command == IpcCommand::MeetingControl) {
+            const std::string action_str = json_str(line, "action");
+            const MeetingControlAction action = meeting_control_action_of(action_str);
+            // One reporter for every exit: a refusal must be a named reason on
+            // the pipe, never a silently skipped branch (the repo's standing
+            // rule — fire-and-acknowledge means the ack is worthless without
+            // the async verdict actually arriving).
+            auto report = [&](bool ok, int code, const std::string &reason) {
+                EngineIpc::write(meeting_control_report(action_str, ok, code, reason));
+            };
+            if (!meeting_svc) { report(false, -1, "not_in_meeting"); continue; }
+            auto *part_ctrl  = meeting_svc->GetMeetingParticipantsController();
+            auto *audio_ctrl = meeting_svc->GetMeetingAudioController();
+            if (!part_ctrl || !audio_ctrl) { report(false, -1, "no_controller"); continue; }
+
+            // Context is gathered fresh per command — ids are meeting-scoped,
+            // so resolution happens HERE, never earlier (global constraint).
+            uint32_t self_id = 0;
+            bool privileged = false;
+            if (auto *self = part_ctrl->GetMySelfUser()) {
+                self_id = self->GetUserID();
+                const ZOOMSDK::UserRole role = self->GetUserRole();
+                privileged = self->IsHost() ||
+                             role == ZOOMSDK::USERROLE_HOST ||
+                             role == ZOOMSDK::USERROLE_COHOST;
+            }
+            std::vector<std::pair<std::string, uint32_t>> roster_pairs;
+            if (auto *list = part_ctrl->GetParticipantsList()) {
+                for (int i = 0; i < list->GetCount(); ++i) {
+                    if (auto *u = part_ctrl->GetUserByUserID(list->GetItem(i)))
+                        roster_pairs.emplace_back(zchar_to_utf8(u->GetUserName()),
+                                                  u->GetUserID());
+                }
+            }
+            const std::string who = json_str(line, "participant");
+            const MeetingControlTarget target =
+                meeting_control_resolve(roster_pairs, who, self_id);
+            const MeetingControlVerdict verdict =
+                meeting_control_decide(action, privileged, target);
+            if (!verdict.allowed) { report(false, -1, verdict.reason); continue; }
+
+            // Absent field defaults to allowing self-unmute — the humane
+            // default; parsed by absence-of-":false" like video_only
+            // (src/engine-command.h) because the naive decoder has no bools.
+            const bool allow_unmute =
+                line.find("\"allow_unmute\":false") == std::string::npos;
+            ZOOMSDK::SDKError err = ZOOMSDK::SDKERR_UNKNOWN;
+            switch (action) {
+            case MeetingControlAction::Mute:
+                err = audio_ctrl->MuteAudio(target.user_id, allow_unmute);
+                break;
+            case MeetingControlAction::AskUnmute:
+                // A consent REQUEST on modern SDKs — the target sees the
+                // host's unmute prompt; success means delivered, and the real
+                // unmute shows up as the roster's is_muted flipping.
+                err = audio_ctrl->UnMuteAudio(target.user_id);
+                break;
+            case MeetingControlAction::MuteAll:
+                // MuteAudio's own doc: "ZERO(0) indicates to mute all the
+                // participants." There is no dedicated mute-all call.
+                err = audio_ctrl->MuteAudio(0, allow_unmute);
+                break;
+            case MeetingControlAction::Rename: {
+                // Persistent storage of to_zstr's result is NOT needed here:
+                // unlike Join(), ChangeUserName is synchronous — the pointer
+                // only has to outlive the call.
+                const auto wide_name = to_zstr(json_str(line, "new_name"));
+                err = part_ctrl->ChangeUserName(target.user_id,
+                                                wide_name.c_str(),
+                                                /*bSaveUserName=*/false);
+                break;
+            }
+            case MeetingControlAction::LowerAllHands:
+                // false = everyone who is not a webinar attendee — the whole
+                // room in a regular meeting (the signature's own doc).
+                err = part_ctrl->LowerAllHands(false);
+                break;
+            case MeetingControlAction::Unknown:
+                break; // unreachable: decide() refused it above
+            }
+            report(err == ZOOMSDK::SDKERR_SUCCESS, static_cast<int>(err),
+                   err == ZOOMSDK::SDKERR_SUCCESS ? "" : "sdk_error");
+```
+
+- [ ] **Step 4: Build everything and run the whole suite.**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: full build (plugin AND engine — both binaries ship as a pair), all tests green.
+
+- [ ] **Step 5: Commit.**
+
+```sh
+git add engine/src/main.cpp tests/engine-command-test.cpp
+git commit -m "feat(prod-control): engine meeting_control branch — resolve, gate, call SDK, report verdict"
+```
+
+---
+
+### Task 4: Plugin sender and result stash — `ZoomEngineClient`
+
+The plugin needs a sender that emits the verbatim wire line Task 3 parses, and a `handle_event` branch that logs the engine's verdict line verbatim and stashes it for polling — exactly the `talkback_probe` pattern (`src/zoom-engine-client.cpp:1351-1363`): log verbatim (a stage that doesn't reach the log may as well not have been reported), stash under `m_mtx` with the lock scope kept to the copy alone.
+
+**Files:**
+- Modify: `src/zoom-engine-client.h` (declare `meeting_control()` + `meeting_control_status()` beside `talkback_probe()` at line 153; member `m_meeting_control_status` beside `m_talkback_probe_status` at line 395)
+- Modify: `src/zoom-engine-client.cpp` (sender beside `talkback_probe` at line 907; `handle_event` branch beside the `talkback_probe` branch at line 1351)
+- Test: `tests/engine-command-test.cpp` (the sender's verbatim output lines are already pinned by Tasks 1 and 3 — this task must keep the sender byte-identical to them)
+
+**Interfaces:**
+- Consumes: `IPC_CMD_MEETING_CONTROL` literal (via the emitted string), `json_escape` (already in `zoom-engine-client.cpp`).
+- Produces:
+
+```cpp
+void ZoomEngineClient::meeting_control(const std::string &action,
+    const std::string &participant, const std::string &new_name, bool allow_unmute);
+std::string ZoomEngineClient::meeting_control_status() const; // raw last verdict line, "" before the first
+```
+
+- [ ] **Step 1: Confirm the wire pin exists (the failing state).** The check is Task 3's `routes(...)` lines: the sender below must produce those bytes. Run:
+
+```sh
+cd build && ctest -C Release -R CoreVideoEngineCommand --output-on-failure
+```
+
+Expected: PASS — and any drift the sender introduces later must be reflected there first (that file doubles as the wire-format record; a sender emitting a line the record does not contain is the failure this step guards).
+
+- [ ] **Step 2: Implement the sender.** In `src/zoom-engine-client.cpp`, after `talkback_probe()`:
+
+```cpp
+void ZoomEngineClient::meeting_control(const std::string &action,
+                                       const std::string &participant,
+                                       const std::string &new_name,
+                                       bool allow_unmute)
+{
+    if (!m_running.load(std::memory_order_acquire)) return;
+    // "action" is emitted FIRST after cmd and is never participant-controlled;
+    // the participant-controlled strings come last. Same first-match-scan
+    // reasoning as talkback_nominate()'s "attempt" ordering: the engine's
+    // json_str() is not a real JSON parser, so nothing an operator or a
+    // participant types may sit between a needle and its value.
+    std::string json = R"({"cmd":"meeting_control","action":")" +
+                       json_escape(action) + "\"";
+    if (!allow_unmute) json += R"(,"allow_unmute":false)";
+    if (!participant.empty())
+        json += R"(,"participant":")" + json_escape(participant) + "\"";
+    if (!new_name.empty())
+        json += R"(,"new_name":")" + json_escape(new_name) + "\"";
+    json += "}";
+    write_json(json);
+}
+
+std::string ZoomEngineClient::meeting_control_status() const
+{
+    std::lock_guard<std::mutex> lk(m_mtx);
+    return m_meeting_control_status;
+}
+```
+
+In `handle_event()`, beside the `talkback_probe` branch:
+
+```cpp
+    if (cmd == "meeting_control") {
+        // Verbatim, like every fire-and-acknowledge verdict in this file: the
+        // ack over the socket promised nothing except that THIS line would
+        // eventually say what happened.
+        blog(LOG_INFO, "[obs-zoom-plugin] meeting_control: %s", line.c_str());
+        {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            m_meeting_control_status = line;
+        }
+        return;
+    }
+```
+
+Declarations in `src/zoom-engine-client.h` beside `talkback_probe()` (line 153) and member `std::string m_meeting_control_status;` beside `m_talkback_probe_status` (line 395). Clear it in the `cmd == "left"` world-reset branch (`handle_event()`, the same place `m_roster` is cleared — a verdict from the previous meeting must not answer a poll about this one).
+
+- [ ] **Step 3: Build and run the suite.**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit.**
+
+```sh
+git add src/zoom-engine-client.h src/zoom-engine-client.cpp
+git commit -m "feat(prod-control): plugin meeting_control sender + verbatim verdict stash"
+```
+
+---
+
+### Task 5: Control API — `meeting_control` and `meeting_control_status`
+
+The TCP control API (`src/zoom-control-server.cpp`, 127.0.0.1:19870) gains the operator-facing command, mirroring `talkback_nominate`'s shape exactly (`zoom-control-server.cpp:888-941`): validate synchronously with named errors, check `is_running()` BEFORE acking (F6's lesson — `meeting_control()` early-returns on a dead pipe, so acking first would ack a silently dropped command), fire, and ack with a note pointing at the async verdict. The verdict is polled via `meeting_control_status`.
+
+**Files:**
+- Modify: `src/zoom-control-server.cpp` (new handlers after the `talkback_key` block; add both command names to the `help` list at line 471)
+- Test: request validation is pinned by `tests/meeting-control-plan-test.cpp` (Task 2's `meeting_control_validate` checks); this task wires it.
+
+**Interfaces:**
+- Consumes: `meeting_control_action_of` / `meeting_control_validate` (Task 2); `ZoomEngineClient::meeting_control()` / `meeting_control_status()` (Task 4).
+- Produces: control-API commands `{"cmd":"meeting_control","action":"mute","participant":"Sarah Muller","allow_unmute":true}` and `{"cmd":"meeting_control_status"}`.
+
+- [ ] **Step 1: The failing check.** Add to `tests/meeting-control-plan-test.cpp` (this is the exact contract the handler enforces — write it first):
+
+```cpp
+    // The control server must refuse a rename that names nobody new — pinned
+    // here because the server itself needs Qt+libobs to compile and the two
+    // Majors this repo shipped in Task-5-shaped wiring were both unreachable
+    // by any host test until their logic moved into a header.
+    check(meeting_control_validate(meeting_control_action_of("rename"), "", "New Name") ==
+              "participant_required",
+          "rename with a new_name but no participant is refused participant_required first");
+```
+
+- [ ] **Step 2: Run to verify it fails, then passes** (it passes immediately if Task 2's ordering already checks participant before new_name — if it does, keep the check as a pin and note it compiled red-green with Task 2's header absent):
+
+```sh
+cmake --build build --config Release --target CoreVideoMeetingControlPlanTest --parallel 8
+cd build && ctest -C Release -R CoreVideoMeetingControlPlan --output-on-failure
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Implement the handlers.** In `src/zoom-control-server.cpp` after the `talkback_key` block (include `"meeting-control-plan.h"` at the top):
+
+```cpp
+    // Production push-control: fire-and-acknowledge, talkback_nominate's
+    // shape. The ack only confirms the trigger; the SDKError verdict arrives
+    // as a "meeting_control" OBS log line and is polled below.
+    if (cmd == "meeting_control") {
+        const std::string action_str  = req.value("action").toString().toStdString();
+        const std::string participant = req.value("participant").toString().toStdString();
+        const std::string new_name    = req.value("new_name").toString().toStdString();
+        const MeetingControlAction action = meeting_control_action_of(action_str);
+        const std::string invalid =
+            meeting_control_validate(action, participant, new_name);
+        if (!invalid.empty()) {
+            write_response(socket, {{"ok", false},
+                                    {"error", QString::fromStdString(invalid)}});
+            return;
+        }
+        // F6's lesson: is_running() BEFORE the ack — meeting_control() drops
+        // the command silently on a dead pipe.
+        if (!ZoomEngineClient::instance().is_running()) {
+            write_response(socket, {{"ok", false}, {"error", "engine_not_running"},
+                {"message", "The Zoom engine is not running."}});
+            return;
+        }
+        if (ZoomEngineClient::instance().state() != MeetingState::InMeeting) {
+            write_response(socket, {{"ok", false}, {"error", "not_in_meeting"},
+                {"message", "Join the meeting before sending meeting control."}});
+            return;
+        }
+        blog(LOG_INFO, "[obs-zoom-plugin] Control API: meeting_control action=%s",
+             action_str.c_str());
+        ZoomEngineClient::instance().meeting_control(action_str, participant,
+            new_name, req.value("allow_unmute").toBool(true));
+        write_response(socket, {{"ok", true},
+            {"note", "sent; poll meeting_control_status or watch the OBS log "
+                     "for the meeting_control verdict"}});
+        return;
+    }
+
+    if (cmd == "meeting_control_status") {
+        write_response(socket, {{"ok", true},
+            {"last_result", QString::fromStdString(
+                 ZoomEngineClient::instance().meeting_control_status())}});
+        return;
+    }
+```
+
+Add `"meeting_control"` and `"meeting_control_status"` to the `help` command list.
+
+- [ ] **Step 4: Build, run the suite, and drive it live once.**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Then against a real meeting (single OBS instance; host or co-host account): `join`, `start_engine` twice, then `{"cmd":"meeting_control","action":"mute","participant":"<name>"}` — expect `ok:true` on the socket, a `meeting_control ... "ok":true,"code":0` OBS log line, and the dock roster's mute badge flipping; then the same from a NON-privileged join — expect `"reason":"not_host_or_cohost"` in the verdict, never silence. Send `{"cmd":"leave"}` before closing OBS.
+
+- [ ] **Step 5: Commit.**
+
+```sh
+git add src/zoom-control-server.cpp tests/meeting-control-plan-test.cpp
+git commit -m "feat(prod-control): control API meeting_control + polled verdict"
+```
+
+---
+
+### Task 6: Dock — per-participant context menu
+
+The dock's participant list (`m_participant_list`, `src/zoom-dock.h:113`, rebuilt at `src/zoom-dock.cpp:2227-2248`) already stores the display name at `Qt::UserRole + 1` precisely so by-name actions never resolve off the id (the comment at `zoom-dock.cpp:2236-2240` says exactly this). A right-click menu offers the state-appropriate actions; which entries appear is pure logic in the plan header, because the dock needs libobs and Qt to compile and this repo's rule is that no decision lives where no test can reach it.
+
+**Files:**
+- Modify: `src/meeting-control-plan.h` (menu helper), `tests/meeting-control-plan-test.cpp`
+- Modify: `src/zoom-dock.cpp` (context-menu policy where `m_participant_list` is constructed; handler)
+
+**Interfaces:**
+- Consumes: `ZoomEngineClient::meeting_control()` (Task 4), `ZoomEngineClient::roster()`.
+- Produces: `std::vector<MeetingControlMenuItem> meeting_control_menu(bool is_muted);`
+
+- [ ] **Step 1: The failing test.** Append to `tests/meeting-control-plan-test.cpp`:
+
+```cpp
+    // ── Dock menu composition (Task 6) ──────────────────────────────────────
+    {
+        const auto unmuted = meeting_control_menu(false);
+        check(unmuted.size() == 2 &&
+                  unmuted[0].action == MeetingControlAction::Mute &&
+                  unmuted[1].action == MeetingControlAction::Rename,
+              "unmuted participant offers Mute then Rename — never Ask to Unmute");
+        const auto muted = meeting_control_menu(true);
+        check(muted.size() == 2 &&
+                  muted[0].action == MeetingControlAction::AskUnmute &&
+                  muted[1].action == MeetingControlAction::Rename,
+              "muted participant offers Ask to Unmute then Rename — never Mute");
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+```sh
+cmake --build build --config Release --target CoreVideoMeetingControlPlanTest --parallel 8
+```
+
+Expected: compile FAILURE, `'meeting_control_menu': identifier not found`.
+
+- [ ] **Step 3: Implement.** In `src/meeting-control-plan.h`:
+
+```cpp
+struct MeetingControlMenuItem {
+    MeetingControlAction action;
+    const char *label; // UI text; the dock uses it verbatim
+};
+
+// Offering "Mute" on someone already muted (or "Ask to Unmute" on someone
+// talking) is a menu that can only refuse — the dock-keys milestone's m3/m4
+// rule: never offer a press whose only possible outcome is a refusal.
+inline std::vector<MeetingControlMenuItem> meeting_control_menu(bool is_muted)
+{
+    std::vector<MeetingControlMenuItem> items;
+    if (is_muted)
+        items.push_back({MeetingControlAction::AskUnmute, "Ask to Unmute"});
+    else
+        items.push_back({MeetingControlAction::Mute, "Mute"});
+    items.push_back({MeetingControlAction::Rename, "Rename..."});
+    return items;
+}
+```
+
+In `src/zoom-dock.cpp`, where `m_participant_list` is constructed, set `m_participant_list->setContextMenuPolicy(Qt::CustomContextMenu);` and connect:
+
+```cpp
+    connect(m_participant_list, &QListWidget::customContextMenuRequested, this,
+            [this](const QPoint &pos) {
+        auto *item = m_participant_list->itemAt(pos);
+        if (!item) return;
+        // By NAME, from UserRole+1 — the id in UserRole is meeting-scoped and
+        // this menu can outlive a roster tick (the stored-name comment at the
+        // rebuild site is the law here).
+        const std::string name =
+            item->data(Qt::UserRole + 1).toString().toStdString();
+        bool is_muted = false;
+        for (const auto &p : ZoomEngineClient::instance().roster())
+            if (p.display_name == name) { is_muted = p.is_muted; break; }
+        QMenu menu(m_participant_list);
+        for (const auto &entry : meeting_control_menu(is_muted)) {
+            const MeetingControlAction action = entry.action;
+            menu.addAction(QString::fromUtf8(entry.label), [this, action, name]() {
+                std::string new_name;
+                if (action == MeetingControlAction::Rename) {
+                    bool accepted = false;
+                    new_name = QInputDialog::getText(this, tr("Rename Participant"),
+                        tr("New display name:"), QLineEdit::Normal,
+                        QString::fromStdString(name), &accepted).toStdString();
+                    if (!accepted || new_name.empty()) return;
+                }
+                const char *action_str =
+                    action == MeetingControlAction::Mute      ? "mute" :
+                    action == MeetingControlAction::AskUnmute ? "ask_unmute" :
+                                                                "rename";
+                ZoomEngineClient::instance().meeting_control(action_str, name,
+                                                             new_name, true);
+            });
+        }
+        menu.addSeparator();
+        menu.addAction(tr("Mute All"), []() {
+            ZoomEngineClient::instance().meeting_control("mute_all", "", "", true);
+        });
+        menu.addAction(tr("Lower All Hands"), []() {
+            ZoomEngineClient::instance().meeting_control("lower_all_hands", "", "", true);
+        });
+        menu.exec(m_participant_list->mapToGlobal(pos));
+    });
+```
+
+Add `#include <QMenu>`, `#include <QInputDialog>`, and `#include "meeting-control-plan.h"` to `zoom-dock.cpp`'s includes. The verdict surfaces exactly as everywhere else: the `meeting_control` OBS log line, and the roster badge flipping on the next `participants` update — no new label.
+
+- [ ] **Step 4: Run to verify it passes.**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: full build, all green. Then live: right-click a participant in the dock while host — mute badge flips within one roster tick.
+
+- [ ] **Step 5: Commit.**
+
+```sh
+git add src/meeting-control-plan.h tests/meeting-control-plan-test.cpp src/zoom-dock.cpp
+git commit -m "feat(prod-control): dock participant context menu (mute / ask-unmute / rename / mute-all / lower-hands)"
+```
+
+---
+
+### Task 7: Companion actions
+
+Five new actions in `companion/companion-module-corevideo-obs/src/actions.ts`, sending `meeting_control` over the same control API via `inst.sendPlugin()`. Participants are stored BY NAME (the `participantChoices` dropdown at `actions.ts:24-27` already exists and is already rebuilt on roster change by `index.ts:203`) — and unlike `zoom_assign`, these actions send the NAME itself, never a resolved id: the control API takes names, so no `resolveParticipantId` call, no staleness window at all. The module has vitest (`state.test.ts`), so this task is genuinely test-first.
+
+**Files:**
+- Create: `companion/companion-module-corevideo-obs/src/actions.test.ts`
+- Modify: `companion/companion-module-corevideo-obs/src/actions.ts`
+- Modify: `companion/companion-module-corevideo-obs/package.json` (version 1.0.2 → 1.0.3, BOTH the top-level `"version"` and the `companion.version` block) and `companion/companion-module-corevideo-obs/companion/manifest.json` (`"version": "1.0.3"`; leave `runtime.apiVersion` at 2.1.3)
+
+**Interfaces:**
+- Consumes: control-API `meeting_control` (Task 5) via `inst.sendPlugin`.
+- Produces: actions `zoom_mute_participant`, `zoom_ask_unmute`, `zoom_mute_all`, `zoom_rename_participant`, `zoom_lower_all_hands`.
+
+- [ ] **Step 1: Write the failing test.** Create `src/actions.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { buildActions } from './actions.js'
+import { defaultState } from './state.js'
+import type { CoreVideoInstance } from './index.js'
+
+function stubInstance() {
+	const sendPlugin = vi.fn()
+	const state = defaultState()
+	state.zoom.participants = [
+		{ id: 101, name: 'Sarah Muller', has_video: true, is_talking: false, is_muted: false },
+		{ id: 102, name: 'Luis Ortiz', has_video: true, is_talking: false, is_muted: true },
+	]
+	const inst = {
+		state,
+		sendPlugin,
+		sendSidecar: vi.fn(),
+		obsRequest: vi.fn(),
+		log: vi.fn(),
+	} as unknown as CoreVideoInstance
+	return { inst, sendPlugin }
+}
+
+describe('meeting_control actions', () => {
+	it('sends mute by NAME, never by id', () => {
+		const { inst, sendPlugin } = stubInstance()
+		const actions = buildActions(inst) as Record<string, { callback: (a: unknown) => unknown }>
+		actions.zoom_mute_participant.callback({ options: { participant: 'Sarah Muller' } })
+		expect(sendPlugin).toHaveBeenCalledWith({
+			cmd: 'meeting_control', action: 'mute', participant: 'Sarah Muller',
+		})
+	})
+
+	it('sends ask_unmute — the action is a request, so it is not named unmute', () => {
+		const { inst, sendPlugin } = stubInstance()
+		const actions = buildActions(inst) as Record<string, { callback: (a: unknown) => unknown }>
+		actions.zoom_ask_unmute.callback({ options: { participant: 'Luis Ortiz' } })
+		expect(sendPlugin).toHaveBeenCalledWith({
+			cmd: 'meeting_control', action: 'ask_unmute', participant: 'Luis Ortiz',
+		})
+	})
+
+	it('sends mute_all with allow_unmute carried through', () => {
+		const { inst, sendPlugin } = stubInstance()
+		const actions = buildActions(inst) as Record<string, { callback: (a: unknown) => unknown }>
+		actions.zoom_mute_all.callback({ options: { allow_unmute: false } })
+		expect(sendPlugin).toHaveBeenCalledWith({
+			cmd: 'meeting_control', action: 'mute_all', allow_unmute: false,
+		})
+	})
+
+	it('sends rename with the new name', () => {
+		const { inst, sendPlugin } = stubInstance()
+		const actions = buildActions(inst) as Record<string, { callback: (a: unknown) => unknown }>
+		actions.zoom_rename_participant.callback({
+			options: { participant: 'Sarah Muller', new_name: 'Sarah M (Panel)' },
+		})
+		expect(sendPlugin).toHaveBeenCalledWith({
+			cmd: 'meeting_control', action: 'rename',
+			participant: 'Sarah Muller', new_name: 'Sarah M (Panel)',
+		})
+	})
+
+	it('sends lower_all_hands with no target', () => {
+		const { inst, sendPlugin } = stubInstance()
+		const actions = buildActions(inst) as Record<string, { callback: (a: unknown) => unknown }>
+		actions.zoom_lower_all_hands.callback({ options: {} })
+		expect(sendPlugin).toHaveBeenCalledWith({ cmd: 'meeting_control', action: 'lower_all_hands' })
+	})
+})
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+```sh
+cd companion/companion-module-corevideo-obs && npm run test
+```
+
+Expected: FAIL — `actions.zoom_mute_participant` is `undefined`.
+
+- [ ] **Step 3: Implement.** In `src/actions.ts`, add a section after `zoom_cancel_recovery` (inside the returned object). The participant dropdowns reuse the existing `participantChoices` const (rebuilt on roster change per the module's CLAUDE rules):
+
+```ts
+		// ── Zoom: Meeting control (push) ────────────────────────────────────────
+		// All by NAME — the control API resolves to a live id engine-side at
+		// execution time, so unlike zoom_assign there is no id resolution (and
+		// no staleness window) in this module at all. Verdicts are async: the
+		// plugin ack only confirms the trigger; the SDKError verdict lands in
+		// the OBS log and in meeting_control_status.
+
+		zoom_mute_participant: {
+			name: 'Zoom: Mute Participant',
+			options: [
+				{
+					type: 'dropdown', id: 'participant', label: 'Participant (by name)',
+					default: '', allowCustom: true, choices: participantChoices,
+				},
+			],
+			callback: (a) => inst.sendPlugin({ cmd: 'meeting_control', action: 'mute',
+				participant: a.options.participant }),
+		},
+
+		zoom_ask_unmute: {
+			// "Ask", honestly: the SDK's UnMuteAudio on another user raises the
+			// host's unmute prompt on THEIR screen — it cannot force a mic hot.
+			name: 'Zoom: Ask Participant to Unmute',
+			options: [
+				{
+					type: 'dropdown', id: 'participant', label: 'Participant (by name)',
+					default: '', allowCustom: true, choices: participantChoices,
+				},
+			],
+			callback: (a) => inst.sendPlugin({ cmd: 'meeting_control', action: 'ask_unmute',
+				participant: a.options.participant }),
+		},
+
+		zoom_mute_all: {
+			name: 'Zoom: Mute All',
+			options: [
+				{ type: 'checkbox', id: 'allow_unmute', label: 'Allow self-unmute', default: true },
+			],
+			callback: (a) => inst.sendPlugin({ cmd: 'meeting_control', action: 'mute_all',
+				allow_unmute: a.options.allow_unmute }),
+		},
+
+		zoom_rename_participant: {
+			name: 'Zoom: Rename Participant',
+			options: [
+				{
+					type: 'dropdown', id: 'participant', label: 'Participant (by name)',
+					default: '', allowCustom: true, choices: participantChoices,
+				},
+				{ type: 'textinput', id: 'new_name', label: 'New display name', default: '' },
+			],
+			callback: (a) => inst.sendPlugin({ cmd: 'meeting_control', action: 'rename',
+				participant: a.options.participant, new_name: a.options.new_name }),
+		},
+
+		zoom_lower_all_hands: {
+			name: 'Zoom: Lower All Hands',
+			options: [],
+			callback: () => inst.sendPlugin({ cmd: 'meeting_control', action: 'lower_all_hands' }),
+		},
+```
+
+Then bump the version to 1.0.3 in `package.json` (both places) and `companion/manifest.json` — Companion refuses to overwrite a module version already on disk, so an unbumped rebuild silently keeps testing the old bundle.
+
+- [ ] **Step 4: Run to verify it passes, then build the installable bundle.**
+
+```sh
+cd companion/companion-module-corevideo-obs && npm run test && npm run build
+node -e "import('./dist/index.js').then(m => { if (typeof m.default !== 'function') { console.error('entrypoint is not a constructor'); process.exit(1); } console.log('entrypoint OK'); })"
+```
+
+Expected: vitest green, `tsc` clean, `entrypoint OK` (the ESM/constructor check the Companion loader itself performs).
+
+- [ ] **Step 5: Commit.**
+
+```sh
+git add companion/companion-module-corevideo-obs/src/actions.ts companion/companion-module-corevideo-obs/src/actions.test.ts companion/companion-module-corevideo-obs/package.json companion/companion-module-corevideo-obs/companion/manifest.json
+git commit -m "feat(prod-control): Companion actions — mute / ask-unmute / mute-all / rename / lower-all-hands"
+```
+
+---
+
+Closing notes for the implementer: update `CLAUDE.md` in the same change as the substantive work (standing directive — docs-updated is part of done): the control-API section gains `meeting_control`/`meeting_control_status`, and the Companion section's action list grows by five. Nothing in this plan touches the media path, the audio ring, or teardown ordering; every invariant in CLAUDE.md's list is untouched by construction because `meeting_control` is a pure control-plane round trip.

--- a/docs/superpowers/plans/2026-08-29-share-raw-data-source.md
+++ b/docs/superpowers/plans/2026-08-29-share-raw-data-source.md
@@ -1,0 +1,888 @@
+# Screen Share as a First-Class Source — Gap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four real gaps that keep screen share from being a first-class source — share computer audio (dropped entirely today), a share ISO recording stem (explicitly excluded today), the `capture_ns` stamp the share SHM writer never writes, and a `screen_share` start/stop event on the control API and in Companion — without re-implementing the large share pipeline that already exists and works.
+
+**Architecture:** The engine (`ZoomObsEngine.exe`) already subscribes the active share via `IZoomSDKRenderer::subscribe(shareSourceID, RAW_DATA_TYPE_SHARE)` and publishes I420 frames into a generation-named SHM mailbox that the plugin's `zoom_share_source` reads. This plan extends the existing seams only: share audio rides the existing per-uuid audio ring (a new `share_audio` routing flag in `EngineAudio`, filled by the currently-stubbed `onShareAudioRawDataReceived`), the ISO stem rides the existing `record_video_frame`/`record_audio_frame` path (a one-predicate policy change plus a share-idle close), and the operator event rides the control server's existing 250 ms `poll_and_push()` edge detector.
+
+**Tech Stack:** C++17, Zoom Windows Meeting SDK 7.1.5.43953, CMake + CTest, named-pipe line-JSON IPC (`src/engine-ipc.h`), named shared memory, Qt6 for dock UI, TypeScript (`@companion-module/base` 2.x, vitest) for the Companion module.
+
+**Spec:** This document doubles as the spec. Requirements, with their current status stated honestly:
+
+1. **`RAW_DATA_TYPE_SHARE` subscription — ALREADY FULLY IMPLEMENTED.** `engine/src/engine-share.cpp` owns the whole lifecycle: attach on join (`engine/src/main.cpp:1024-1030`), scan `GetViewableSharingUserList()`/`GetSharingSourceInfoList()` for the active `shareSourceID` (`active_share_source_id()`), subscribe via `createRenderer` + `setRawDataResolution(ZoomSDKResolution_1080P)` + `subscribe(id, RAW_DATA_TYPE_SHARE)` (`engine-share.cpp:188-227`), and follow share begin/end/switch through `onSharingStatus`/`onShareContentNotification` (`engine-share.cpp:395-438`). Not re-planned. (SDK note: `ZoomSDKResolution` tops out at `ZoomSDKResolution_1080P` — there is no 4K entry in `third_party/zoom-sdk/h/rawdata_renderer_interface.h:12-20`, so 1080p is the most we can request; that is an SDK ceiling, not a gap.)
+2. **Dedicated "content" OBS source — ALREADY FULLY IMPLEMENTED.** `zoom_share_source` is registered in `src/zoom-source.cpp:2867-2872` as a `ZoomSource` variant defaulting to `AssignmentMode::ScreenShare`; assignment plumbing exists in the dock, output dialog, control API (`assign_output_ex` mode `screen_share`), OSC, and Companion's `zoom_assign_screen_share` action. Not re-planned. (`src/zoom-share-delegate.cpp` contains an older in-process duplicate whose `zoom_share_source_register()` has **no call site** — dead registration code. Deleting it is out of scope here; it must not be resurrected by this work.)
+3. **Dynamic share resolution — ALREADY FULLY IMPLEMENTED.** The engine's `ensure_shm()` moves to a new `_gN`-suffixed region on any growth (`engine-share.cpp:248-276`, per `src/shm-generation.h`), the frame event carries `shm_gen`, and the plugin's `shm_read_i420_frame()` remaps on generation change (`src/engine-ipc.h:604-677`). The ISO side re-segments on any width/height change (`ensure_session_locked`, `src/zoom-iso-recorder.cpp:467-479`). Not re-planned.
+4. **Share audio — GAP.** `EngineAudio::onShareAudioRawDataReceived` is an empty stub (`engine/src/engine-audio.cpp:418`); every sample of shared computer sound is dropped on the engine path. Tasks 1 closes this end to end.
+5. **`capture_ns` — GAP**, documented as such in `src/engine-ipc.h:117-122`: the share writer never stamps `ShmFrameHeader::capture_ns`, so a share output shows "-" for A/V Offset forever. Task 2.
+6. **Share ISO stem — GAP.** `ZoomIsoRecorder::should_record()` hard-excludes `AssignmentMode::ScreenShare` (`src/zoom-iso-recorder.cpp:452`) even though share frames already reach `record_video_frame()` (`src/zoom-source.cpp:1617`). Task 3.
+7. **Share start/stop events to the operator — PARTIAL.** Dock (roster "sharing" tags, `screen_share_assignment_label`, `ScreenShareUnavailable` health), control API polling (`list_participants` → `is_sharing_screen`; `list_outputs` → `screen_share_available`/`_participant_id`/`_participant_name`), and OSC push (`/zoom/event/screen_share`, `src/zoom-osc-server.cpp:938`) all exist. Missing: a pushed `screen_share` event on the TCP control API's `subscribe_events` stream (Task 4) and any Companion feedback/variable for share state (Task 5 — today Companion has only the assign action).
+
+## Global Constraints
+
+- Build from the worktree: `cmake --build build --config Release --parallel 8`; test: `cd build && ctest -C Release --output-on-failure` — must be N/N green (63 tests registered today; 65 after this plan).
+- Tests are plain executables, no framework: one `check()`-style file per invariant cluster in `tests/`, registered in `CMakeLists.txt` with `add_executable` + `add_test`. SDK-bound code that cannot be unit-tested says so and names its live verification instead.
+- Comments state the constraint the code cannot show; when a change is motivated by a live failure, say what happened, with numbers.
+- **Media events are prompts, not payloads** (CLAUDE.md): a share frame event means "read the newest frame", an audio event means "drain the ring". Nothing in this plan may put media payload semantics on the pipe.
+- Audio ring discipline is untouchable: free-running indices, edge-triggered `notify`, drain-fully-on-wakeup (`src/engine-ipc.h`). Share audio reuses `output_audio_frame()` verbatim rather than growing a sibling.
+- ISO pacing doctrine (`src/iso-video-pacer.h`): `-use_wallclock_as_timestamps` is proven a no-op on this ffmpeg build; every video stem is paced to `kIsoVideoTargetFps` before the pipe, and share inherits that path unchanged.
+- Never run a second OBS instance while one is testing (pipe/SDK singleton collision, crash loop). Send `{"cmd":"leave"}` before closing OBS.
+- Install verification is always the matched pair — `obs-zoom-plugin.dll` AND `zoom-runtime\ZoomObsEngine.exe`.
+- Update CLAUDE.md in the same change as the substantive work (standing directive).
+
+---
+
+### Task 1: Share computer audio, end to end
+
+The engine subscribes one process-wide raw-audio helper and fans buffers out by per-target flags (`isolate_audio`, `audience_audio`, default mixed — `engine/src/engine-audio.cpp:373-417`). Share audio needs a third flag, not a new pipeline: `onShareAudioRawDataReceived` fires only while someone shares with computer sound, exactly the shape of `onOneWayAudioRawDataReceived`. The plugin's side already works untouched — a share-assigned `ZoomSource` carries `OBS_SOURCE_AUDIO`, and its generic per-uuid audio-ring reader (`output_audio_from_shared_memory`) neither knows nor cares which engine callback filled the ring. The opt-in must be explicit on the wire (`"share_audio":true`) so an old plugin against a new engine keeps today's behavior byte-for-byte, and so mixed targets never double-receive share sound (the meeting mix already contains it).
+
+**Files:**
+- Modify: `src/engine-command.h:121-124` (new parse helper beside `ipc_subscribe_is_video_only`)
+- Modify: `engine/src/engine-audio.h:33-37` (init signature), `:55-83` (AudioTarget), `engine/src/engine-audio.cpp:14-49` (init), `:373-387` (mixed skip), `:418` (the stub)
+- Modify: `engine/src/main.cpp:1793-1794` (screenshare subscribe branch)
+- Modify: `src/zoom-engine-client.cpp:868-873` (`subscribe_screenshare` emits the field)
+- Test: `tests/engine-command-test.cpp`
+
+**Interfaces:**
+- Consumes: `EngineAudio::output_audio_frame(AudioTarget&, const std::string&, AudioRawData*, const char*)` (existing, unchanged).
+- Produces: `inline bool ipc_subscribe_wants_share_audio(const std::string &line)`; `bool EngineAudio::init(IpcFd e2p_fd, const std::string &source_uuid, uint32_t participant_id, bool isolate_audio, bool audience_audio, bool share_audio = false)`. Task 3's share ISO stem consumes the audio this task makes flow (via `record_audio_frame`, no new interface).
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `tests/engine-command-test.cpp`, before the final `if (failures == 0)` block:
+
+```cpp
+    // --- Share audio is an explicit opt-in on the screenshare subscribe ---
+    // The engine's onShareAudioRawDataReceived was a stub until 2026-08-29;
+    // when it started delivering, the opt-in had to be explicit so an old
+    // plugin (which never sends the field) keeps the audio-less behavior it
+    // was built against, and so mixed targets never hear share sound twice
+    // (the meeting mix already contains it).
+    check(ipc_subscribe_wants_share_audio(
+              R"({"cmd":"subscribe","source_uuid":"s1","mode":"screenshare","share_audio":true})"),
+          "share_audio:true on a screenshare subscribe was not detected");
+    check(!ipc_subscribe_wants_share_audio(
+              R"({"cmd":"subscribe","source_uuid":"s1","mode":"screenshare"})"),
+          "a subscribe without share_audio must not register an audio target");
+    check(!ipc_subscribe_wants_share_audio(
+              R"({"cmd":"subscribe","source_uuid":"s1","mode":"screenshare","share_audio":false})"),
+          "share_audio:false was treated as an opt-in");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cmake --build build --config Release --target CoreVideoEngineCommandTest --parallel 8
+```
+
+Expected: FAIL to compile with `'ipc_subscribe_wants_share_audio': identifier not found`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/engine-command.h`, immediately after `ipc_subscribe_is_video_only` (line 124):
+
+```cpp
+// Share computer sound for a screenshare subscribe. Same match discipline as
+// ipc_subscribe_is_video_only above. Explicit opt-in, default OFF: the field
+// is absent from every subscribe an older plugin sends, and absent-means-off
+// is what keeps a new engine byte-compatible with it.
+inline bool ipc_subscribe_wants_share_audio(const std::string &line)
+{
+    return line.find("\"share_audio\":true") != std::string::npos;
+}
+```
+
+In `engine/src/engine-audio.h`, change the `init` declaration (line 33) to:
+
+```cpp
+    bool init(IpcFd e2p_fd,
+              const std::string &source_uuid,
+              uint32_t participant_id,
+              bool isolate_audio,
+              bool audience_audio,
+              bool share_audio = false);
+```
+
+and in `AudioTarget` change the constructor and add the flag:
+
+```cpp
+        AudioTarget(IpcFd e2p, uint32_t pid, bool isolate, bool audience,
+                    bool share)
+            : e2p_fd(e2p), participant_id(pid),
+              isolate_audio(isolate), audience_audio(audience),
+              share_audio(share) {}
+        // ...existing members...
+        // Receives ONLY onShareAudioRawDataReceived buffers. Mutually
+        // exclusive with the other routes by construction: main.cpp's
+        // screenshare branch always passes isolate/audience false.
+        bool share_audio = false;
+```
+
+In `engine/src/engine-audio.cpp`, thread the flag through `init` (definition line 14: add the `bool share_audio` parameter, pass `share_audio` as the new constructor argument at line 42, and add `it->second->share_audio = share_audio;` beside the other in-place updates at lines 45-48). Then make the mixed route skip share targets (line 383):
+
+```cpp
+        // Skip isolate, audience AND share targets — none receive the mix.
+        if (entry.second->isolate_audio || entry.second->audience_audio ||
+            entry.second->share_audio)
+            continue;
+```
+
+(The two `onOneWayAudioRawDataReceived` passes need no change: both already require `isolate_audio` or `audience_audio` true, which a share target never is.)
+
+Replace the stub at `engine/src/engine-audio.cpp:418`:
+
+```cpp
+void EngineAudio::onShareAudioRawDataReceived(AudioRawData *data, uint32_t user_id)
+{
+    // Fires only while someone is sharing WITH computer sound — silence here
+    // usually means the sharer didn't tick "Share sound", not a fault.
+    if (!data || m_e2p_fd == kIpcInvalidFd || data->GetBufferLen() == 0) return;
+    tile_clock_log(user_id, data->GetTimeStamp(), tile_clock_now_ns(), "a");
+
+    std::lock_guard<std::mutex> lock(m_targets_mtx);
+    for (auto &entry : m_targets) {
+        if (!entry.second || !entry.second->share_audio) continue;
+        // Slot self-description (see ShmAudioSlot::participant_id): stamp the
+        // SHARER so ISO attribution follows a share takeover mid-recording.
+        entry.second->participant_id = user_id;
+        output_audio_frame(*entry.second, entry.first, data,
+                           "audio_share_frame_received");
+    }
+}
+```
+
+In `engine/src/main.cpp`, extend the screenshare branch (lines 1793-1794):
+
+```cpp
+                if (mode == "screenshare") {
+                    share_engine.subscribe(uuid, e2p);
+                    if (ipc_subscribe_wants_share_audio(line)) {
+                        EngineAudio::instance().init(e2p, uuid,
+                                                     /*participant_id=*/0,
+                                                     /*isolate_audio=*/false,
+                                                     /*audience_audio=*/false,
+                                                     /*share_audio=*/true);
+                    } else {
+                        // Mirror the video_only rule above: a re-subscribe
+                        // without the flag must stop the audio traffic a
+                        // previous opted-in subscribe of this uuid started.
+                        EngineAudio::instance().remove(uuid);
+                    }
+                } else {
+```
+
+In `src/zoom-engine-client.cpp`, make the plugin always request it (lines 868-873):
+
+```cpp
+void ZoomEngineClient::subscribe_screenshare(const std::string &source_uuid)
+{
+    if (!m_running.load(std::memory_order_acquire) || source_uuid.empty()) return;
+    write_json(R"({"cmd":"subscribe","source_uuid":")" + json_escape(source_uuid) +
+        R"(","mode":"screenshare","share_audio":true})");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: PASS — `engine-command: all tests passed`, full suite 63/63 (no new registrations in this task).
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/engine-command.h engine/src/engine-audio.h engine/src/engine-audio.cpp engine/src/main.cpp src/zoom-engine-client.cpp tests/engine-command-test.cpp
+git commit -m "feat(share): deliver share computer audio to screenshare sources"
+```
+
+---
+
+### Task 2: Stamp `capture_ns` on share frames
+
+`ShmFrameHeader::capture_ns`'s own comment (`src/engine-ipc.h:117-122`) calls this out: `engine/src/engine-video.cpp:318` stamps it, `engine/src/engine-share.cpp` does not — the share writer leaves the field at the region's zero-fill, the plugin's reader treats 0 as "not measured", and every share output shows "-" for A/V Offset permanently. "That is a gap, not a design decision." One line closes it; the comment that documents the lie is corrected in the same commit (this repo's standing comment-lie policy — three of them shipped in the talkback milestone alone).
+
+**Files:**
+- Modify: `engine/src/engine-share.cpp` (`#include "tile-clock-log.h"` at the top, one stamp in `onRawDataFrameReceived` at lines 345-353)
+- Modify: `src/engine-ipc.h:117-122` (delete the now-false "NOT WRITTEN BY EVERY PRODUCER" paragraph)
+
+**Interfaces:**
+- Consumes: `tile_clock_now_ns()` from `engine/src/tile-clock-log.h` (already used by `engine-video.cpp:228` and `engine-audio.cpp` with the same include).
+- Produces: nothing new — the existing plugin reader (`shm_read_i420_frame`'s `out_capture_ns`) starts receiving real values with zero plugin changes.
+
+- [ ] **Step 1: The failing check**
+
+No unit test — the writer is SDK-bound (`YUVRawDataI420` arrives only from a live renderer, and linking `engine-share.cpp` into a test drags in `createRenderer`/`destroyRenderer` from the SDK import library). The check is live, and it is written down before the code: with a share running, the diagnostics dialog's A/V Offset column for the share output must show a number instead of "-". Same precedent as the talkback plan's SDK-bound tasks: the compile is the gate at this step, Step 4 is the verification.
+
+- [ ] **Step 2: Confirm the current live failure**
+
+With any meeting + share active on the installed build: diagnostics dialog → share output → A/V Offset reads "-". (This is already known-true from the `engine-ipc.h` comment; re-confirming costs one glance during the Task 1 live pass and anchors the before/after.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+At the top of `engine/src/engine-share.cpp`, after `#include "engine-writer.h"`:
+
+```cpp
+#include "tile-clock-log.h"
+```
+
+In `onRawDataFrameReceived`, where the header fields are written (lines 351-353), add the stamp beside them:
+
+```cpp
+        hdr->width = w;
+        hdr->height = h;
+        hdr->y_len = static_cast<uint32_t>(y_len);
+        // Same clock, same caveats as engine-video.cpp's stamp — see
+        // ShmFrameHeader::capture_ns. Unstamped, the reader treats 0 as "not
+        // measured" and a share output showed "-" for A/V Offset forever
+        // (the engine-ipc.h comment documented this as a known gap).
+        hdr->capture_ns = tile_clock_now_ns();
+```
+
+In `src/engine-ipc.h`, replace the paragraph at lines 117-122 ("NOT WRITTEN BY EVERY PRODUCER ... That is a gap, not a design decision.") with:
+
+```cpp
+    // Written by BOTH producers: engine/src/engine-video.cpp and (since
+    // 2026-08-29) engine/src/engine-share.cpp stamp tile_clock_now_ns() here.
+    // A reader still treats 0 as "not measured" — a fresh region's zero-fill
+    // can be read before the first stamped frame lands.
+```
+
+- [ ] **Step 4: Build, run the suite, verify live**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: 63/63 green. Live (matched pair installed, share running): the share output's A/V Offset shows a real millisecond figure.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add engine/src/engine-share.cpp src/engine-ipc.h
+git commit -m "feat(share): stamp capture_ns on share frames so A/V offset is measured"
+```
+
+---
+
+### Task 3: Share ISO stem
+
+Share frames already flow through the exact machinery the stem needs: `record_video_frame()` is called for every engine frame a share source publishes (`src/zoom-source.cpp:1617`), sessions re-segment on any resolution change (`ensure_session_locked`), video is paced to `kIsoVideoTargetFps` before the ffmpeg pipe (`iso_video_frames_due()`), and — after Task 1 — share audio reaches `record_audio_frame()` (`src/zoom-source.cpp:2100`) with `iso_audio_silence_frames()` gap-fill. The only thing standing in the way is one predicate: `should_record()` returns false for `AssignmentMode::ScreenShare` (`src/zoom-iso-recorder.cpp:452`). Flipping it needs a second rule alongside: a share END sends no `on_output_removed` — the frames just cease — so an idle-close is the end-of-share signal, or one stem would silently span multiple share bursts with the between-time compressed out of the CFR video (exactly the "file shorter than the meeting" defect class the pacer exists for). Both decisions are pure, so they move into a header a test can pin.
+
+**Files:**
+- Create: `src/iso-record-policy.h`
+- Modify: `src/zoom-iso-recorder.cpp:447-458` (`should_record`), `:428-432` (comment on the share-close branch), `:686-706` (`sweep_unresolved_locked` gains the share-idle close), plus `#include "iso-record-policy.h"` at the top
+- Test: `tests/iso-record-policy-test.cpp`
+- Modify: `CMakeLists.txt` (register after the `CoreVideoIsoVideoPacer` block, `CMakeLists.txt:950-957`)
+
+**Interfaces:**
+- Consumes: `AssignmentMode` from `src/zoom-types.h` (pure — includes only `<cstdint>/<functional>/<string>`).
+- Produces: `inline bool iso_should_record(bool recorder_active, const std::string &source_uuid, AssignmentMode assignment, uint32_t resolved_participant_id)`; `inline bool iso_share_session_idle_expired(uint64_t last_video_ns, uint64_t now_ns)`; `constexpr uint64_t kIsoShareIdleCloseNs`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/iso-record-policy-test.cpp`:
+
+```cpp
+// tests/iso-record-policy-test.cpp
+// Which outputs get an ISO stem, and when a share stem ends. Pinned because
+// the previous rule was an inline hard-exclusion of ScreenShare that nothing
+// tested — and because a share end arrives as NOTHING (no roster edge, no
+// output removal, the frames just cease), so the idle-close threshold IS the
+// end-of-share signal and must not drift.
+#include "iso-record-policy.h"
+
+#include <iostream>
+
+static int failures = 0;
+
+static void check(bool ok, const char *message)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+int main()
+{
+    const std::string uuid = "u1";
+
+    // --- The recorder gate and the uuid gate hold for every mode ---
+    check(!iso_should_record(false, uuid, AssignmentMode::ScreenShare, 7),
+          "an inactive recorder must never open a stem");
+    check(!iso_should_record(true, std::string(), AssignmentMode::ScreenShare, 7),
+          "an empty source_uuid must never open a stem");
+
+    // --- Share records regardless of participant resolution ---
+    // Frames only flow while a share is active, so arrival is the liveness
+    // signal; the sharer's id (carried on the frame event) may lag it.
+    check(iso_should_record(true, uuid, AssignmentMode::ScreenShare, 0),
+          "a share stem must open even before the sharer id resolves");
+    check(iso_should_record(true, uuid, AssignmentMode::ScreenShare, 42),
+          "a share stem must open with a resolved sharer id");
+
+    // --- The pre-existing rules for the other modes are unchanged ---
+    check(iso_should_record(true, uuid, AssignmentMode::Participant, 42),
+          "a resolved participant must record");
+    check(!iso_should_record(true, uuid, AssignmentMode::Participant, 0),
+          "an unresolved participant must not record");
+    check(iso_should_record(true, uuid, AssignmentMode::ActiveSpeaker, 0),
+          "active speaker records even unresolved");
+    check(iso_should_record(true, uuid, AssignmentMode::SpotlightIndex, 0),
+          "spotlight records even unresolved");
+
+    // --- Share-idle close: strict threshold, no firing before first frame ---
+    check(!iso_share_session_idle_expired(0, 99'000'000'000ULL),
+          "a session with no video yet must not idle-close");
+    check(!iso_share_session_idle_expired(10'000'000'000ULL, 9'000'000'000ULL),
+          "a clock step backwards must not idle-close");
+    check(!iso_share_session_idle_expired(10'000'000'000ULL,
+                                          10'000'000'000ULL + kIsoShareIdleCloseNs),
+          "exactly the threshold is not yet expired (strict greater-than)");
+    check(iso_share_session_idle_expired(10'000'000'000ULL,
+                                         10'000'000'000ULL + kIsoShareIdleCloseNs + 1),
+          "one ns past the threshold must idle-close");
+
+    if (failures == 0)
+        std::cout << "iso-record-policy: all tests passed\n";
+    return failures == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Add to `CMakeLists.txt` immediately after the `add_test(NAME CoreVideoIsoVideoPacer ...)` block (line ~957):
+
+```cmake
+    # Which outputs get an ISO stem. ScreenShare was hard-excluded inline and
+    # untested; a share end also arrives as silence (no output removal), so
+    # the idle-close threshold is the end-of-share signal. See
+    # src/iso-record-policy.h.
+    add_executable(CoreVideoIsoRecordPolicyTest
+        tests/iso-record-policy-test.cpp
+    )
+    target_include_directories(CoreVideoIsoRecordPolicyTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoIsoRecordPolicy
+             COMMAND CoreVideoIsoRecordPolicyTest)
+```
+
+Then:
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target CoreVideoIsoRecordPolicyTest --parallel 8
+```
+
+Expected: FAIL — `Cannot open include file: 'iso-record-policy.h'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/iso-record-policy.h`:
+
+```cpp
+#pragma once
+//
+// iso-record-policy.h — which outputs get an ISO stem, and when a share
+// stem ends.
+//
+// ScreenShare was excluded from ISO by a hard `return false` inside
+// ZoomIsoRecorder::should_record() with no test pinning it, dating from
+// before the share path could feed the recorder at all. Everything the stem
+// needs already exists downstream: record_video_frame() paces share frames
+// to the same fixed cadence as every other stem (src/iso-video-pacer.h),
+// ensure_session_locked() re-segments on any resolution change (shares
+// resize far more often than cameras), and share audio gap-fill rides
+// src/iso-audio-gap-fill.h.
+//
+// The share-specific wrinkle is the ENDING. A participant stem ends via
+// on_output_removed() or the unresolved grace sweep; a share ending emits
+// neither — Zoom just stops delivering frames. Without an idle close, one
+// stem spans every share burst of the meeting with the idle time compressed
+// out of the CFR video (the same "file shorter than real time" defect class
+// iso-video-pacer.h documents, measured live 2026-08-19 as files finishing
+// in ~55-60% of the meeting's duration). Idle time on the video path is
+// therefore the end-of-share signal.
+//
+// Free of Qt / OBS / SDK dependencies so a test can pin both rules.
+//
+#include "zoom-types.h"
+
+#include <cstdint>
+#include <string>
+
+// 5 s with no share frame = the share is over; close and finalize the stem.
+// Comfortably above any real mid-share stall this codebase has measured
+// (share delivery pauses on static content are sub-second keepalives), and
+// short enough that back-to-back shares land in separate, correctly-timed
+// files.
+constexpr uint64_t kIsoShareIdleCloseNs = 5'000'000'000ULL;
+
+inline bool iso_should_record(bool recorder_active,
+                              const std::string &source_uuid,
+                              AssignmentMode assignment,
+                              uint32_t resolved_participant_id)
+{
+    if (!recorder_active || source_uuid.empty()) return false;
+    // Share frames only arrive while a share is live, so arrival itself is
+    // the liveness gate; the sharer id on the frame event may resolve late
+    // and must not hold the stem hostage.
+    if (assignment == AssignmentMode::ScreenShare) return true;
+    if (resolved_participant_id == 0 &&
+        assignment != AssignmentMode::ActiveSpeaker &&
+        assignment != AssignmentMode::SpotlightIndex)
+        return false;
+    return true;
+}
+
+// Strict greater-than, and never fires before the first frame (0) or across
+// a backwards clock step — same defensive shape as ipc_heartbeat_expired().
+inline bool iso_share_session_idle_expired(uint64_t last_video_ns,
+                                           uint64_t now_ns)
+{
+    return last_video_ns != 0 && now_ns > last_video_ns &&
+           (now_ns - last_video_ns) > kIsoShareIdleCloseNs;
+}
+```
+
+In `src/zoom-iso-recorder.cpp`: add `#include "iso-record-policy.h"` beside the other iso includes (line 2-4); replace the body of `should_record` (lines 447-458):
+
+```cpp
+bool ZoomIsoRecorder::should_record(const ZoomOutputInfo &info,
+                                    uint32_t resolved_participant_id) const
+{
+    return iso_should_record(m_active.load(std::memory_order_acquire),
+                             info.source_uuid, info.assignment,
+                             resolved_participant_id);
+}
+```
+
+Update the comment on the ScreenShare branch of `on_output_updated` (line 428-431) — the branch itself stays, its meaning narrows:
+
+```cpp
+    if (info.assignment == AssignmentMode::ScreenShare) {
+        // Reachable only when should_record() said no — i.e. the recorder
+        // stopped (share is otherwise always recordable). Final, no grace.
+        close_session_locked(info.source_uuid);
+        return;
+    }
+```
+
+Extend `sweep_unresolved_locked` (lines 686-706) — the share-idle rule joins the existing loop, checked first:
+
+```cpp
+    for (auto &entry : m_sessions) {
+        Session &session = entry.second;
+        // A share end arrives as NOTHING (no output removal, frames just
+        // cease), so idle time on the video path is the end-of-share signal
+        // — see iso-record-policy.h.
+        if (session.assignment == AssignmentMode::ScreenShare &&
+            iso_share_session_idle_expired(session.last_video_ns, now_ns)) {
+            to_close.push_back(entry.first);
+            continue;
+        }
+        if (session.unresolved_since_ns == 0 ||
+            now_ns < session.unresolved_since_ns)
+            continue;
+        if (now_ns - session.unresolved_since_ns > kUnresolvedGraceNs)
+            to_close.push_back(entry.first);
+    }
+```
+
+(The close loop below it is shared; adjust its log line to say "unresolved or share-idle" rather than duplicating the loop.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: 64/64 green including `CoreVideoIsoRecordPolicy`. Live check during the next verification meeting: start ISO recording, share a screen for ~30 s, stop sharing, wait 10 s — a `*_screen_share_*` MP4/WAV pair appears in the ISO folder, plays at real-time speed, and a second share produces a second pair.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/iso-record-policy.h src/zoom-iso-recorder.cpp tests/iso-record-policy-test.cpp CMakeLists.txt
+git commit -m "feat(share): record a share ISO stem, closed by share-idle"
+```
+
+---
+
+### Task 4: `screen_share` event on the control API
+
+The control server already pushes edges to `subscribe_events` subscribers from a 250 ms poll (`poll_and_push()`, `src/zoom-control-server.cpp:129-169`: `meeting_state`, `active_speaker`, `speaker_director_changed`) plus roster-driven `roster_changed`. Share state is only *pollable* today (`list_outputs` / `list_participants`); a Companion button or external controller wanting "share just started" has to diff rosters itself. The sharer scan already exists in three copies (`output_to_json` line 196-200, `src/zoom-output-health.h:34-38`, `src/zoom-dock.cpp:378-385`) — the fourth caller is the moment it moves into a shared pure header so the edge detector can be pinned by a test.
+
+**Files:**
+- Create: `src/share-activity.h`
+- Modify: `src/zoom-control-server.h:40` (add `uint32_t m_last_share_user = 0;` after `m_last_speaker`), `src/zoom-control-server.cpp` (`poll_and_push` at 129-169; initial snapshot in the `subscribe_events` handler at 1088-1105; `#include "share-activity.h"`)
+- Test: `tests/share-activity-test.cpp`
+- Modify: `CMakeLists.txt` (register after the `CoreVideoOutputHealth` block, `CMakeLists.txt:549-556`)
+
+**Interfaces:**
+- Consumes: `ParticipantInfo` / `std::vector<ParticipantInfo>` from `src/zoom-types.h` (pure); `ZoomControlServer::push_event(const QJsonObject&)` (existing).
+- Produces: `inline uint32_t share_active_user(const std::vector<ParticipantInfo> &roster)`; wire event `{"event":"screen_share","active":bool,"user_id":N,"name":"..."}`. Task 5 consumes the wire event.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/share-activity-test.cpp`:
+
+```cpp
+// tests/share-activity-test.cpp
+// The sharer scan behind the control API's screen_share push event. Pinned
+// because the engine guarantees AT MOST ONE is_sharing_screen participant
+// (main.cpp's set_active_share_user writes the flag exclusively), and the
+// event edge (A->0, 0->A, and the single-edge A->B takeover) depends on
+// this function returning that one id deterministically.
+#include "share-activity.h"
+
+#include <iostream>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool ok, const char *message)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+static ParticipantInfo person(uint32_t id, bool sharing)
+{
+    ParticipantInfo p;
+    p.user_id = id;
+    p.display_name = "P" + std::to_string(id);
+    p.is_sharing_screen = sharing;
+    return p;
+}
+
+int main()
+{
+    // --- Nobody sharing -> 0, including the empty roster ---
+    check(share_active_user({}) == 0, "empty roster did not report no sharer");
+    check(share_active_user({person(1, false), person(2, false)}) == 0,
+          "no-sharer roster did not report 0");
+
+    // --- The one sharer is found regardless of position ---
+    check(share_active_user({person(1, false), person(2, true)}) == 2,
+          "the sharing participant was not found");
+    check(share_active_user({person(3, true), person(1, false)}) == 3,
+          "a sharer at the head of the roster was not found");
+
+    // --- Defensive: two flagged (engine invariant broken) -> first wins,
+    //     deterministically, rather than flapping between the two ---
+    check(share_active_user({person(4, true), person(5, true)}) == 4,
+          "two flagged sharers did not resolve first-wins");
+
+    // --- A takeover (A -> B) is a VALUE change, so the caller's
+    //     last!=now edge detector emits exactly one event for it ---
+    const uint32_t before = share_active_user({person(6, true), person(7, false)});
+    const uint32_t after  = share_active_user({person(6, false), person(7, true)});
+    check(before == 6 && after == 7 && before != after,
+          "a share takeover did not present as a single value change");
+
+    if (failures == 0)
+        std::cout << "share-activity: all tests passed\n";
+    return failures == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Add to `CMakeLists.txt` immediately after the `add_test(NAME CoreVideoOutputHealth ...)` block (line ~556):
+
+```cmake
+    # The sharer scan behind the control API's screen_share push event and
+    # its two pre-existing duplicate call sites. See src/share-activity.h.
+    add_executable(CoreVideoShareActivityTest
+        tests/share-activity-test.cpp
+    )
+    target_include_directories(CoreVideoShareActivityTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoShareActivity
+             COMMAND CoreVideoShareActivityTest)
+```
+
+Then:
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target CoreVideoShareActivityTest --parallel 8
+```
+
+Expected: FAIL — `Cannot open include file: 'share-activity.h'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/share-activity.h`:
+
+```cpp
+#pragma once
+//
+// share-activity.h — who owns the active screen share, per the roster.
+//
+// The engine maintains AT MOST ONE is_sharing_screen participant
+// (engine/src/main.cpp's set_active_share_user assigns the flag
+// exclusively: `p.is_sharing_screen = user_id != 0 && p.user_id == user_id`).
+// This scan already existed in three inline copies (zoom-control-server.cpp's
+// output_to_json, zoom-output-health.h, zoom-dock.cpp) before the screen_share
+// push event needed a fourth; the pattern this repo keeps re-learning (the
+// talkback milestone's members_present_locked, among others) is that the
+// second hand-copied loop is the one that drifts silently.
+//
+// Qt/OBS-free so tests/share-activity-test.cpp can pin it.
+//
+#include "zoom-types.h"
+
+#include <cstdint>
+#include <vector>
+
+// The sharing participant's user_id, or 0 when nobody shares. First-wins if
+// the at-most-one invariant is ever broken upstream — deterministic beats
+// flapping between two ids at the caller's 250 ms poll.
+inline uint32_t share_active_user(const std::vector<ParticipantInfo> &roster)
+{
+    for (const ParticipantInfo &p : roster) {
+        if (p.is_sharing_screen)
+            return p.user_id;
+    }
+    return 0;
+}
+```
+
+In `src/zoom-control-server.h`, after `uint32_t m_last_speaker = 0;` (line 40):
+
+```cpp
+    uint32_t            m_last_share_user = 0;
+```
+
+In `src/zoom-control-server.cpp`, `#include "share-activity.h"` with the local includes, then extend `poll_and_push()` after the speaker-director block (line 168):
+
+```cpp
+    // Share start/stop/takeover, as an edge. Roster-derived like everything
+    // else here; OSC already pushes the same edge (/zoom/event/screen_share),
+    // this brings the TCP subscribe_events stream to parity.
+    const auto share_roster = ZoomEngineClient::instance().roster();
+    const uint32_t share_user = share_active_user(share_roster);
+    if (share_user != m_last_share_user) {
+        m_last_share_user = share_user;
+        QString share_name;
+        const auto sharer = std::find_if(share_roster.begin(), share_roster.end(),
+            [share_user](const ParticipantInfo &p) {
+                return p.user_id == share_user;
+            });
+        if (sharer != share_roster.end())
+            share_name = QString::fromStdString(sharer->display_name);
+        push_event({
+            {"event",   "screen_share"},
+            {"active",  share_user != 0},
+            {"user_id", static_cast<double>(share_user)},
+            {"name",    share_name},
+        });
+    }
+```
+
+And in the `subscribe_events` handler (lines 1088-1105), after the existing `meeting_state` / `active_speaker` snapshot pushes, add the same snapshot so a subscriber that connects mid-share does not wait for the next edge:
+
+```cpp
+        const auto snap_roster = ZoomEngineClient::instance().roster();
+        const uint32_t snap_share = share_active_user(snap_roster);
+        QString snap_share_name;
+        const auto snap_sharer = std::find_if(snap_roster.begin(), snap_roster.end(),
+            [snap_share](const ParticipantInfo &p) {
+                return p.user_id == snap_share;
+            });
+        if (snap_sharer != snap_roster.end())
+            snap_share_name = QString::fromStdString(snap_sharer->display_name);
+        push_event({{"event", "screen_share"},
+                    {"active", snap_share != 0},
+                    {"user_id", static_cast<double>(snap_share)},
+                    {"name", snap_share_name}});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: 65/65 green including `CoreVideoShareActivity`. Wire check without a meeting is meaningless; during the next live pass: `printf '{"cmd":"subscribe_events"}\n' | nc 127.0.0.1 19870` held open shows one `{"event":"screen_share","active":true,...}` line when a share starts and `"active":false` when it stops.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/share-activity.h src/zoom-control-server.h src/zoom-control-server.cpp tests/share-activity-test.cpp CMakeLists.txt
+git commit -m "feat(share): push screen_share start/stop events on the control API"
+```
+
+---
+
+### Task 5: Companion share state — variables and feedback
+
+Companion today has exactly one share touchpoint: the `zoom_assign_screen_share` action (`companion/companion-module-corevideo-obs/src/actions.ts:110-119`). An operator cannot light a button when a share is live or show the sharer's name on it. Task 4's pushed event carries everything needed; the state transition goes into `state.ts` as a pure reducer (the module already has vitest coverage there, `state.test.ts`), because this repo's talkback rounds proved twice that logic inlined in event wiring is logic no test can reach. Companion refuses to overwrite an installed module version, so the version bumps in the same commit (CLAUDE.md's standing gotcha).
+
+**Files:**
+- Modify: `companion/companion-module-corevideo-obs/src/state.ts` (state fields + reducer), `src/index.ts:208-227` (`handlePluginEvent` gains the `screen_share` case), `src/variables.ts` (two variables), `src/feedbacks.ts` (one boolean feedback)
+- Modify: `companion/companion-module-corevideo-obs/package.json` (version `1.0.2` → `1.0.3`, both the top-level field at line 3 and the legacy `companion.version` at line 24) and `companion/companion-module-corevideo-obs/companion/manifest.json` (its `version` field, same bump)
+- Test: `companion/companion-module-corevideo-obs/src/state.test.ts`
+
+**Interfaces:**
+- Consumes: wire event `{"event":"screen_share","active":bool,"user_id":N,"name":"..."}` from Task 4.
+- Produces: `export function applyScreenShareEvent(state: ModuleState, userId: number, name: string): boolean`; variables `zoom_screen_share` (`yes`/`no`) and `zoom_screen_share_name`; feedback `zoom_screen_share_active`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `companion/companion-module-corevideo-obs/src/state.test.ts`:
+
+```ts
+describe('applyScreenShareEvent', () => {
+	it('records a share start and reports the change', () => {
+		const s = defaultState()
+		expect(applyScreenShareEvent(s, 42, 'Alex Rivera')).toBe(true)
+		expect(s.zoom.screenShareUserId).toBe(42)
+		expect(s.zoom.screenShareName).toBe('Alex Rivera')
+	})
+
+	it('clears the name on share stop even if the event still carries one', () => {
+		const s = defaultState()
+		applyScreenShareEvent(s, 42, 'Alex Rivera')
+		expect(applyScreenShareEvent(s, 0, 'Alex Rivera')).toBe(true)
+		expect(s.zoom.screenShareUserId).toBe(0)
+		expect(s.zoom.screenShareName).toBe('')
+	})
+
+	it('reports no change for a duplicate event, so feedbacks are not rechecked', () => {
+		const s = defaultState()
+		applyScreenShareEvent(s, 42, 'Alex Rivera')
+		expect(applyScreenShareEvent(s, 42, 'Alex Rivera')).toBe(false)
+	})
+
+	it('treats a takeover (A to B) as one change', () => {
+		const s = defaultState()
+		applyScreenShareEvent(s, 42, 'Alex Rivera')
+		expect(applyScreenShareEvent(s, 43, 'Sam Ortiz')).toBe(true)
+		expect(s.zoom.screenShareUserId).toBe(43)
+		expect(s.zoom.screenShareName).toBe('Sam Ortiz')
+	})
+})
+```
+
+with `applyScreenShareEvent` added to the existing import from `./state.js`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cd companion/companion-module-corevideo-obs && npm test
+```
+
+Expected: FAIL — `applyScreenShareEvent` is not exported from `./state.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/state.ts`, extend the `zoom` block of `ModuleState` (after `outputs: Output[]`):
+
+```ts
+		screenShareUserId: number
+		screenShareName: string
+```
+
+seed both in `defaultState()` (`screenShareUserId: 0, screenShareName: ''`), and add:
+
+```ts
+// Reducer for the control API's screen_share push event. Pure and exported
+// so state.test.ts can pin the stop-clears-name and duplicate-is-no-change
+// rules — the module's event wiring is unreachable from tests.
+export function applyScreenShareEvent(
+	state: ModuleState,
+	userId: number,
+	name: string,
+): boolean {
+	const nextName = userId !== 0 ? name : ''
+	const changed =
+		state.zoom.screenShareUserId !== userId ||
+		state.zoom.screenShareName !== nextName
+	state.zoom.screenShareUserId = userId
+	state.zoom.screenShareName = nextName
+	return changed
+}
+```
+
+In `src/index.ts`, add a case to `handlePluginEvent` (the switch at lines 209-225), importing `applyScreenShareEvent` from `./state.js`:
+
+```ts
+			case 'screen_share':
+				if (applyScreenShareEvent(
+						this.state,
+						(msg['user_id'] as number) ?? 0,
+						(msg['name'] as string) ?? '',
+					))
+					this.checkFeedbacks('zoom_screen_share_active')
+				break
+```
+
+In `src/variables.ts`, add to `variableDefinitions`:
+
+```ts
+	zoom_screen_share:      { name: 'Zoom: Screen Share Active' },
+	zoom_screen_share_name: { name: 'Zoom: Screen Share Participant Name' },
+```
+
+and to `buildVariableValues`:
+
+```ts
+		zoom_screen_share:      state.zoom.screenShareUserId !== 0 ? 'yes' : 'no',
+		zoom_screen_share_name: state.zoom.screenShareName,
+```
+
+In `src/feedbacks.ts`, add beside `zoom_recovery_active`:
+
+```ts
+		zoom_screen_share_active: {
+			type: 'boolean',
+			name: 'Zoom: Screen Share Active',
+			description: 'True while any participant is sharing their screen',
+			defaultStyle: { bgcolor: GREEN, color: BLACK },
+			options: [],
+			callback: () => inst.state.zoom.screenShareUserId !== 0,
+		},
+```
+
+Bump the version to `1.0.3` in `package.json` (both fields) and `companion/manifest.json` — Companion refuses to overwrite an installed version, so without the bump every install test would exercise the old bundle.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cd companion/companion-module-corevideo-obs && npm run build && npm test
+```
+
+Expected: tsc clean, vitest green including the four new `applyScreenShareEvent` cases. (The C++ suite is untouched by this task; no ctest run needed.)
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add companion/companion-module-corevideo-obs/src/state.ts companion/companion-module-corevideo-obs/src/state.test.ts companion/companion-module-corevideo-obs/src/index.ts companion/companion-module-corevideo-obs/src/variables.ts companion/companion-module-corevideo-obs/src/feedbacks.ts companion/companion-module-corevideo-obs/package.json companion/companion-module-corevideo-obs/companion/manifest.json
+git commit -m "feat(share): Companion screen-share feedback and variables"
+```
+
+---
+
+## Self-Review
+
+**Gap coverage.** Requirement 4 (share audio) → Task 1. Requirement 5 (`capture_ns`) → Task 2. Requirement 6 (ISO stem) → Task 3, riding the existing pacer and gap-fill rather than duplicating either. Requirement 7 (events) → Tasks 4-5 for the two surfaces that lacked them; dock and OSC are stated as already done in the Spec and not re-planned. Requirements 1-3 are stated as fully implemented, with file/line evidence, and no task touches them beyond Task 2's one-line stamp inside the existing writer.
+
+**SDK ground truth.** Every SDK name used was verified against `third_party/zoom-sdk/h`: `RAW_DATA_TYPE_SHARE` and `IZoomSDKRenderer::subscribe(uint32_t, ZoomSDKRawDataType)` (`rawdata_renderer_interface.h:22-57`), `IMeetingShareController` / `IMeetingShareCtrlEvent` / `ZoomSDKSharingSourceInfo` with fields `userid`/`shareSourceID`/`status`/`contentType` (`meeting_sharing_interface.h:43-80,149-207`), `YUVRawDataI420::GetStreamWidth/GetStreamHeight/GetSourceID` and `AudioRawData::GetBuffer/GetBufferLen/GetSampleRate/GetChannelNum/GetTimeStamp` (`rawdata_def.h`), `onShareAudioRawDataReceived(AudioRawData*, uint32_t)` (`rawdata_audio_helper_interface.h:18`). Notable layout fact: the tracked tree is FLAT — `meeting_sharing_interface.h`, `rawdata_renderer_interface.h`, `rawdata_audio_helper_interface.h` and `rawdata_def.h` sit directly under `h/`, with `h/meeting_service_components/` containing only two unrelated headers; the existing `__has_include` fallbacks in `engine-share.h`/`engine-audio.h` already absorb this and no task adds a bare `meeting_service_components/` or `rawdata/` include path. No interface this plan needs is missing from the tracked tree.
+
+**Type consistency.** `ipc_subscribe_wants_share_audio(const std::string&)` is defined in Task 1 Step 3 and called in Task 1's `main.cpp` branch with that signature. `EngineAudio::init` gains `bool share_audio = false` as a defaulted sixth parameter — the untouched `SubscribeAudio` branch at `main.cpp:1772` keeps compiling, and the screenshare branch passes all six explicitly. `AudioTarget`'s constructor gains a fifth `bool share` matching the single `make_unique<AudioTarget>` call site, which Task 1 updates in the same edit. `iso_should_record(bool, const std::string&, AssignmentMode, uint32_t)` and `iso_share_session_idle_expired(uint64_t, uint64_t)` match between test, header, and both recorder call sites. `share_active_user(const std::vector<ParticipantInfo>&)` matches between test and both control-server call sites. `applyScreenShareEvent(state, number, string): boolean` matches between `state.test.ts` and `index.ts`.
+
+**Placeholder scan:** none. The two test-less steps (Task 2, and Task 1's engine/plugin wiring beyond its helper test) are explicit statements about SDK-bound code with a named live verification, following the talkback Milestone 1 precedent, not deferred work.
+
+**Deliberately out of scope, stated rather than hidden:** deleting the dead `zoom_share_source_register()` duplicate in `src/zoom-share-delegate.cpp` and the legacy in-process share delegate it belongs to (strangler-pattern cleanup with its own blast radius); any share *sending* (`StartMonitorShare` etc. — CoreVideo consumes shares, it does not produce them); multi-share (the engine deliberately follows the single active share, first-wins, per `active_share_source_id()`); and a 4K share path, which `ZoomSDKResolution`'s 1080P ceiling forecloses at the SDK boundary.
+
+**One known soft spot, flagged:** Task 3's `kIsoShareIdleCloseNs = 5 s` is a judgment call, not a measured number — no soak has yet measured the longest frame gap Zoom produces mid-share on static content. If the first live pass shows a single share splitting into multiple files, raise the constant; the test pins the strict-threshold semantics, not the 5.

--- a/docs/superpowers/plans/2026-08-29-webinar-support.md
+++ b/docs/superpowers/plans/2026-08-29-webinar-support.md
@@ -1,0 +1,898 @@
+# Zoom Webinar Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CoreVideo join Zoom webinars deliberately — detecting webinar mode and our role, completing the register/screen-name handshakes a webinar join demands, offering promote/demote panelist controls, and refusing (with a named reason) every CoreVideo feature that cannot work for the role we hold — instead of joining one by accident and failing feature-by-feature in silence.
+
+**Architecture:** The engine detects webinar mode via `IMeetingInfo::GetMeetingType()` and our role via `IUserInfo::GetUserRole()`, and reports both over E2P as a new `meeting_mode` event, latest-wins like `awaiting_admission`. All availability decisions (given mode + role → which CoreVideo features work, with named reasons) live in one pure header, `src/webinar-capability.h`, consumed by both processes and pinned by a host test. Promote/demote is a thin engine wrapper whose two SDK call lines are isolated in a separate TU compiled only when the full SDK drop supplies `meeting_webinar_ctrl_interface.h` — the same `EXISTS` gate CMakeLists.txt:1168 already uses for the talkback header.
+
+**Tech Stack:** C++17, Zoom Windows Meeting SDK 7.1.5.43953, CMake + CTest, named-pipe line-JSON IPC, Qt6.
+
+**Spec:** This document doubles as the spec. Requirements:
+
+1. Joining a webinar URL/ID must reach `MEETING_STATUS_INMEETING` without a human dismissing an SDK dialog: the engine redirects the webinar register and screen-name prompts to itself (`RedirectWebinarNeedRegister` / `RedirectWebinarNameInputDialog`, meeting_configuration_interface.h:915/922) and answers them from the join command's own fields.
+2. The plugin must know, and show, "this is a webinar, and you are attendee/panelist/host" — the dock and the control API both surface it.
+3. Every gated feature refuses with a **named reason**, never silently: per-participant raw video subscription, per-participant/ISO audio, talkback, and the Active Speaker director are all panelist-or-better in a webinar. The raw-data receive path rides the local-recording privilege, which a webinar **attendee** cannot hold — attendees have no per-participant raw streams at all.
+4. Promote/demote panelist by **display name** (host/co-host only), reported with the SDK's own error code.
+5. Webinar attendees have **no waiting room**: the pre-broadcast state is the practice session/backstage (`IUserInfo::IsInWebinarBackstage()`, meeting_participants_ctrl_interface.h:274, is the signal). The waiting-room-shaped machinery (`awaiting_admission`, the join-watchdog exemption in `src/join-watchdog.h`) must not misread backstage as a waiting room, and nothing may attempt waiting-room admission of webinar attendees.
+6. Talkback in a webinar is **unverified**: the tracked SDK tree says nothing about talkback×webinar interaction. It fails CLOSED (`webinar` reason) until the Task 6 live gate proves otherwise — a to-verify, not an assumption.
+
+**SDK ground truth (hard constraint).** The tracked vendored SDK tree (`third_party/zoom-sdk/h`) has **no** `meeting_webinar_ctrl_interface.h`. It has only the forward declaration `class IMeetingWebinarController;` (meeting_service_interface.h:957) and `IMeetingService::GetMeetingWebinarController()` (meeting_service_interface.h:1148). So `IMeetingWebinarController`'s **definition** — including the promote/demote methods (named approximately `PromptePanelist2Attendee` / `DepromptAttendee2Panelist`, Zoom's own spellings, which must be **copied from the full local SDK drop's `meeting_webinar_ctrl_interface.h` at implementation time, never guessed**) — is unavailable to any TU this repo's CI compiles. The repo already has this exact situation and its answer: CMakeLists.txt:1168 gates `CoreVideoEngineTalkbackSelectTest` on `EXISTS "${ZOOM_SDK_INCLUDE_DIR}/meeting_service_components/meeting_talkback_ctrl_interface.h"`, because the full local SDK drop supplies headers the tracked tree lacks. Task 5 uses the identical gate, and is structured so everything except the two SDK call lines compiles and tests against the tracked tree.
+
+What the tracked tree **does** verifiably have (each read for this plan):
+
+- meeting_service_interface.h — `MEETING_TYPE_NONE/NORMAL/WEBINAR/BREAKOUTROOM` (:185-191), `IMeetingInfo::GetMeetingType()` (:703, on `IMeetingInfo`, class at :672, reached via `IMeetingService::GetMeetingInfo()` :1061), `GetMeetingWebinarController()` (:1148), `GetMeetingConfiguration()` (:1185).
+- meeting_participants_ctrl_interface.h — `enum UserRole` with `USERROLE_PANELIST` / `USERROLE_ATTENDEE` (:18-33), `WebinarAttendeeStatus { bool allow_talk; }` (:38-46), `IUserInfo::GetUserRole()` (:164), `GetWebinarAttendeeStatus()` (:206), `IsInWebinarBackstage()` (:274), `GetMySelfUser()` (:526), `LowerAllHands(bool forWebinarAttendees)` (:570).
+- meeting_configuration_interface.h — `IWebinarNeedRegisterHandler` + ByUrl/ByEmail subclasses (:95-166, `InputWebinarRegisterEmailAndScreenName` :157), `IWebinarInputScreenNameHandler` (:172-191, `InputName` :181, `Cancel` :188), `onWebinarNeedRegisterNotification` (:375), `onWebinarNeedInputScreenName` (:387), `RedirectWebinarNeedRegister` (:915), `RedirectWebinarNameInputDialog` (:922), `PrePopulateWebinarRegistrationInfo` (:1002), `IMeetingConfiguration::SetEvent` (:1033).
+
+Grepped the whole repo for `webinar` (case-insensitive) outside `third_party/`: **zero hits**. There is no existing webinar handling to preserve or migrate.
+
+## Global Constraints
+
+- Build: `cmake --build build --config Release --parallel 8`. Test: `cd build && ctest -C Release --output-on-failure` — must be N/N green after every task (each task states its expected delta; the suite must never shrink).
+- Tests are plain executables, no framework, `check()`-style, one file per invariant cluster in `tests/`, registered in `CMakeLists.txt` with `add_executable` + `add_test`.
+- Commands are routed by **exact match** on the declared `cmd` field (`src/engine-command.h`), pinned in `tests/engine-command-test.cpp` — never substrings.
+- Participants are addressed **by display name**, resolved to a meeting-scoped `userID` at use time. Never persist a raw Zoom user ID.
+- Comments state the constraint the code cannot show; when a change is motivated by a live failure, say what happened, with numbers.
+- SDK headers missing from the tracked tree are gated with `EXISTS` on `${ZOOM_SDK_INCLUDE_DIR}` per the talkback precedent (CMakeLists.txt:1168) — never vendored from the full drop, never stubbed with invented declarations.
+- Never run a second OBS instance while one is testing (pipe/SDK singleton collision, crash loop). Send `{"cmd":"leave"}` before closing OBS.
+- An engine older than this feature emits no `meeting_mode` event, and a DLL-only install is this project's canonical mistake — every plugin-side default must therefore behave exactly as today (meeting semantics), with webinar gating engaging only on positive evidence.
+
+---
+
+### Task 1: The capability verdict — one pure header
+
+Every feature this plan gates lives in a different file owned by a different subsystem (`src/speaker-director.cpp`, the talkback controller, `src/zoom-iso-recorder.cpp`, the outputs). Scattering "if webinar and attendee then refuse" across all of them is how the talkback feature shipped two Majors in wiring no test could reach — so the decision is made in exactly one Qt/OBS/SDK-free header, the same reason `src/talkback-plan.h` and `src/zoom-join-decision.h` exist, and everything else only asks it.
+
+**Files:**
+- Create: `src/webinar-capability.h`
+- Test: `tests/webinar-capability-test.cpp` (new)
+- Modify: `CMakeLists.txt` (register the test after the `CoreVideoEngineTalkbackSelect` block, CMakeLists.txt:1185)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `enum class MeetingMode { Unknown, Meeting, Webinar }`; `enum class LocalRole { Unknown, Host, CoHost, Panelist, Attendee, BreakoutModerator }`; `enum class CoreVideoFeature { RawVideoSubscribe, PerParticipantAudio, IsoRecord, Talkback, SpeakerDirector, WaitingRoomAdmission, PromoteDemote }`; `struct FeatureVerdict { bool available; const char *reason; }`; `FeatureVerdict webinar_feature_verdict(MeetingMode, LocalRole, CoreVideoFeature)`; `LocalRole local_role_from_id(const std::string&)`; `const char *local_role_id(LocalRole)`. Tasks 2, 4 and 5 consume all of these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/webinar-capability-test.cpp`:
+
+```cpp
+// tests/webinar-capability-test.cpp
+// Pins the mode+role -> feature table. The reasons are load-bearing: they are
+// what the operator sees instead of a silent failure, so a reason changing or
+// emptying is a regression, not a refactor.
+#include "webinar-capability.h"
+
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+static void check(bool ok, const char *message)
+{
+    if (!ok) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+int main()
+{
+    // --- An ordinary meeting gates nothing, for any role ---
+    for (auto role : {LocalRole::Host, LocalRole::Attendee, LocalRole::Unknown}) {
+        for (auto f : {CoreVideoFeature::RawVideoSubscribe, CoreVideoFeature::Talkback,
+                       CoreVideoFeature::SpeakerDirector, CoreVideoFeature::IsoRecord}) {
+            const auto v = webinar_feature_verdict(MeetingMode::Meeting, role, f);
+            check(v.available, "a plain meeting gated a feature");
+            check(std::string(v.reason).empty(), "an available verdict carried a reason");
+        }
+    }
+
+    // --- Unknown mode = pre-webinar engine (DLL-only install): behave as today ---
+    check(webinar_feature_verdict(MeetingMode::Unknown, LocalRole::Unknown,
+                                  CoreVideoFeature::RawVideoSubscribe).available,
+          "Unknown mode gated raw video -- an old engine would regress every meeting");
+
+    // --- Webinar attendee: no raw media of any kind ---
+    for (auto f : {CoreVideoFeature::RawVideoSubscribe,
+                   CoreVideoFeature::PerParticipantAudio,
+                   CoreVideoFeature::IsoRecord}) {
+        const auto v = webinar_feature_verdict(MeetingMode::Webinar, LocalRole::Attendee, f);
+        check(!v.available, "a webinar attendee was offered raw media");
+        check(std::string(v.reason) == "webinar_attendee_no_raw_media",
+              "attendee raw-media refusal reason wrong");
+    }
+    // --- Webinar panelist: raw media allowed (privilege path verified live in Task 6) ---
+    check(webinar_feature_verdict(MeetingMode::Webinar, LocalRole::Panelist,
+                                  CoreVideoFeature::RawVideoSubscribe).available,
+          "a webinar panelist was refused raw video");
+
+    // --- Talkback fails CLOSED in any webinar until the live gate proves it ---
+    const auto tb = webinar_feature_verdict(MeetingMode::Webinar, LocalRole::Host,
+                                            CoreVideoFeature::Talkback);
+    check(!tb.available, "talkback offered in a webinar before the live gate verified it");
+    check(std::string(tb.reason) == "talkback_unverified_in_webinar",
+          "talkback webinar refusal reason wrong");
+
+    // --- Director cannot direct as an attendee; waiting-room admission never exists ---
+    check(!webinar_feature_verdict(MeetingMode::Webinar, LocalRole::Attendee,
+                                   CoreVideoFeature::SpeakerDirector).available,
+          "attendee was offered the speaker director");
+    check(std::string(webinar_feature_verdict(MeetingMode::Webinar, LocalRole::Host,
+              CoreVideoFeature::WaitingRoomAdmission).reason) == "webinar_has_no_waiting_room",
+          "webinar waiting-room refusal reason wrong");
+
+    // --- Promote/demote: host and co-host only ---
+    check(webinar_feature_verdict(MeetingMode::Webinar, LocalRole::CoHost,
+                                  CoreVideoFeature::PromoteDemote).available,
+          "co-host was refused promote/demote");
+    check(std::string(webinar_feature_verdict(MeetingMode::Webinar, LocalRole::Panelist,
+              CoreVideoFeature::PromoteDemote).reason) == "promote_requires_host_or_cohost",
+          "panelist promote refusal reason wrong");
+    check(std::string(webinar_feature_verdict(MeetingMode::Meeting, LocalRole::Host,
+              CoreVideoFeature::PromoteDemote).reason) == "not_a_webinar",
+          "promote in a plain meeting must refuse with not_a_webinar");
+
+    // --- Role ids round-trip; an unknown id is Unknown, never a crash ---
+    for (auto r : {LocalRole::Host, LocalRole::CoHost, LocalRole::Panelist,
+                   LocalRole::Attendee, LocalRole::BreakoutModerator}) {
+        check(local_role_from_id(local_role_id(r)) == r, "role id did not round-trip");
+    }
+    check(local_role_from_id("someday_a_new_role") == LocalRole::Unknown,
+          "an unrecognised role id did not map to Unknown");
+
+    if (failures == 0)
+        std::cout << "webinar-capability: all tests passed\n";
+    return failures == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Register in `CMakeLists.txt` after the `CoreVideoEngineTalkbackSelect` block (after CMakeLists.txt:1185):
+
+```cmake
+    # The mode+role -> feature table for webinars. One pure header, because the
+    # talkback feature's two Majors both lived in wiring spread across files
+    # that no host test could reach. See src/webinar-capability.h.
+    add_executable(CoreVideoWebinarCapabilityTest
+        tests/webinar-capability-test.cpp
+    )
+    target_include_directories(CoreVideoWebinarCapabilityTest PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    add_test(NAME CoreVideoWebinarCapability
+             COMMAND CoreVideoWebinarCapabilityTest)
+```
+
+```sh
+cmake -S . -B build && cmake --build build --config Release --target CoreVideoWebinarCapabilityTest --parallel 8
+```
+
+Expected: FAIL — `Cannot open include file: 'webinar-capability.h'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/webinar-capability.h`:
+
+```cpp
+#pragma once
+//
+// webinar-capability.h — given the meeting mode and our role, which CoreVideo
+// features exist, with a NAMED reason when they do not.
+//
+// Webinars are not meetings with more people. An attendee holds no raw-data
+// streams at all (raw receive rides the local-recording privilege, which only
+// panelist-and-better can hold), webinars have no waiting room (the
+// pre-broadcast state is the practice session / backstage), and the tracked
+// SDK tree says nothing about talkback inside a webinar — so talkback fails
+// CLOSED here until the live gate (Task 6 of the 2026-08-29 webinar plan)
+// proves it, exactly as the talkback probe treated its own entitlement.
+//
+// MeetingMode::Unknown behaves like Meeting on purpose: an engine older than
+// this feature never emits meeting_mode, and a DLL-only install is this
+// project's canonical mistake — gating on Unknown would regress every
+// ordinary meeting behind a half-applied install.
+//
+// Free of Qt / OBS / Zoom SDK dependencies so the whole table is pinned by
+// tests/webinar-capability-test.cpp with no engine and no meeting.
+//
+#include <string>
+
+enum class MeetingMode { Unknown, Meeting, Webinar };
+enum class LocalRole { Unknown, Host, CoHost, Panelist, Attendee, BreakoutModerator };
+
+enum class CoreVideoFeature {
+    RawVideoSubscribe,    // per-participant raw video (zoom-source outputs)
+    PerParticipantAudio,  // isolated / audience audio sources
+    IsoRecord,            // per-source ISO recording (needs raw A+V)
+    Talkback,             // nominate / key
+    SpeakerDirector,      // Active Speaker director
+    WaitingRoomAdmission, // anything waiting-room shaped
+    PromoteDemote,        // webinar promote/demote panelist controls
+};
+
+struct FeatureVerdict {
+    bool available;
+    const char *reason; // "" when available; a stable id otherwise, never prose
+};
+
+// Wire ids for the role, matching what the engine's meeting_mode event emits.
+inline const char *local_role_id(LocalRole r)
+{
+    switch (r) {
+    case LocalRole::Host:              return "host";
+    case LocalRole::CoHost:            return "cohost";
+    case LocalRole::Panelist:          return "panelist";
+    case LocalRole::Attendee:          return "attendee";
+    case LocalRole::BreakoutModerator: return "breakout_moderator";
+    case LocalRole::Unknown:           return "unknown";
+    }
+    return "unknown";
+}
+
+inline LocalRole local_role_from_id(const std::string &id)
+{
+    if (id == "host")               return LocalRole::Host;
+    if (id == "cohost")             return LocalRole::CoHost;
+    if (id == "panelist")           return LocalRole::Panelist;
+    if (id == "attendee")           return LocalRole::Attendee;
+    if (id == "breakout_moderator") return LocalRole::BreakoutModerator;
+    return LocalRole::Unknown;
+}
+
+inline FeatureVerdict webinar_feature_verdict(MeetingMode mode, LocalRole role,
+                                              CoreVideoFeature feature)
+{
+    // Promote/demote is the one feature that exists ONLY in a webinar.
+    if (feature == CoreVideoFeature::PromoteDemote) {
+        if (mode != MeetingMode::Webinar)
+            return {false, "not_a_webinar"};
+        if (role == LocalRole::Host || role == LocalRole::CoHost)
+            return {true, ""};
+        return {false, "promote_requires_host_or_cohost"};
+    }
+
+    // Unknown = pre-webinar engine: behave exactly as today (see header).
+    if (mode != MeetingMode::Webinar)
+        return {true, ""};
+
+    switch (feature) {
+    case CoreVideoFeature::RawVideoSubscribe:
+    case CoreVideoFeature::PerParticipantAudio:
+    case CoreVideoFeature::IsoRecord:
+        // Raw receive rides the local-recording privilege; an attendee cannot
+        // hold it and has no per-participant streams to subscribe to anyway.
+        if (role == LocalRole::Attendee || role == LocalRole::Unknown)
+            return {false, "webinar_attendee_no_raw_media"};
+        return {true, ""};
+    case CoreVideoFeature::Talkback:
+        // Fails closed for EVERY role: the tracked SDK tree is silent on
+        // talkback x webinar. Flip only on a recorded Task 6 live pass.
+        return {false, "talkback_unverified_in_webinar"};
+    case CoreVideoFeature::SpeakerDirector:
+        // Directing needs the raw streams it cuts between.
+        if (role == LocalRole::Attendee || role == LocalRole::Unknown)
+            return {false, "webinar_attendee_no_raw_media"};
+        return {true, ""};
+    case CoreVideoFeature::WaitingRoomAdmission:
+        // Webinar attendees have no waiting room; the pre-broadcast state is
+        // backstage (IUserInfo::IsInWebinarBackstage), which is not ours to admit.
+        return {false, "webinar_has_no_waiting_room"};
+    case CoreVideoFeature::PromoteDemote:
+        break; // handled above
+    }
+    return {false, "unknown_feature"};
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```sh
+cmake --build build --config Release --target CoreVideoWebinarCapabilityTest --parallel 8
+cd build && ctest -C Release -R CoreVideoWebinarCapability --output-on-failure
+```
+
+Expected: PASS, `webinar-capability: all tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/webinar-capability.h tests/webinar-capability-test.cpp CMakeLists.txt
+git commit -m "feat(webinar): mode+role capability table with named refusal reasons"
+```
+
+---
+
+### Task 2: Engine reports `meeting_mode` — webinar flag, role, backstage
+
+The plugin cannot ask the SDK anything; the engine must tell it. The precedent is `awaiting_admission` (engine/src/main.cpp:998-1005): sent on every relevant change, carrying the full state, so neither side tracks edges. `meeting_mode` follows it exactly — emitted on `MEETING_STATUS_INMEETING` and again on every roster change (roles change via promote/demote and host handoff, and `EngineParticipants::roster_changed()` at engine/src/main.cpp:608 already fires on all five roster callbacks plus `onHostChangeNotification`, meeting_participants_ctrl_interface.h:351).
+
+**Files:**
+- Modify: `engine/src/main.cpp` — add `report_meeting_mode()` to `EngineParticipants` (near `send_roster()`, :640), call it from `roster_changed()` (:608) and from `EngineMeetingEvent`'s `MEETING_STATUS_INMEETING` branch (:1008, which already reaches `m_participants`).
+
+**Interfaces:**
+- Consumes: `local_role_id` from Task 1 (`src/webinar-capability.h`; `engine/src/` TUs already include `src/` headers — talkback-plan.h precedent).
+- Produces: E2P event `{"cmd":"meeting_mode","webinar":<bool>,"role":"<id>","backstage":<bool>}`. Task 4 parses it.
+
+- [ ] **Step 1: State the check**
+
+No unit test — this member is SDK-bound (it reads `IMeetingInfo` and `IUserInfo` live), the same explicit statement Task 3 of the talkback Milestone 1 plan made. The compile is the check here; the observable behaviour is pinned by Task 4's parse test and verified live in Task 6.
+
+- [ ] **Step 2: Write the implementation**
+
+In `engine/src/main.cpp`, inside `EngineParticipants` next to `send_roster()` (:640), add:
+
+```cpp
+    // Mirrors awaiting_admission (see onMeetingStatusChanged): full state on
+    // every send, so neither side tracks edges. Sent from roster_changed()
+    // because promote/demote and host handoff arrive as roster/host callbacks,
+    // and from INMEETING so the plugin learns the mode before the first roster.
+    void report_meeting_mode()
+    {
+        if (!m_meeting_svc_ptr || !*m_meeting_svc_ptr) return;
+        ZOOMSDK::IMeetingService *svc = *m_meeting_svc_ptr;
+
+        bool webinar = false;
+        if (ZOOMSDK::IMeetingInfo *info = svc->GetMeetingInfo())
+            webinar = info->GetMeetingType() == ZOOMSDK::MEETING_TYPE_WEBINAR;
+
+        LocalRole role = LocalRole::Unknown;
+        bool backstage = false;
+        if (auto *pc = svc->GetMeetingParticipantsController()) {
+            if (ZOOMSDK::IUserInfo *self = pc->GetMySelfUser()) {
+                switch (self->GetUserRole()) {
+                case ZOOMSDK::USERROLE_HOST:     role = LocalRole::Host; break;
+                case ZOOMSDK::USERROLE_COHOST:   role = LocalRole::CoHost; break;
+                case ZOOMSDK::USERROLE_PANELIST: role = LocalRole::Panelist; break;
+                case ZOOMSDK::USERROLE_ATTENDEE: role = LocalRole::Attendee; break;
+                case ZOOMSDK::USERROLE_BREAKOUTROOM_MODERATOR:
+                    role = LocalRole::BreakoutModerator; break;
+                default:                         role = LocalRole::Unknown; break;
+                }
+                // Only meaningful in a webinar; false elsewhere by the SDK's
+                // own contract, so no mode check is needed to send it.
+                backstage = self->IsInWebinarBackstage();
+            }
+        }
+        EngineIpc::write(std::string(R"({"cmd":"meeting_mode","webinar":)") +
+            (webinar ? "true" : "false") +
+            R"(,"role":")" + local_role_id(role) +
+            R"(","backstage":)" + (backstage ? "true" : "false") + "}");
+    }
+```
+
+Add `#include "webinar-capability.h"` beside main.cpp's other `src/` includes. In `roster_changed()` (:608), add `report_meeting_mode();` after `send_roster();`. In `onMeetingStatusChanged`'s `MEETING_STATUS_INMEETING` branch (:1008), after the `m_participants->attach(...)` call, add:
+
+```cpp
+            if (m_participants)
+                m_participants->report_meeting_mode();
+```
+
+- [ ] **Step 3: Build and run the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: engine links clean; suite green — this task adds no tests but must break none.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add engine/src/main.cpp
+git commit -m "feat(webinar): engine reports meeting_mode (webinar flag, local role, backstage)"
+```
+
+---
+
+### Task 3: Webinar join handshakes — register and screen-name redirects
+
+A headless engine joining a registration-required webinar today would hit an SDK dialog no one can click. `IMeetingConfiguration` (acquired via `GetMeetingConfiguration()`, meeting_service_interface.h:1185 — the engine currently never acquires it; grep confirms zero call sites) can redirect both prompts to callbacks we answer from the join command's own fields. The ByUrl registration variant cannot be answered headlessly at all — the honest move is to report the URL over E2P and cancel, so the operator registers in a browser and rejoins, instead of hanging the join silently.
+
+**Files:**
+- Modify: `engine/src/main.cpp` — new `EngineConfigEvent : public ZOOMSDK::IMeetingConfigurationEvent` beside `EngineMeetingEvent` (:739); acquisition + redirects in the `IpcCommand::Join` branch (:1440-1498); a new optional join field `registration_email`.
+- Modify: `src/zoom-control-server.cpp` (:719 join command) and `src/zoom-engine-client.cpp`'s `join()` — pass `registration_email` through when supplied.
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: E2P events `{"cmd":"webinar_join","stage":"register_by_email"|"register_by_url"|"screen_name","code":<int>}` and `{"cmd":"webinar_register_url","url":"..."}`. Join command gains optional `"registration_email"`.
+
+- [ ] **Step 1: State the check**
+
+No unit test — SDK-bound (every line touches `IMeetingConfiguration` or a handler object the SDK owns and destroys after one call, per meeting_configuration_interface.h:179/186). The compile is the check; Task 6 Step 3 exercises both handshakes live. This is the same explicit statement the talkback plan's Tasks 3/4 made.
+
+- [ ] **Step 2: Write the implementation**
+
+In `engine/src/main.cpp`, beside `EngineMeetingEvent` (:739):
+
+```cpp
+// Answers the two webinar join prompts the SDK would otherwise raise as
+// dialogs a headless engine can never dismiss. IMeetingConfigurationEvent has
+// many pure virtuals beyond these two (it also inherits
+// IMeetingConfigurationFreeMeetingEvent); every one not shown here is
+// overridden with an empty body — the compiler enumerates the full list, and
+// inventing behaviour for prompts we have never seen live would be guessing.
+class EngineConfigEvent : public ZOOMSDK::IMeetingConfigurationEvent {
+public:
+    // The join command's display name / registration email, captured before
+    // Join() because the SDK fires these callbacks mid-join.
+    void set_join_identity(std::string display_name, std::string email)
+    {
+        m_display_name = std::move(display_name);
+        m_email = std::move(email);
+    }
+
+    void onWebinarNeedRegisterNotification(
+        ZOOMSDK::IWebinarNeedRegisterHandler *handler) override
+    {
+        if (!handler) return;
+        if (handler->GetWebinarNeedRegisterType() ==
+            ZOOMSDK::IWebinarNeedRegisterHandler::WebinarReg_By_Email_and_DisplayName) {
+            const std::wstring wemail(m_email.begin(), m_email.end());
+            const std::wstring wname(m_display_name.begin(), m_display_name.end());
+            auto *by_email =
+                static_cast<ZOOMSDK::IWebinarNeedRegisterHandlerByEmail *>(handler);
+            const ZOOMSDK::SDKError e = by_email->InputWebinarRegisterEmailAndScreenName(
+                wemail.c_str(), wname.c_str());
+            EngineIpc::write(
+                R"({"cmd":"webinar_join","stage":"register_by_email","code":)" +
+                std::to_string(static_cast<int>(e)) + "}");
+            return;
+        }
+        // ByUrl cannot be completed headlessly: report the URL so the operator
+        // can register in a browser, then cancel the join rather than hang it.
+        auto *by_url = static_cast<ZOOMSDK::IWebinarNeedRegisterHandlerByUrl *>(handler);
+        EngineIpc::write(R"({"cmd":"webinar_register_url","url":")" +
+            json_escape(zchar_to_utf8(by_url->GetWebinarRegisterUrl())) + R"("})");
+        by_url->Cancel();
+        EngineIpc::write(
+            R"({"cmd":"webinar_join","stage":"register_by_url","code":-1})");
+    }
+
+    void onWebinarNeedInputScreenName(
+        ZOOMSDK::IWebinarInputScreenNameHandler *handler) override
+    {
+        if (!handler) return;
+        const std::wstring wname(m_display_name.begin(), m_display_name.end());
+        const ZOOMSDK::SDKError e = handler->InputName(wname.c_str());
+        EngineIpc::write(R"({"cmd":"webinar_join","stage":"screen_name","code":)" +
+            std::to_string(static_cast<int>(e)) + "}");
+    }
+
+    // ... every remaining pure virtual of IMeetingConfigurationEvent (and its
+    // IMeetingConfigurationFreeMeetingEvent base): empty override bodies ...
+
+private:
+    std::string m_display_name;
+    std::string m_email;
+};
+```
+
+(The `std::wstring(begin, end)` widening matches ASCII-only email/name; use main.cpp's existing `to_zstr()` helper instead if it is visible at this point in the file — it is, and it is the correct call: the sketch above is the fallback shape, `to_zstr` the required one.)
+
+In the `IpcCommand::Join` branch, after `CreateMeetingService` / `SetEvent` (:1456-1458) and before `Join(jp)` (:1495):
+
+```cpp
+                const std::string registration_email = json_str(line, "registration_email");
+                config_event.set_join_identity(display_name, registration_email);
+                if (ZOOMSDK::IMeetingConfiguration *cfg =
+                        meeting_svc->GetMeetingConfiguration()) {
+                    cfg->SetEvent(&config_event);
+                    cfg->RedirectWebinarNeedRegister(true);
+                    cfg->RedirectWebinarNameInputDialog(true);
+                    if (!registration_email.empty())
+                        cfg->PrePopulateWebinarRegistrationInfo(
+                            to_zstr(registration_email).c_str(),
+                            g_wide_name.c_str());
+                }
+```
+
+with `static EngineConfigEvent config_event;` declared beside the other long-lived engine objects (near :1290). Note `PrePopulateWebinarRegistrationInfo` takes raw pointers the SDK may hold across the async join — pass `g_wide_name.c_str()` and store the widened email in a new persistent `g_wide_reg_email` beside the other `g_wide_*` variables (:1312-1328), not a temporary.
+
+Plugin side: `ZoomEngineClient::join()` and the control-server `join` handler (:719) forward an optional `registration_email` string field verbatim, defaulting to absent; `src/zoom-dock.cpp` is untouched this task (the dock gains nothing until an operator asks — control-API-first, like `talkback_probe`).
+
+- [ ] **Step 3: Build and run the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: green, no delta.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add engine/src/main.cpp src/zoom-engine-client.h src/zoom-engine-client.cpp src/zoom-control-server.cpp
+git commit -m "feat(webinar): answer register/screen-name join prompts headlessly"
+```
+
+---
+
+### Task 4: Plugin state + feature gating
+
+The plugin learns the mode from `meeting_mode`, exposes it, and every gated surface asks `webinar_feature_verdict()` before acting. The refusal points are: the talkback controller's `key_on()`/nominate (already refusal-shaped — add one more named reason), the speaker-director enable path in `src/zoom-dock.cpp`'s 100 ms tick, and the control server's `talkback_nominate`/`assign_output` handlers. Raw-media subscription itself is NOT pre-refused plugin-side: for a panelist it must work, and for an attendee the engine's existing `video_subscribe_failed` path already reports per-source — the plugin adds the *explanation* (the verdict reason) to the dock status instead of a second gate that could false-refuse on a stale role.
+
+**Files:**
+- Modify: `src/zoom-engine-client.h` (near `is_awaiting_admission()`, :260), `src/zoom-engine-client.cpp` (`handle_event`, beside the `awaiting_admission` branch at :1440)
+- Modify: `src/zoom-dock.cpp` (mode badge + director gating), `src/zoom-control-server.cpp` (refusals), talkback controller (`key_on` refusal)
+- Test: `tests/webinar-capability-test.cpp` (extend — the gating decisions are already pure; this task adds the state-holder round-trip)
+
+**Interfaces:**
+- Consumes: `meeting_mode` event (Task 2), `webinar_feature_verdict` / `local_role_from_id` (Task 1).
+- Produces: `MeetingMode ZoomEngineClient::meeting_mode() const`, `LocalRole ZoomEngineClient::local_role() const`, `bool ZoomEngineClient::is_webinar_backstage() const`. `talkback_status` and refusals gain the verdict reasons.
+
+- [ ] **Step 1: Write the failing test**
+
+The event→state mapping must be pure so a host test can reach it (the talkback feature's N5 lesson: wiring inlined in `handle_event` is untestable). Append to `tests/webinar-capability-test.cpp`, before the final `if (failures == 0)`:
+
+```cpp
+    // --- The wire mapping: what handle_event stores from a meeting_mode line ---
+    {
+        WebinarState st; // defaults must equal "old engine": Unknown/Unknown/false
+        check(st.mode == MeetingMode::Unknown && st.role == LocalRole::Unknown &&
+              !st.backstage, "WebinarState default is not the old-engine default");
+        webinar_state_apply(st, /*webinar=*/true, /*role_id=*/"attendee",
+                            /*backstage=*/true);
+        check(st.mode == MeetingMode::Webinar && st.role == LocalRole::Attendee &&
+              st.backstage, "meeting_mode apply did not store webinar/attendee/backstage");
+        webinar_state_apply(st, false, "host", false);
+        check(st.mode == MeetingMode::Meeting && st.role == LocalRole::Host,
+              "meeting_mode apply did not overwrite latest-wins");
+        webinar_state_reset(st);
+        check(st.mode == MeetingMode::Unknown,
+              "reset did not return to the old-engine default -- a stale Webinar "
+              "verdict would gate the NEXT, ordinary meeting");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cmake --build build --config Release --target CoreVideoWebinarCapabilityTest --parallel 8
+```
+
+Expected: FAIL to compile — `'WebinarState' was not declared`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/webinar-capability.h`:
+
+```cpp
+// The plugin-side holder for the engine's meeting_mode event. Latest-wins,
+// like awaiting_admission. reset() returns to the OLD-ENGINE default
+// (Unknown), and is wired into the same three world-reset points the talkback
+// nomination record uses (handle_event's "left" branch, stop_for_reconnect(),
+// start() after its joins): a Webinar verdict surviving into the next meeting
+// would gate features in an ordinary meeting.
+struct WebinarState {
+    MeetingMode mode = MeetingMode::Unknown;
+    LocalRole role = LocalRole::Unknown;
+    bool backstage = false;
+};
+
+inline void webinar_state_apply(WebinarState &st, bool webinar,
+                                const std::string &role_id, bool backstage)
+{
+    st.mode = webinar ? MeetingMode::Webinar : MeetingMode::Meeting;
+    st.role = local_role_from_id(role_id);
+    st.backstage = backstage;
+}
+
+inline void webinar_state_reset(WebinarState &st) { st = WebinarState{}; }
+```
+
+Then wire it (Qt-bound, pinned only through the pure functions above):
+
+- `src/zoom-engine-client.h`: `WebinarState m_webinar_state; mutable std::mutex` reuse `m_mtx`; accessors `meeting_mode()` / `local_role()` / `is_webinar_backstage()` reading under the lock, declared beside `is_awaiting_admission()` (:260).
+- `src/zoom-engine-client.cpp` `handle_event`, beside the `awaiting_admission` branch (:1440):
+
+```cpp
+    if (cmd == "meeting_mode") {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        webinar_state_apply(m_webinar_state, obj.value("webinar").toBool(),
+                            obj.value("role").toString().toStdString(),
+                            obj.value("backstage").toBool());
+        return;
+    }
+```
+
+  plus `webinar_state_reset(m_webinar_state)` in the `"left"` branch (:1453), in `stop_for_reconnect()`, and in `start()` after its thread joins — the three world-reset points, verbatim per the talkback N2/N7 history. Also `blog(LOG_INFO, ...)` any `webinar_join` / `webinar_register_url` line verbatim, exactly as `talkback_probe` lines are logged (:1351).
+- Gating call sites, each a two-liner asking the verdict and surfacing `v.reason`: the talkback controller's `key_on()` and `ZoomControlServer`'s `talkback_nominate` refuse when `webinar_feature_verdict(mode, role, CoreVideoFeature::Talkback)` is unavailable; `src/zoom-dock.cpp`'s director group disables with the reason as tooltip when `SpeakerDirector` is unavailable; the dock header shows `Webinar — Attendee (limited)` from `meeting_mode()`/`local_role()` whenever mode is `Webinar`.
+
+- [ ] **Step 4: Run test to verify it passes, then the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: PASS (`webinar-capability: all tests passed`), suite green.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/webinar-capability.h tests/webinar-capability-test.cpp src/zoom-engine-client.h src/zoom-engine-client.cpp src/zoom-dock.cpp src/zoom-control-server.cpp
+git commit -m "feat(webinar): plugin-side mode state, latest-wins, gated surfaces with named reasons"
+```
+
+---
+
+### Task 5: Promote/demote panelist — commands, wrapper, and the EXISTS gate
+
+Everything about promote/demote except two lines is expressible against the tracked tree: command routing, name resolution, the role gate, the refusal reporting. The two lines that are not — the actual `IMeetingWebinarController` method calls — go in their own TU, compiled only under the same `EXISTS` gate as the talkback test target (CMakeLists.txt:1168), because `meeting_webinar_ctrl_interface.h` exists only in the full local SDK drop. **The exact method names (approximately `PromptePanelist2Attendee` / `DepromptAttendee2Panelist` — Zoom's own spellings) are copied from that header at implementation time on a machine with the full drop; they are deliberately not written in this plan because guessing them wrong would compile on no machine and review as if real.** Without the gate satisfied, the commands still route, resolve and report — they just answer `sdk_header_missing`.
+
+**Files:**
+- Modify: `src/engine-ipc.h:26` (tokens after `IPC_CMD_TALKBACK_NOMINATE`), `src/engine-command.h:32-50` (enum), `:86-105` (routing)
+- Create: `engine/src/engine-webinar.h`, `engine/src/engine-webinar.cpp` (always compiled), `engine/src/engine-webinar-sdk.cpp` (gate-compiled only)
+- Modify: `engine/src/main.cpp` (two command branches beside `IpcCommand::TalkbackProbe`, :1500), `CMakeLists.txt` (ENGINE_SOURCES + the gate), `src/zoom-control-server.cpp` (control commands `webinar_promote` / `webinar_demote`), `src/zoom-engine-client.h/.cpp` (pass-through methods)
+- Test: `tests/engine-command-test.cpp`
+
+**Interfaces:**
+- Consumes: `local_role_id` / `webinar_feature_verdict` (Task 1); `meeting_mode` state engine-side via the same `GetMySelfUser()` reads as Task 2.
+- Produces: `IPC_CMD_WEBINAR_PROMOTE` (`"webinar_promote"`), `IPC_CMD_WEBINAR_DEMOTE` (`"webinar_demote"`), `IpcCommand::WebinarPromote/WebinarDemote`; `void EngineWebinar::promote(ZOOMSDK::IMeetingService *svc, const std::string &name)` and `void EngineWebinar::demote(ZOOMSDK::IMeetingService *svc, const std::string &name)`; internal seam `ZOOMSDK::SDKError webinar_sdk_promote(ZOOMSDK::IMeetingService *svc, unsigned int user_id)` / `webinar_sdk_demote(...)` (the gated TU); E2P report `{"cmd":"webinar_role","action":"promote"|"demote","name":"...","code":<int>}` or `{"cmd":"webinar_role","ok":false,"reason":"..."}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `tests/engine-command-test.cpp`, following the talkback commands' pattern:
+
+```cpp
+    // --- Webinar promote/demote route exactly, and do not collide ---
+    check(ipc_command_of(R"({"cmd":"webinar_promote","name":"Sarah Muller"})") ==
+              IpcCommand::WebinarPromote,
+          "webinar_promote did not route to IpcCommand::WebinarPromote");
+    check(ipc_command_of(R"({"cmd":"webinar_demote","name":"Sarah Muller"})") ==
+              IpcCommand::WebinarDemote,
+          "webinar_demote did not route to IpcCommand::WebinarDemote");
+    check(ipc_command_of(R"({"cmd":"join","display_name":"webinar_promote"})") ==
+              IpcCommand::Join,
+          "a payload containing 'webinar_promote' hijacked the join branch");
+    check(ipc_command_of(R"({"cmd":"webinar_promote_all"})") == IpcCommand::Unknown,
+          "a longer command starting with webinar_promote matched it");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+cmake --build build --config Release --target CoreVideoEngineCommandTest --parallel 8
+```
+
+Expected: FAIL to compile with `'WebinarPromote' is not a member of 'IpcCommand'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/engine-ipc.h` after `IPC_CMD_TALKBACK_NOMINATE` (:26):
+
+```c
+#define IPC_CMD_WEBINAR_PROMOTE "webinar_promote"
+#define IPC_CMD_WEBINAR_DEMOTE  "webinar_demote"
+```
+
+`src/engine-command.h`: append `WebinarPromote, WebinarDemote,` to the enum and, in `ipc_command_of` before the final `return`:
+
+```cpp
+    if (cmd == IPC_CMD_WEBINAR_PROMOTE) return IpcCommand::WebinarPromote;
+    if (cmd == IPC_CMD_WEBINAR_DEMOTE)  return IpcCommand::WebinarDemote;
+```
+
+Create `engine/src/engine-webinar.h`:
+
+```cpp
+#pragma once
+//
+// engine-webinar.h — promote/demote webinar panelists by display name.
+//
+// The tracked SDK tree forward-declares IMeetingWebinarController
+// (meeting_service_interface.h:957) but ships no
+// meeting_webinar_ctrl_interface.h, so the controller's methods cannot be
+// named in any always-compiled TU. The two calls live in
+// engine-webinar-sdk.cpp, compiled only when the full local SDK drop supplies
+// that header (same EXISTS gate as CoreVideoEngineTalkbackSelectTest,
+// CMakeLists.txt:1168). This file and engine-webinar.cpp compile everywhere.
+//
+#include "zoom_sdk.h"
+#include "meeting_service_interface.h"
+
+#include <string>
+
+// The gated seam. Real bodies in engine-webinar-sdk.cpp; without the header,
+// engine-webinar.cpp's fallback bodies return SDKERR_WRONG_USAGE and promote()
+// reports reason "sdk_header_missing" instead of pretending it tried.
+ZOOMSDK::SDKError webinar_sdk_promote(ZOOMSDK::IMeetingService *svc, unsigned int user_id);
+ZOOMSDK::SDKError webinar_sdk_demote(ZOOMSDK::IMeetingService *svc, unsigned int user_id);
+
+class EngineWebinar {
+public:
+    void promote(ZOOMSDK::IMeetingService *svc, const std::string &name);
+    void demote(ZOOMSDK::IMeetingService *svc, const std::string &name);
+
+private:
+    void act(ZOOMSDK::IMeetingService *svc, const std::string &name, bool to_panelist);
+    void refuse(const char *action, const std::string &name, const char *reason);
+};
+```
+
+Create `engine/src/engine-webinar.cpp`:
+
+```cpp
+#include "engine-webinar.h"
+#include "engine-writer.h"        // EngineIpc::write — include, never forward-declare
+#include "engine-json.h"          // json_escape / zchar_to_utf8
+#include "webinar-capability.h"   // the role gate, same table the plugin uses
+
+#include "meeting_participants_ctrl_interface.h"
+
+void EngineWebinar::refuse(const char *action, const std::string &name,
+                           const char *reason)
+{
+    EngineIpc::write(std::string(R"({"cmd":"webinar_role","action":")") + action +
+        R"(","name":")" + json_escape(name) +
+        R"(","ok":false,"reason":")" + reason + R"("})");
+}
+
+void EngineWebinar::act(ZOOMSDK::IMeetingService *svc, const std::string &name,
+                        bool to_panelist)
+{
+    const char *action = to_panelist ? "promote" : "demote";
+    if (!svc) { refuse(action, name, "not_in_meeting"); return; }
+
+    // Same gate the plugin pre-checks — re-checked here because the engine is
+    // the authority and a role can change between the two processes' reads.
+    auto *pc = svc->GetMeetingParticipantsController();
+    if (!pc) { refuse(action, name, "no_participants_controller"); return; }
+    LocalRole my_role = LocalRole::Unknown;
+    if (ZOOMSDK::IUserInfo *self = pc->GetMySelfUser()) {
+        if (self->GetUserRole() == ZOOMSDK::USERROLE_HOST)   my_role = LocalRole::Host;
+        if (self->GetUserRole() == ZOOMSDK::USERROLE_COHOST) my_role = LocalRole::CoHost;
+    }
+    bool webinar = false;
+    if (ZOOMSDK::IMeetingInfo *info = svc->GetMeetingInfo())
+        webinar = info->GetMeetingType() == ZOOMSDK::MEETING_TYPE_WEBINAR;
+    const FeatureVerdict v = webinar_feature_verdict(
+        webinar ? MeetingMode::Webinar : MeetingMode::Meeting, my_role,
+        CoreVideoFeature::PromoteDemote);
+    if (!v.available) { refuse(action, name, v.reason); return; }
+
+    // Resolve by NAME at use time — ids are meeting-scoped and recycled.
+    unsigned int uid = 0;
+    if (ZOOMSDK::IList<unsigned int> *ids = pc->GetParticipantsList()) {
+        for (int i = 0; i < ids->GetCount() && uid == 0; ++i) {
+            ZOOMSDK::IUserInfo *u = pc->GetUserByUserID(ids->GetItem(i));
+            if (u && zchar_to_utf8(u->GetUserName()) == name) uid = ids->GetItem(i);
+        }
+    }
+    // A webinar ATTENDEE is not in this roster (attendees are invisible to
+    // GetParticipantsList for panelist-side clients — verified live in Task 6
+    // Step 4; if that finding differs, this comment and the reason change
+    // together). no_participant_named therefore covers both "typo" and
+    // "attendee not visible to us", and the report says so.
+    if (uid == 0) { refuse(action, name, "no_participant_named"); return; }
+
+    const ZOOMSDK::SDKError e = to_panelist ? webinar_sdk_promote(svc, uid)
+                                            : webinar_sdk_demote(svc, uid);
+    EngineIpc::write(std::string(R"({"cmd":"webinar_role","action":")") + action +
+        R"(","name":")" + json_escape(name) +
+        R"(","code":)" + std::to_string(static_cast<int>(e)) + "}");
+}
+
+void EngineWebinar::promote(ZOOMSDK::IMeetingService *svc, const std::string &name)
+{ act(svc, name, true); }
+void EngineWebinar::demote(ZOOMSDK::IMeetingService *svc, const std::string &name)
+{ act(svc, name, false); }
+
+#if !defined(COREVIDEO_HAS_WEBINAR_CTRL)
+// Tracked-tree fallback: the controller's header does not exist here, so the
+// calls cannot. Loud, distinct failure — never a silent no-op.
+ZOOMSDK::SDKError webinar_sdk_promote(ZOOMSDK::IMeetingService *, unsigned int)
+{ return ZOOMSDK::SDKERR_WRONG_USAGE; }
+ZOOMSDK::SDKError webinar_sdk_demote(ZOOMSDK::IMeetingService *, unsigned int)
+{ return ZOOMSDK::SDKERR_WRONG_USAGE; }
+#endif
+```
+
+Create `engine/src/engine-webinar-sdk.cpp` (compiled only under the gate):
+
+```cpp
+// The ONLY TU that names IMeetingWebinarController's methods. Compiled solely
+// when the full local SDK drop supplies the header (see CMakeLists gate).
+//
+// IMPLEMENTATION-TIME STEP, on a machine with the full drop: open
+// meeting_service_components/meeting_webinar_ctrl_interface.h and copy the
+// EXACT promote/demote method names and signatures (approximately
+// PromptePanelist2Attendee / DepromptAttendee2Panelist — Zoom's own
+// spellings) into the two marked lines. Do not guess them: this plan was
+// written against the tracked tree, which does not contain that header.
+#include "engine-webinar.h"
+#include "meeting_service_components/meeting_webinar_ctrl_interface.h"
+
+ZOOMSDK::SDKError webinar_sdk_promote(ZOOMSDK::IMeetingService *svc, unsigned int user_id)
+{
+    ZOOMSDK::IMeetingWebinarController *ctrl = svc->GetMeetingWebinarController();
+    if (!ctrl) return ZOOMSDK::SDKERR_SERVICE_FAILED;
+    return ctrl-> /* <copy the attendee→panelist method from the full-SDK header> */ (user_id);
+}
+
+ZOOMSDK::SDKError webinar_sdk_demote(ZOOMSDK::IMeetingService *svc, unsigned int user_id)
+{
+    ZOOMSDK::IMeetingWebinarController *ctrl = svc->GetMeetingWebinarController();
+    if (!ctrl) return ZOOMSDK::SDKERR_SERVICE_FAILED;
+    return ctrl-> /* <copy the panelist→attendee method from the full-SDK header> */ (user_id);
+}
+```
+
+`CMakeLists.txt`: add `engine/src/engine-webinar.cpp` to `ENGINE_SOURCES` unconditionally, then beside it:
+
+```cmake
+# Same precedent as the talkback test gate at line ~1168: the tracked SDK tree
+# has no meeting_webinar_ctrl_interface.h; the full local drop does. Without
+# it the engine still builds, and promote/demote answers sdk_header_missing.
+if(EXISTS "${ZOOM_SDK_INCLUDE_DIR}/meeting_service_components/meeting_webinar_ctrl_interface.h")
+    list(APPEND ENGINE_SOURCES engine/src/engine-webinar-sdk.cpp)
+    set(COREVIDEO_HAS_WEBINAR_CTRL TRUE)
+endif()
+```
+
+and `target_compile_definitions(ZoomObsEngine PRIVATE COREVIDEO_HAS_WEBINAR_CTRL)` under the same condition. Wire `main.cpp`: `static EngineWebinar webinar;` beside `talkback` (:1290), and two branches beside `IpcCommand::TalkbackProbe` (:1500):
+
+```cpp
+        } else if (command == IpcCommand::WebinarPromote) {
+            webinar.promote(meeting_svc, json_str(line, "name"));
+        } else if (command == IpcCommand::WebinarDemote) {
+            webinar.demote(meeting_svc, json_str(line, "name"));
+```
+
+When `COREVIDEO_HAS_WEBINAR_CTRL` is unset, map the `SDKERR_WRONG_USAGE` sentinel to reason `sdk_header_missing` inside `act()` (check the define there, before calling the seam) so the operator-facing reason names the real cause, not a generic code. Plugin side: `ZoomEngineClient::webinar_promote(name)` / `webinar_demote(name)` (fire-and-acknowledge, `webinar_role` lines logged verbatim like `talkback_probe`), and `ZoomControlServer` commands `webinar_promote` / `webinar_demote` taking `"name"`, pre-checked against `webinar_feature_verdict` for a fast local refusal.
+
+- [ ] **Step 4: Run test to verify it passes, then the full suite**
+
+```sh
+cmake --build build --config Release --parallel 8
+cd build && ctest -C Release --output-on-failure
+```
+
+Expected: routing test PASS; engine links on the tracked tree (fallback bodies); on a machine with the full SDK drop, configure again and confirm `engine-webinar-sdk.cpp` enters the build and links once the two marked calls are filled in from the real header.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/engine-ipc.h src/engine-command.h tests/engine-command-test.cpp engine/src/engine-webinar.h engine/src/engine-webinar.cpp engine/src/engine-webinar-sdk.cpp engine/src/main.cpp CMakeLists.txt src/zoom-engine-client.h src/zoom-engine-client.cpp src/zoom-control-server.cpp
+git commit -m "feat(webinar): promote/demote panelist by name behind the full-SDK EXISTS gate"
+```
+
+---
+
+### Task 6: Live verification — THE GATE
+
+The compile proves the tracked-tree API exists; only a real webinar proves the constraints this plan encodes. Three of the Spec's claims are stated as to-verify, and this task is where they become facts: (a) an attendee truly has no raw-data path, (b) the panelist role suffices for the local-recording privilege and per-participant subscription, (c) talkback's behaviour inside a webinar. Use a dedicated TEST webinar, never a live show; install the matched pair (both binaries, SHA256-verified) first.
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-08-29-webinar-live-results.md` (the actual output, verbatim)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the go/no-go facts for un-gating talkback (`talkback_unverified_in_webinar`) and for confirming the attendee-roster claim in `engine-webinar.cpp`'s comment.
+
+- [ ] **Step 1: Join as ATTENDEE.** Schedule a webinar on the entitled account; join CoreVideo via the control API with the webinar URL in `meeting_id`. Record: the `webinar_join` stage lines (register/screen-name handshakes), the `meeting_mode` line (`"webinar":true,"role":"attendee"`), whether backstage/practice session reports `"backstage":true` before broadcast starts, and — critically — that the join watchdog and `awaiting_admission` machinery stay quiet (no waiting-room state exists to misreport).
+- [ ] **Step 2: Attendee raw-data constraint.** `start_engine` twice, `assign_output` to a named panelist. Expected: the privilege request or `createRenderer` fails (record the exact `SDKError`); the dock shows the `webinar_attendee_no_raw_media` explanation. If raw media WORKS as an attendee, the capability table's central assumption is wrong — stop, record, and amend Task 1's table before anything ships.
+- [ ] **Step 3: Promote to panelist, live.** From the host's Zoom client, promote CoreVideo. Record: a fresh `meeting_mode` line with `"role":"panelist"` arriving via `roster_changed()` (this is the event path Task 2 exists for), then repeat Step 2 — subscription and ISO must now work end-to-end (frames flowing, WAV/MP4 nonzero).
+- [ ] **Step 4: Roster visibility + promote/demote round trip.** As panelist/co-host, run `{"cmd":"webinar_promote","name":"<attendee display name>"}`. Record whether the attendee appears in `GetParticipantsList` at all (the `no_participant_named` comment in engine-webinar.cpp depends on this answer — fix the comment if reality differs), the `webinar_role` result line, and the demote round trip. Also record `GetWebinarAttendeeStatus()->allow_talk` before/after the host allows an attendee to talk, if observable.
+- [ ] **Step 5: Talkback in a webinar.** As co-host or host, on a machine with the full SDK drop, run `{"cmd":"talkback_probe","participant":"<panelist name>"}` after TEMPORARILY bypassing the `talkback_unverified_in_webinar` refusal (a local, uncommitted edit — the gate exists precisely so this bypass cannot ship). Record every rung. Only a full green ladder plus human confirmation justifies changing the Task 1 verdict; a `meeting_supported=false` or NOPERMISSION rung makes the fail-closed verdict permanent and documented.
+- [ ] **Step 6: Record and decide.** Write all of it into `docs/superpowers/notes/2026-08-29-webinar-live-results.md`, update the CLAUDE.md invariants list in the same change (docs-updated is part of done), and commit:
+
+```sh
+git add docs/superpowers/notes/2026-08-29-webinar-live-results.md CLAUDE.md
+git commit -m "docs(webinar): live gate results — attendee/panelist raw-data, promote round trip, talkback verdict"
+```
+
+---
+
+## Self-Review
+
+**Placeholder scan.** Task 5's two marked call sites in `engine-webinar-sdk.cpp` are the plan's one stated SDK gap, not a placeholder: the method names physically do not exist in the tracked tree (`third_party/zoom-sdk/h` has no `meeting_webinar_ctrl_interface.h` — verified by glob), the gap is fenced behind the same `EXISTS` gate the repo already uses at CMakeLists.txt:1168, a loud fallback (`sdk_header_missing`) covers the ungated build, and the fill-in step is written into the file itself. Task 3's `std::wstring(begin, end)` sketch names `to_zstr` as the required call. Tasks 2 and 3 declare "no unit test, SDK-bound" explicitly with the live verification route named — the same statement the talkback Milestone 1 plan made for its Tasks 3/4. Everything else carries real code.
+
+**Cross-task type consistency.** `MeetingMode` / `LocalRole` / `CoreVideoFeature` / `FeatureVerdict` / `WebinarState` are defined once in Task 1's `src/webinar-capability.h` and consumed by Tasks 2 (engine, `local_role_id`), 4 (plugin, `webinar_state_apply` / `webinar_feature_verdict`) and 5 (engine, `webinar_feature_verdict`) with matching signatures. `webinar_sdk_promote/demote(ZOOMSDK::IMeetingService*, unsigned int)` is declared in Task 5's header and defined twice under mutually exclusive compilation (`#if !defined(COREVIDEO_HAS_WEBINAR_CTRL)` fallback vs. the gated TU) — exactly one definition links in either configuration. `IPC_CMD_WEBINAR_PROMOTE/DEMOTE` and the two enum values are produced and consumed only in Task 5. Every SDK symbol named in code was verified against the tracked headers by line number (listed in the Spec section); the only unverified names are the two the plan explicitly refuses to write.
+
+**Honest constraints, restated once.** Attendees have no per-participant raw streams and cannot hold the local-recording privilege (fail-closed in Task 1, proven or amended in Task 6 Step 2). Talkback is meetings-only until Task 6 Step 5 says otherwise. Webinar attendees have no waiting room; backstage (`IsInWebinarBackstage`) is the pre-broadcast signal and is reported, never "admitted". `MeetingMode::Unknown` fails OPEN by design, because a DLL-only half-install is this repo's canonical mistake and gating on it would break every ordinary meeting.


### PR DESCRIPTION
Six implementation plans for adopting untapped Zoom Meeting SDK features, each grounded in the vendored SDK headers and the repo's existing test framework:

- **share-raw-data-source** — screen share as a first-class source (`RAW_DATA_TYPE_SHARE`) with its own ISO stem and dynamic-resolution handling
- **captions-transcription** — live transcription events into a caption stream + transcript sidecar aligned to ISO timestamps
- **network-quality-telemetry** — `onUserNetworkStatusChanged` + statistics warnings feeding the demotion logic and per-source dock health
- **production-control-surface** — spotlight/pin/mute/rename/mute-all via the dock UI and Companion actions
- **webinar-support** — webinar join, attendee/panelist role gating, promote/demote
- **obf-token-audit** — compliance with the March 2, 2026 cross-account join token requirement (`app_privilege_token`/ZAK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcU7dhikTwjnTiKyfEdMph