### PR TITLE
docs: bring the wiki and plugin guide to v0.1.44, and document talkback

### DIFF
--- a/docs/CORE_PLUGIN_FUNCTIONALITY.md
+++ b/docs/CORE_PLUGIN_FUNCTIONALITY.md
@@ -2,7 +2,14 @@
 
 This guide covers the main CoreVideo OBS plugin workflows. It intentionally
 focuses on the OBS plugin, `ZoomObsEngine`, Zoom source assignment, control APIs,
-audio routing, and ISO recording.
+audio routing, talkback, and ISO recording.
+
+Current release: **v0.1.44**. Where a section describes something newer than
+that, it says so.
+
+One naming quirk to get out of the way: the OBS **sources** this plugin
+registers are called `CoreVideo ...`, but its **docks and Tools menu entries**
+are still called `Zoom ...`. Both are this plugin.
 
 ## Media Architecture
 
@@ -31,10 +38,15 @@ alternative transport in the future.
 The CoreVideo plugin is operated from inside OBS. These diagrams mirror the
 current core plugin controls: the Zoom Control dock, regular OBS scenes/sources,
 the Active Speaker Director controls, the dockable profile-oriented Zoom Output
-Manager, and the Zoom Participant source properties. Exact styling can vary by
-OBS theme and platform, but the controls and labels should match the current
+Manager, and the CoreVideo Participant source properties. Exact styling can vary
+by OBS theme and platform, but the controls and labels should match the current
 plugin. This guide intentionally describes the OBS plugin path; optional
 Sidecar control-surface features are tracked separately in the roadmap.
+
+The plugin registers five docks, each with a matching **Tools** menu entry that
+focuses it: **Zoom Control**, **Zoom Output Manager**, **Zoom Diagnostics**,
+**Zoom ISO Recorder**, and **Zoom Talkback**. **Tools > Zoom Plugin Settings**
+opens the settings dialog, which is where Zoom sign-in lives.
 
 ![CoreVideo OBS workspace with Zoom Control dock](images/corevideo-obs-workspace.svg)
 
@@ -53,10 +65,21 @@ show can be routed without opening individual source properties.
 Active-speaker, spotlight, and screen-share routing gaps are reported as
 specific health states, so operators can tell the difference between "waiting
 for the next directed speaker" and a stale or missing video feed.
-In `v0.1.18` it is a persistent OBS dock, so operators can keep assignments,
-live previews, and feed health visible while working in normal OBS scenes.
-Profile loading reports matched outputs and any saved source names that are not
-present in the current OBS scene/source set before the operator clicks Apply.
+It is a persistent OBS dock, so operators can keep assignments, live previews,
+and feed health visible while working in normal OBS scenes. Profile loading
+reports matched outputs and any saved source names that are not present in the
+current OBS scene/source set before the operator clicks Apply.
+
+Two columns exist for audio timing: **Delay (embedded)** and **A/V Offset
+(embedded)**. Both act on a video source's own embedded audio track and neither
+touches the dedicated CoreVideo Audio sources - see the Audio Routing section
+below. **Hide participants without video** filters the
+participant table, the output assignment lists, and the participant source
+picker; someone with their camera off cannot be routed to an output or a tile at
+all. It never hides a participant who is already assigned, so switching a camera
+off cannot make a picker lose its own selection. Audio source pickers are
+deliberately unaffected - a camera-off participant is often exactly who you want
+a dedicated audio source for.
 
 Open the **Zoom Diagnostics** dock, or use **Tools > Zoom Diagnostics** to focus it,
 during a live session to see requested versus
@@ -67,40 +90,54 @@ resubscribed by recovery logic. Use **Create Support Bundle** from this dock to
 write a redacted troubleshooting bundle with engine status, output health,
 recent debug events, plugin settings with tokens removed, ISO recorder and
 FFmpeg encoder/session status, runtime/package validation, and the latest OBS
-log when available. On Windows, CoreVideo also creates a `.zip` next to the
-support bundle folder when PowerShell is available. OBS log data is written as a
-recent redacted excerpt; OAuth codes, access
-tokens, refresh tokens, ZAK/JWT values, passcodes, client secrets, and
-authorization headers are removed before the bundle is written.
+log when available. Bundles are written to
+`%APPDATA%\obs-studio\plugin_config\obs-zoom-plugin\support-bundles\CoreVideo-support-<timestamp>\`,
+and on Windows CoreVideo also creates a `.zip` beside that folder when
+PowerShell is available; the dialog reports both paths. OBS log data is written
+as a redacted excerpt of the last 500 lines; OAuth codes, access tokens, refresh
+tokens, ZAK/JWT values, passcodes, client secrets, and authorization headers are
+removed before the bundle is written. Meeting and participant names, participant
+IDs, and ISO file paths are **not** redacted - read the bundle before attaching
+it to a public issue.
 
-![CoreVideo Zoom Participant source properties](images/corevideo-source-properties.svg)
+![CoreVideo Participant source properties](images/corevideo-source-properties.svg)
 
-Each Zoom Participant source can be configured independently for fixed
+Each CoreVideo Participant source can be configured independently for fixed
 participants, active speaker, spotlight slot, screen share, isolated audio,
 audience audio, resolution, video-loss behavior, and hardware conversion.
 
 ## Joining Meetings
 
 1. Open OBS.
-2. Open **Tools > Zoom Control**.
-3. Enter a Zoom meeting ID or full Zoom join URL.
-4. Enter a display name.
-5. Use **Auto Zoom sign-in** for the published broker-backed flow.
-6. Click **Join**.
-7. Use the visible Zoom Meeting SDK window for waiting-room admission, self
-   video/audio, and normal meeting controls.
-8. Click **Start Engine** after joining to request raw media from Zoom.
+2. Sign in once from **Tools > Zoom Plugin Settings** with **Sign in with
+   Zoom**. There is no sign-in button on the Zoom Control dock.
+3. Open **Tools > Zoom Control**.
+4. Enter a Zoom meeting ID or full Zoom join URL, a passcode if the meeting has
+   one, and a display name.
+5. Leave the join-token dropdown on **Zoom sign-in**. `User ZAK` and `App
+   privilege token` are for tokens Zoom support has issued you specifically; the
+   token field stays disabled and reads "Automatic from Zoom sign-in" otherwise.
+6. Tick **Join as Webinar / Zoom Events** for a webinar - the SDK uses a
+   different entry point for those.
+7. Click **Join**.
+8. Use the visible Zoom Meeting SDK window for waiting-room admission, self
+   video/audio, and normal meeting controls. CoreVideo waits out a waiting room
+   rather than giving up on it (v0.1.44); the two-minute join watchdog holds its
+   window open for as long as the wait lasts, and is armed by this **Join**
+   button only - a join issued over the control API is not watched.
+9. Click **Start Engine** after joining to request raw media from Zoom.
 
-For external-account meetings, configure OAuth in **Tools > Zoom Plugin
-Settings**. Published builds use the embedded CoreVideo broker URL: the browser
-sign-in uses Zoom Public Client OAuth + PKCE, CoreVideo fetches the signed-in
-user's ZAK, and the helper authenticates the Meeting SDK with the embedded
-Marketplace Public Client ID as `AuthContext.publicAppKey`. End users do not
-enter client IDs or secrets.
+Published builds use the embedded CoreVideo broker: the browser sign-in uses
+Zoom Public Client OAuth + PKCE against `https://corevideo.iamfatness.us/oauth/start`,
+CoreVideo fetches the signed-in user's ZAK, and the helper authenticates the
+Meeting SDK with the embedded Marketplace Public Client ID as
+`AuthContext.publicAppKey`. End users do not enter client IDs or secrets. The
+site itself is `corevideo.io`; both names route to the same worker, and the
+iamfatness host is the one compiled into shipped builds.
 
 ## Source Assignment
 
-Add one or more **Zoom Participant** sources in OBS. Each source can follow a
+Add one or more **CoreVideo Participant** sources in OBS. Each source can follow a
 different assignment mode:
 
 | Mode | Behavior | Common Use |
@@ -310,17 +347,234 @@ directed, candidate, or manual speaker changes.
 
 ## Audio Routing
 
-CoreVideo supports three audio modes for participant outputs:
+CoreVideo has **two independent audio paths**, and knowing which one you are on
+decides what guarantees you get. No code connects them.
+
+**The dedicated path** is the audio-only OBS sources: **CoreVideo Participant
+Audio**, **CoreVideo Active Speaker Audio**, and the legacy **CoreVideo Audience
+Audio**. These drain the engine's 8-slot shared-memory ring in order, derive
+timestamps from a running sample count rather than from arrival, count and report
+anything they lose (`list_audio_sources` -> `overrun_slots`, which should stay at
+`0`), and honour the global audio delay trim. **Route these to program for
+anything that matters.**
+
+**The embedded path** is the audio track a CoreVideo video source publishes
+alongside its picture, configured from that source's own properties. It reads the
+newest buffer only, is stamped at arrival, and has no loss accounting. It is
+convenient, not lossless.
+
+Audio modes for a video source's embedded track:
 
 | Routing | Behavior |
 |---|---|
 | Mixed | Full meeting mix |
-| Isolated | Only the assigned participant's one-way audio |
+| Isolated | Only the assigned participant's one-way audio (**Isolate selected participant's audio (suppress mix)**) |
 | Audience | Residual one-way audio for participants not assigned to isolated outputs |
 
-Use **Isolated** when you need the assigned participant only. Use **Audience**
-for a remaining-room or overflow mic channel after dedicated isolated sources
-have claimed named participants.
+Use **Isolated** when you need the assigned participant only. **Audience** is
+kept for existing shows - its OBS source is labelled `(legacy)` - as a
+remaining-room or overflow mic channel after dedicated isolated sources have
+claimed named participants.
+
+### Delay and the measured A/V offset
+
+Video is the slower path in any software production chain, so audio arrives at
+OBS ahead of its matching picture and needs delaying to line back up. There is
+one control per path, and each moves only its own:
+
+- **Tools > Zoom Plugin Settings > Audio > Audio delay (dedicated sources)** is a
+  single global trim, 0-500 ms, for every dedicated CoreVideo Audio source. It
+  takes effect on the next audio buffer, including on sources already running.
+- The Output Manager's per-row **Delay (embedded)** trims one video source's own
+  embedded track, and **A/V Offset (embedded)** is the measured number to trim it
+  against. The offset is `video_latency_us - audio_latency_us` measured from
+  engine capture to OBS publish: positive means audio is early by that many
+  milliseconds, which is what to dial into Delay. It reads `-` until both
+  latencies have actually been measured.
+
+Delay can only ever push audio later; it can never advance it. Trim off air -
+lowering a delay pushes the timestamp backward once and briefly glitches the
+affected source.
+
+The same field is settable over TCP. Omit it entirely on unrelated calls, such as
+a plain reassignment, or it resets to 0:
+
+```json
+{"cmd":"assign_output","source":"CoreVideo Participant 1","participant_id":123456,"audio_delay_ms":80}
+```
+
+### Silence is a Zoom property, not a dropout
+
+Zoom only calls audio back for a participant who is currently making sound, so a
+silent stretch produces no buffers at all rather than buffers of silence. Two
+consequences CoreVideo handles and one it cannot: the master clock resyncs rather
+than letting a quiet participant walk steadily into the past; the first buffer
+after a run of true digital silence is ramped in over a few milliseconds so the
+resumption does not click; and speech the far end never sent stays missing.
+
+## Talkback (Intercom)
+
+**Newer than v0.1.44.** The Talkback dock is on `main` and ships in the next
+release; it is not in the v0.1.44 installer.
+
+Talkback is private director-to-talent audio carried over Zoom's own talkback
+channels - the operator can talk to one person, or to everyone, without the
+meeting or the program mix hearing it. Open it from **Tools > Zoom Talkback**,
+or as the **Zoom Talkback** dock.
+
+The dock is modelled on a Clear-Com/RTS intercom panel rather than on a list of
+settings: one grid, **All talent** across the top, then one compact cell per
+person. A cell is the talk key and the status display at the same time.
+
+### Assigning channels first
+
+Zoom channels are **created at assignment time, never at key time**. A key press
+only looks its target up in the standing channel set and starts sending, because
+creating a channel on the press costs a create round trip plus an invite round
+trip - measured live as the director's first syllable being discarded on every
+press.
+
+1. Press **Edit talent**. The grid is replaced by a tick-box list of the roster,
+   so exactly one list of people is on screen at a time.
+2. Tick everyone you may need to talk to.
+3. Press **Assign channels (N)**, or **Clear all channels** when nothing is
+   ticked.
+4. Press **Done** and read the plan report.
+
+Zoom allows **16 channels and 10 people per channel**. The plan report says how
+many channels are in use, who has a private channel, who has no private channel
+and must be reached through All talent, and who is on no channel at all and
+therefore hears nothing. Anyone the budget cannot cover is named rather than
+silently dropped.
+
+Assignment is not instant. Zoom rate-limits channel and membership calls -
+undocumented, and refused with `SDKERR_TOO_FREQUENT_CALL` - so CoreVideo paces
+every create and every invite at one call per 600 ms. A large talent list can
+take around twenty seconds to fully provision and confirm. That cost is paid once
+at assignment and never at key time.
+
+Talent are stored **by display name**, never by Zoom user ID: IDs are
+meeting-scoped, so someone who drops and rejoins gets a new one. CoreVideo
+re-resolves membership from the roster with no operator action.
+
+### Keying
+
+- Choose the OBS audio source you talk through in the dock's source combo. No key
+  is pressable until you do. Use a dedicated source with every program track
+  unchecked in Advanced Audio Properties.
+- The line under the combo says whether that source is going out on a program
+  track - `Off program (safe)`, or `On air via track N. The audience will hear
+  this.`
+- Hold a cell to talk. Tick **Latch** to make one press open the key and the next
+  close it. Whether a press closes an open key is decided from the mode it was
+  opened with, so changing Latch mid-key cannot strand it.
+- **Only one key is open at a time, anywhere** - including a key opened by the
+  control API or Companion, which the dock shows but will not close.
+- A short tone confirms open and close, on the engine's confirmed live edge
+  rather than on the button press.
+- The banner at the top is the authority on whether you are audible. It reads
+  `Off air`, `Keying <target>`, `ON AIR: <target>`, `Key refused: <target>`, or
+  `ON AIR - BOT MUTED: <target>`.
+
+### What a cell says
+
+| Cell state | Means |
+|---|---|
+| `ready` | They have a channel and are in it. |
+| `ON AIR` | The key is open and the engine has confirmed it. |
+| `assigning...` | The channel ladder is still provisioning. Keys are refused, never half-honoured. |
+| `no channel` | The budget could not cover them. Assign channels again with fewer people. |
+| `not in channel` | They have a channel but are not in it - most often a different breakout room. |
+| `no talkback` | Their Zoom client reported no talkback support, or nothing reaches them. |
+| `some missed` | On the All talent cell: the plan is short, so this key does not reach everybody. |
+
+### Three delivery rules that are silent in the failure direction
+
+None of these is documented by Zoom. Each was found live, and each fails quietly.
+
+1. **Talkback delivers only while CoreVideo's own meeting audio is open.** Muted,
+   `SendAudioDataToChannel` returns success, members are confirmed, and everyone
+   hears silence. CoreVideo unmutes itself at key time and re-asserts every two
+   seconds in case a host re-mutes it. If Zoom refuses the unmute the key is
+   still allowed - the channels are real and a host can still unmute - but the
+   banner reads **ON AIR - BOT MUTED** and drops the member tally, because "3 of
+   3 present" beside "nobody can hear you" is the instrument that made this
+   invisible in the first place.
+2. **Talkback reaches only the breakout room the engine is in.** A talent in
+   another room shows `not in channel` and hears nothing, no matter how healthy
+   the channel looks.
+3. **Sends are mono.** The SDK accepts stereo and silently delivers nothing, so
+   CoreVideo downmixes at the boundary. Only the sample rates the SDK documents
+   are accepted; anything else is refused loudly rather than resampled.
+
+Channel membership is acoustically neutral until a key is pressed. Zoom appears
+to create channels already ducked, so CoreVideo sets each channel's background
+volume to unity at creation, before any invite, and ducks to 30% only while a key
+is live.
+
+### Talkback over the control API
+
+The dock and the TCP control API are the only keying surfaces today - there are
+no OSC addresses, no Companion actions, and no OBS hotkey for talkback yet.
+
+`talkback_nominate` and `talkback_key` are fire-and-acknowledge: the response
+only confirms the trigger was accepted. The plan outcome arrives asynchronously
+as `"cmd":"talkback_nominate"` lines in the OBS log, and is polled through
+`talkback_status`.
+
+```json
+{"cmd":"talkback_nominate","nominees":["Alex Rivera","Sarah Muller"]}
+```
+
+```json
+{"cmd":"talkback_key","state":"on","target":"Alex Rivera","source":"Director Mic","mode":"push_to_talk"}
+```
+
+```json
+{"cmd":"talkback_key","state":"off"}
+```
+
+`target` is `"all"` or a nominee's display name. `mode` is `push_to_talk`
+(default) or `latch`. A key opened this way must be renewed with
+`{"cmd":"talkback_renew"}` - a surface whose release can be lost in transit has
+to prove it is still there. `{"state":"off"}` always succeeds.
+
+```json
+{"cmd":"talkback_status"}
+```
+
+The reply carries the live key state and a `nomination` object holding the
+**confirmed** plan - who has a private channel, who is uncovered, who is
+unreachable - plus `last_attempt_ok` and `last_attempt_reason`, which describe the
+most recent attempt separately and can disagree with the confirmed plan without
+corrupting it.
+
+`{"cmd":"talkback_probe","participant":"<display name>"}` is a diagnostic, also
+reachable from the collapsed **Diagnostic: talkback probe** section at the bottom
+of the dock. It opens a channel, invites that one participant, sends a
+three-second 440 Hz tone **that they will hear**, ducks their meeting audio for
+its duration, and destroys the channel. It requires host or co-host; a plain
+participant is refused with `SDKERR_NO_PERMISSION`.
+
+## Companion / Stream Deck
+
+`companion/companion-module-corevideo-obs` is a Bitfocus Companion module
+speaking the same TCP control API. It requires **Companion v5 or later** -
+earlier builds cap the module API at 1.12 and cannot load it at all.
+
+Actions are `zoom_join`, `zoom_leave`, `zoom_assign`, `zoom_assign_spotlight`,
+`zoom_assign_screen_share`, and `zoom_cancel_recovery`. Both the output and the
+participant are dropdowns on `zoom_assign`, populated from the module's own live
+state, and the same output picker is on the spotlight and screen-share actions.
+Participants are offered and stored **by name**,
+because Zoom user IDs are meeting-scoped: a button holding a raw ID points at
+nobody after a rejoin, and at the wrong face once IDs are recycled. The ID is
+resolved from the name against the live roster at press time; a name not in the
+meeting resolves to nobody and logs a warning rather than guessing. Raw numeric
+IDs still work, and buttons built before this change still work through the
+legacy `participant_id` option.
+
+There are no Companion actions for talkback yet.
 
 ## Auto ISO Recording
 
@@ -395,6 +649,30 @@ Output files are written as:
 - `*.mp4` for encoded I420 video through FFmpeg using the selected H.264
   encoder
 - `*.wav` for matching PCM audio
+- `*.ffmpeg.log` beside them, holding FFmpeg's own account of the session. Read
+  this first when a file is missing or truncated.
+
+### Timing
+
+Both files are paced to real elapsed time against the same clock, so each is
+individually accurate and the two stay in sync with each other.
+
+That is not free, and it is worth knowing why. Raw video carries no per-frame
+timestamps, and Zoom's per-source delivery fluctuates between roughly 10 and
+60 fps with conditions outside CoreVideo's control - so frames are paced to a
+fixed cadence before they reach FFmpeg, duplicating the held frame to backfill a
+stall and dropping excess from a burst. Audio has the mirror-image problem for a
+different reason: Zoom only calls audio back for someone currently making sound,
+so silence is backfilled across every gap or the WAV shrinks by the total silent
+duration. Both were wrong before v0.1.42/v0.1.43 - a source averaging 15 fps
+recorded under a declared 30 fps finished in about half the real duration, and an
+over-eager first gap-fill briefly doubled every WAV. If you see either symptom,
+check your version first.
+
+The hardware encoder fallback chain is NVENC -> QSV -> AMF -> libx264, and it
+walks the whole chain: a source demoted off NVENC on a machine with no working
+QSV or AMF runtime now reaches libx264, the tier with no hardware dependency to
+fail on.
 
 When `record_program` is true, CoreVideo also starts the normal OBS program
 recording and stops it when ISO recording stops, but only if CoreVideo started
@@ -443,13 +721,13 @@ Quality retries are skipped when a feed is already observed at 1080p.
 Assign a source to a fixed participant with isolated mono audio:
 
 ```json
-{"cmd":"assign_output_ex","source":"Zoom Participant 1","mode":"participant","participant_id":123456,"isolate_audio":true,"audio_channels":"mono","video_resolution":"1080p"}
+{"cmd":"assign_output_ex","source":"CoreVideo Participant 1","mode":"participant","participant_id":123456,"isolate_audio":true,"audio_channels":"mono","video_resolution":"1080p"}
 ```
 
 Assign a source to active speaker:
 
 ```json
-{"cmd":"assign_output_ex","source":"Zoom Participant 2","mode":"active_speaker","audio_channels":"mono","video_resolution":"1080p"}
+{"cmd":"assign_output_ex","source":"CoreVideo Participant 2","mode":"active_speaker","audio_channels":"mono","video_resolution":"1080p"}
 ```
 
 Inspect and control the Active Speaker Director:
@@ -473,7 +751,7 @@ Inspect and control the Active Speaker Director:
 Assign a source to spotlight slot 1:
 
 ```json
-{"cmd":"assign_output_ex","source":"Zoom Participant 3","mode":"spotlight","spotlight_slot":1,"audio_channels":"mono","video_resolution":"1080p"}
+{"cmd":"assign_output_ex","source":"CoreVideo Participant 3","mode":"spotlight","spotlight_slot":1,"audio_channels":"mono","video_resolution":"1080p"}
 ```
 
 ## OSC Control Examples
@@ -528,19 +806,19 @@ hold remaining, two exclusion IDs, and status text such as `holding`,
 Assign a source:
 
 ```text
-/zoom/output/assign_ex "Zoom Participant 1" "participant" 123456 1
+/zoom/output/assign_ex "CoreVideo Participant 1" "participant" 123456 1
 ```
 
 Assign active speaker:
 
 ```text
-/zoom/assign_output/active_speaker "Zoom Participant 1"
+/zoom/assign_output/active_speaker "CoreVideo Participant 1"
 ```
 
 Set isolated audio:
 
 ```text
-/zoom/isolate_audio "Zoom Participant 1" 1
+/zoom/isolate_audio "CoreVideo Participant 1" 1
 ```
 
 Start and stop ISO recording:
@@ -557,6 +835,13 @@ Start and stop ISO recording:
 |---|---|
 | Color bars only | Confirm the meeting is joined, raw media is started, and the source has a participant/role assignment. |
 | No isolated audio | Confirm the source is assigned to a real participant and `isolate_audio` is true. |
-| ISO recording does not start | Confirm `ffmpeg` is on PATH or provide `ffmpeg_path`. |
+| ISO recording does not start | Confirm `ffmpeg` is on PATH or provide `ffmpeg_path`; read the session's `.ffmpeg.log`. |
 | External meeting rejected | Confirm the Meeting SDK app/client ID is approved or published for external meeting joins. |
-| Plugin cannot launch engine | Confirm `ZoomObsEngine.exe` and Zoom SDK runtime DLLs are installed under `obs-plugins/64bit/zoom-runtime`. |
+| Plugin cannot launch engine | Confirm `ZoomObsEngine.exe` and the Zoom SDK runtime DLLs are installed under `obs-plugins/64bit/zoom-runtime`. The plugin looks there first, then beside its own DLL. A DLL-only copy is the most common self-inflicted failure - install both binaries as a pair. |
+| Every source black after a breakout room | Zoom revokes the raw-recording privilege on breakout entry without disconnecting you. Re-requested automatically since v0.1.40; on older builds, stop and start raw media. |
+| Audio breaks up on every source at once | Look for an orphaned `ZoomObsEngine.exe` from a previous OBS session ghost-writing the same shared memory. Swept automatically at launch since v0.1.41. |
+| Talkback key says live but nobody hears | Read the banner. **ON AIR - BOT MUTED** means Zoom refused the unmute; a cell reading `not in channel` usually means a different breakout room. |
+| Join sits on "joining" forever | Either a waiting room (normal - CoreVideo waits) or your own account already hosting elsewhere, which now fails loudly with `account_busy_elsewhere` / `909001`. |
+
+Full troubleshooting, log collection, and the support-bundle walkthrough are on
+the [Support page](https://corevideo.io/support/).

--- a/docs/OPERATOR_QUICKSTART.md
+++ b/docs/OPERATOR_QUICKSTART.md
@@ -14,6 +14,9 @@ source-build and Marketplace setup details unless they affect day-to-day use.
    - **Zoom Output Manager**
    - **Zoom Diagnostics**
    - **Zoom ISO Recorder**
+   - **Zoom Talkback**
+
+Each has a matching entry under **Tools**, alongside **Zoom Plugin Settings**.
 
 Published installers include the OBS plugin, `ZoomObsEngine`, Zoom SDK runtime,
 Qt runtime, TLS plugins, OAuth callback helper, and locale files. End users do
@@ -21,22 +24,29 @@ not need to download the Zoom SDK or enter Zoom app credentials.
 
 ## Sign In
 
-1. Open **Zoom Control**.
-2. Click **Sign in with Zoom**.
+1. Open **Tools > Zoom Plugin Settings**.
+2. Click **Sign in with Zoom**. This button is in the settings dialog, not on the
+   Zoom Control dock.
 3. Approve CoreVideo in the browser.
-4. Return to OBS and confirm the status shows connected.
+4. Return to OBS and confirm the dialog's status line shows you are signed in.
+   **Sign out** is beside it if you ever need to start a fresh flow.
 
 CoreVideo uses the published app's Public Client OAuth and Meeting SDK public
 app key. There should be no prompt for a client secret in a production build.
 
 ## Join A Meeting
 
-1. Enter the meeting ID.
+1. Enter the meeting ID, or paste a full Zoom join URL.
 2. Enter the passcode if needed.
 3. Choose the join display name.
-4. Click **Join**.
-5. Use the visible Zoom Meeting SDK window for waiting room admit, self audio,
-   self video, and normal in-meeting controls.
+4. Leave the join-token dropdown on **Zoom sign-in** unless Zoom support has
+   given you a ZAK or an app privilege token to paste.
+5. Tick **Join as Webinar / Zoom Events** for a webinar.
+6. Click **Join**, then **Start Engine** once you are in.
+7. Use the visible Zoom Meeting SDK window for waiting room admit, self audio,
+   self video, and normal in-meeting controls. Joining early and waiting to be
+   admitted is fine - CoreVideo holds its join window open for the length of a
+   legitimate waiting-room wait rather than giving up on it.
 
 If join fails, open **Zoom Diagnostics** and export a support bundle before
 changing settings. The bundle redacts tokens and includes OBS/engine/ISO status.
@@ -100,6 +110,46 @@ that follows the current directed speaker.
 
 The director is CoreVideo's own speaker-follow logic. It is not the same thing
 as Zoom's active-speaker video feed.
+
+## Audio
+
+Route the dedicated **CoreVideo Participant Audio** and **CoreVideo Active
+Speaker Audio** sources to program rather than relying on a video source's own
+embedded audio track. The dedicated path drains the engine's ring in order,
+stamps from a master clock, and counts what it loses; the embedded track reads
+only the newest buffer and accounts for nothing.
+
+Audio arrives ahead of picture, so trim it back - **Tools > Zoom Plugin Settings
+> Audio > Audio delay (dedicated sources)** for the dedicated sources, and the
+Output Manager's per-row **Delay (embedded)** for one video source's own track,
+against the **A/V Offset (embedded)** column beside it. Trim off air: lowering a
+delay pushes the timestamp backward once and glitches that source.
+
+## Talkback
+
+**Newer than v0.1.44 - on `main`, not in the v0.1.44 installer.**
+
+Open **Zoom Talkback** to talk privately to talent over Zoom's own talkback
+channels.
+
+1. Choose the OBS audio source you talk through in the dock's source combo. Use
+   a dedicated source with every program track unchecked in Advanced Audio
+   Properties, and read the line under the combo - it tells you whether the
+   audience would hear it.
+2. Press **Edit talent**, tick everyone you may need to talk to, press **Assign
+   channels**, then **Done**. Channels are created now so a key press has only to
+   open the microphone. Zoom rate-limits this, so a large list can take around
+   twenty seconds. Do it before the show, not during it.
+3. Read the plan report. Zoom allows 16 channels and 10 people per channel;
+   anyone the budget could not cover is named.
+4. Hold a cell to talk, or tick **Latch** for press-on/press-off. **All talent**
+   is the full-width cell on top.
+5. Trust the banner, not the button. `ON AIR` means the engine confirmed it;
+   `ON AIR - BOT MUTED` means Zoom will not let CoreVideo unmute and nobody hears
+   you - ask the host to unmute CoreVideo.
+
+Talkback reaches only the breakout room the engine is in. A cell reading `not in
+channel` usually means the talent is in a different room.
 
 ## ISO Recording
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,30 +1,71 @@
 # CoreVideo Wiki
 
-Welcome to the CoreVideo wiki - an OBS Studio plugin for live Zoom meeting video, audio, screen share, and Zoom interpretation audio channel capture.
+CoreVideo is an OBS Studio plugin that pulls Zoom meeting video, audio, screen
+share, and Zoom interpretation audio into OBS as native sources - no NDI, no
+virtual camera, no screen capture of a Zoom window. Latest release: **v0.1.44**
+(2026-08-22).
 
-**[Full Documentation & Architecture Diagrams](https://corevideo.io/documentation/)**
+This wiki holds the policy and support pages. Everything operational - install,
+configuration, architecture, the control APIs - lives on the documentation site,
+which is generated from the same repository and is always the more current of
+the two.
 
-**[Core Plugin Guide & Examples](https://corevideo.io/core-plugin/)**
+| | |
+|---|---|
+| **Full documentation** | https://corevideo.io/documentation/ |
+| **Plugin guide** (sources, assignment, talkback, ISO recording, control APIs) | https://corevideo.io/core-plugin/ |
+| **Downloads** | https://corevideo.io/download/ |
 
 ---
 
-## Pages
+## Pages here
 
+- [Support](Support) - troubleshooting, log collection, how to file a useful bug
 - [Privacy Policy](Privacy-Policy)
 - [Terms of Use](Terms-of-Use)
-- [Support](Support)
 
 ---
 
-## Quick Links
+## Where things are
 
 | Resource | Link |
 |---|---|
-| Documentation site | https://corevideo.io/documentation/ |
-| Core plugin guide | https://corevideo.io/core-plugin/ |
-| OAuth / Marketplace setup | https://corevideo.io/oauth/ |
-| Latest Windows release | https://github.com/iamfatness/CoreVideo/releases/latest |
-| macOS beta (Apple Silicon) + install guide | https://corevideo.io/documentation/#mac-beta |
+| Latest release (Windows installer + ZIP) | https://github.com/iamfatness/CoreVideo/releases/latest |
+| Changelog | https://github.com/iamfatness/CoreVideo/blob/main/CHANGELOG.md |
 | Source code | https://github.com/iamfatness/CoreVideo |
-| Issues & bug reports | https://github.com/iamfatness/CoreVideo/issues |
-| Releases | https://github.com/iamfatness/CoreVideo/releases |
+| Issues and bug reports | https://github.com/iamfatness/CoreVideo/issues |
+| Security disclosure | https://github.com/iamfatness/CoreVideo/blob/main/SECURITY.md |
+| Roadmap | https://github.com/iamfatness/CoreVideo/blob/main/docs/ROADMAP.md |
+| Zoom OAuth / Marketplace setup | https://corevideo.io/documentation/#flow-oauth |
+| Bitfocus Companion module | https://github.com/iamfatness/CoreVideo/tree/main/companion |
+
+---
+
+## Platform status
+
+**Windows 10/11 x64 is the only supported, packaged platform.** It is the only
+configuration with a release pipeline, and the only one the maintainers build,
+test, and run in production.
+
+The CMake project configures on macOS, Linux, and Windows arm64, and CI compiles
+the cross-platform sources on macOS and Linux to catch portability regressions -
+but none of those produce an installable build. The one macOS bundle ever
+published was `v0.1.32-beta.1`, which is many releases behind and should not be
+used for a show. See
+[Platform Support](https://github.com/iamfatness/CoreVideo/blob/main/README.md#platform-support)
+for what a source build on those platforms does and does not get you.
+
+CoreVideo is in public beta and the installer is not code-signed yet, so Windows
+SmartScreen flags it on first run.
+
+---
+
+## Getting help
+
+Start with [Support](Support). It covers where the logs are, how to produce a
+redacted support bundle from the **Zoom Diagnostics** dock, and the failures
+that come up most often. A bug report with a support bundle attached is worth
+several without one.
+
+CoreVideo is an independent MIT-licensed project and is not affiliated with,
+endorsed by, or supported by Zoom Video Communications, Inc.

--- a/wiki/Privacy-Policy.md
+++ b/wiki/Privacy-Policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-_Last updated: May 2026_
+_Last updated: September 2026_
 
 ## Overview
 
@@ -26,6 +26,37 @@ CoreVideo receives participant metadata from the Zoom SDK (display names, user I
 - Displayed within OBS for source assignment purposes
 - Not transmitted outside the local machine by CoreVideo
 
+### Talkback (Intercom) Audio
+
+CoreVideo's talkback feature is the one path where audio travels **outward**. When
+the operator holds or latches a talkback key, CoreVideo reads the OBS audio source
+the operator selected and sends it to Zoom over the Zoom Meeting SDK's own
+talkback channels, so that the selected participants hear it. This audio goes to
+Zoom and to no one else; it is not sent to any CoreVideo server or third party,
+and CoreVideo does not record it.
+
+Two properties are worth stating plainly because they are not obvious:
+
+- Talkback requires CoreVideo's own meeting microphone to be unmuted, so
+  CoreVideo unmutes itself for the duration of a key and restores the previous
+  state on release if it was the one that opened it.
+- The talkback diagnostic probe sends an audible three-second test tone to the
+  selected participant and briefly lowers their meeting audio. Only run it on
+  someone who is expecting it.
+
+### Recordings You Make
+
+CoreVideo's ISO recorder writes MP4 video and WAV audio files, plus an FFmpeg log
+per session, to a folder the operator chooses. Diagnostic support bundles are
+written to the OBS plugin configuration directory. All of these stay on the
+operator's machine; CoreVideo never uploads them. A support bundle redacts
+credentials but does contain meeting and participant display names, participant
+IDs, and recording file paths - review one before sharing it.
+
+The Zoom Meeting SDK is initialised with its own logging and crash dumps enabled,
+which it writes locally under its own control. CoreVideo does not set or override
+that location and does not collect those files.
+
 ### Credentials and Tokens
 
 Published CoreVideo builds use Zoom Public Client OAuth + PKCE through the CoreVideo broker. End users do not enter Zoom app client secrets.
@@ -34,10 +65,12 @@ The following local settings may be saved by the plugin:
 
 | Credential / setting | Storage location | Purpose |
 |---|---|---|
-| Zoom OAuth access/refresh tokens | OBS plugin config directory | Zoom sign-in, token refresh, and ZAK requests |
-| Control server token | OBS plugin config directory | Authenticating TCP/OSC API clients |
-| Control server ports | OBS plugin config directory | TCP JSON and UDP OSC port configuration |
+| Zoom OAuth access/refresh tokens | OBS global configuration, `[ZoomPlugin]` section | Zoom sign-in, token refresh, and ZAK requests |
+| Control server token | OBS global configuration, `[ZoomPlugin]` section | Authenticating TCP API clients |
+| Control server ports | OBS global configuration, `[ZoomPlugin]` section | TCP JSON and UDP OSC port configuration |
+| Talkback preferences | OBS global configuration, `[ZoomPlugin]` section | The chosen talkback audio source name and latch setting |
 | Output profiles | OBS plugin config directory | Optional participant-to-source mappings |
+| Support bundles | OBS plugin config directory | Local troubleshooting exports, written only when the operator asks |
 
 On Windows, OAuth tokens are DPAPI-protected before storage. Meeting SDK client secrets are not stored in the plugin or broker for the public-client production path.
 
@@ -56,6 +89,19 @@ CoreVideo uses the **Zoom Meeting SDK** to join and capture meeting content. Whe
 
 The broker at `corevideo.iamfatness.us` is used only for Zoom OAuth token exchange and refresh. It does not receive or process meeting audio, video, screen share, or participant media.
 
+### GitHub (Update Check)
+
+Once per OBS session, CoreVideo makes a single anonymous HTTPS GET request to the
+public GitHub Releases API
+(`api.github.com/repos/iamfatness/CoreVideo/releases/latest`) to see whether a
+newer release is available. The request carries no meeting data, credentials,
+telemetry, or CoreVideo-specific identifiers - only what GitHub already logs for
+any anonymous HTTP request, such as an IP address, governed by GitHub's own
+privacy statement. The check never blocks startup, never downloads or installs
+anything, and fails silently when offline. It can be turned off in **Tools ->
+Zoom Plugin Settings -> Check for updates on startup**, which is enabled by
+default.
+
 ### Cloudflare and GitHub (Documentation)
 
 The documentation site at `corevideo.io` is served through Cloudflare and sourced from the public CoreVideo GitHub repository. Cloudflare's and GitHub's privacy policies apply to visits to that site:
@@ -67,7 +113,8 @@ The documentation site at `corevideo.io` is served through Cloudflare and source
 
 ## Data Retention
 
-- **No meeting media is retained by CoreVideo** beyond the local OBS session unless the operator records or streams through OBS.
+- **No meeting media is retained by CoreVideo** beyond the local OBS session unless the operator records or streams through OBS, or uses CoreVideo's own ISO recorder.
+- ISO recordings, their FFmpeg logs, and support bundles persist on disk until the operator deletes them. CoreVideo never removes them and never uploads them.
 - OAuth tokens persist until the user signs out, revokes access, or removes the plugin configuration.
 - Credentials saved in the OBS config directory persist until deleted via the Settings dialog or plugin removal.
 - OBS itself may retain scenes, sources, and recordings per its own configuration - outside the scope of this policy.

--- a/wiki/Support.md
+++ b/wiki/Support.md
@@ -1,138 +1,455 @@
 # Support
 
+Current release: **v0.1.44**. Windows 10/11 x64 is the only supported, packaged
+platform - see [Platform Support](https://github.com/iamfatness/CoreVideo/blob/main/README.md#platform-support)
+before filing a bug against a source build on anything else.
+
 ## Documentation
 
-Before opening an issue, check the full documentation site - most configuration questions and architecture details are covered there:
+Most configuration and architecture questions are answered on the documentation
+site:
 
 **[https://corevideo.io/documentation/](https://corevideo.io/documentation/)**
 
 | Topic | Link |
 |---|---|
-| Installation & build | [Installation](https://corevideo.io/documentation/#installation) |
-| Configuration | [Configuration](https://corevideo.io/documentation/#configuration) |
-| Zoom Control Dock | [Zoom Control Dock](https://corevideo.io/documentation/#zoom-dock) |
-| Assignment modes (Spotlight, Active Speaker, Screen Share) | [Assignment Modes](https://corevideo.io/documentation/#assignment-modes) |
-| Active speaker debounce | [Active Speaker Mode](https://corevideo.io/documentation/#active-speaker) |
+| Adding the plugin to OBS | [Adding the App](https://corevideo.io/documentation/#adding) |
+| Requirements | [Requirements](https://corevideo.io/documentation/#requirements) |
+| Configuration reference | [Configuration](https://corevideo.io/documentation/#configuration) |
+| Zoom Control dock | [Zoom Control Dock](https://corevideo.io/documentation/#zoom-dock) |
+| Assignment modes (participant, active speaker, spotlight, screen share) | [Assignment Modes](https://corevideo.io/documentation/#assignment-modes) |
+| Active Speaker Director | [Active Speaker Mode](https://corevideo.io/documentation/#active-speaker) |
 | Auto-reconnect | [Auto-Reconnect](https://corevideo.io/documentation/#auto-reconnect) |
 | Hardware video acceleration | [Hardware Video Acceleration](https://corevideo.io/documentation/#hw-accel) |
+| ISO recording | [Auto ISO Recording](https://corevideo.io/documentation/#iso-recording) |
 | TCP control API | [TCP Control API](https://corevideo.io/documentation/#control-api) |
 | OSC control API | [OSC Control API](https://corevideo.io/documentation/#osc-api) |
-| IPC protocol reference | [IPC Protocol](https://corevideo.io/documentation/#ipc-protocol) |
+| Sources, talkback, audio routing | [Plugin guide](https://corevideo.io/core-plugin/) |
+
+---
+
+## What things are called
+
+CoreVideo's OBS **sources** are named `CoreVideo ...`, but its **docks and Tools
+menu entries** are still named `Zoom ...`. Both belong to this plugin. Searching
+the Tools menu for "CoreVideo" finds nothing.
+
+| Docks (View -> Docks, and Tools) | Sources (Sources -> Add) |
+|---|---|
+| Zoom Control | CoreVideo Participant |
+| Zoom Output Manager | CoreVideo Active Speaker |
+| Zoom Diagnostics | CoreVideo Screen Share |
+| Zoom ISO Recorder | CoreVideo Tiles |
+| Zoom Talkback | CoreVideo Participant Audio |
+| (Tools only) Zoom Plugin Settings | CoreVideo Active Speaker Audio |
+| | CoreVideo Audience Audio (legacy) |
+| | Zoom Interpretation Audio |
+
+---
+
+## Collecting logs
+
+### The support bundle - do this first
+
+Open the **Zoom Diagnostics** dock (or **Tools -> Zoom Diagnostics**) and click
+**Create Support Bundle**. This is the single most useful thing you can attach
+to a bug report, and it is what the GitHub issue template asks for.
+
+The bundle is written to:
+
+```
+%APPDATA%\obs-studio\plugin_config\obs-zoom-plugin\support-bundles\CoreVideo-support-<yyyyMMdd-HHmmss>\
+```
+
+On Windows a `.zip` of that folder is created beside it, using PowerShell. The
+dialog tells you both paths when it finishes. If PowerShell is unavailable, or
+you are not on Windows, only the folder is written and you zip it yourself.
+
+It contains `summary.json`, `summary.txt`, `engine-status.json`,
+`settings-redacted.json`, `runtime-manifest.json`, `iso-recorder.json`, and
+`obs-latest.log` - a redacted excerpt of the last 500 lines of the newest OBS
+log. Inside are the plugin version, meeting and engine state, the per-output
+table (assignment, requested/negotiated/observed resolution, fps, health), the
+participant roster, the last engine debug events, ISO recorder status, a
+manifest of the runtime files that are supposed to be installed, and a
+machine-readable `failure_classifications` list - values such as
+`missing_runtime`, `auth_not_ready`, `no_video_frames`, `stale_feed`,
+`low_quality_feed`, `iso_encoder_error`.
+
+**What is redacted:** OAuth access and refresh tokens, ZAK/JWT values, client
+secrets, passcodes, the control-server token, and `Authorization:` headers, in
+the JSON and in the log excerpt. Secrets are reduced to a length and their last
+four characters, or to a presence flag.
+
+**What is not redacted:** meeting and participant display names, participant
+IDs, and ISO recording file paths. Look through the bundle before attaching it
+to a public issue if any of that is sensitive.
+
+### The OBS log
+
+CoreVideo has no log file of its own. Everything - plugin and engine alike -
+goes into the OBS log, prefixed `[obs-zoom-plugin]`. Engine lines arrive as
+`[obs-zoom-plugin] Zoom engine debug: ...`.
+
+In OBS: **Help -> Log Files -> Upload Current Log File**, then paste the link.
+The files themselves are under `%APPDATA%\obs-studio\logs`.
+
+The version is logged once at load, so check that first - a stale DLL is a
+common cause of "the fix didn't work":
+
+```
+[obs-zoom-plugin] Loading plugin v0.1.44
+```
+
+### Verbose engine logging
+
+High-frequency engine events (per-frame and per-buffer stages) are suppressed by
+default - they were producing a 27 MB log in a 90-minute meeting. To turn them
+on, set the environment variable `CV_ZOOM_VERBOSE_LOG` to any value other than
+`0` before starting OBS:
+
+```
+set CV_ZOOM_VERBOSE_LOG=1
+"C:\Program Files\obs-studio\bin\64bit\obs64.exe"
+```
+
+Expect a very large log. Turn it off again afterwards. Note these events are
+captured in the diagnostics ring buffer - and so in the support bundle - even
+when they are not in the OBS log, so try the support bundle before resorting to
+this.
+
+### ISO recording
+
+Each ISO session writes an `<recording>.ffmpeg.log` sidecar next to its output
+files. If an ISO file is missing or truncated, that log holds FFmpeg's own
+account of why.
 
 ---
 
 ## Reporting Bugs
 
 Open an issue at **[github.com/iamfatness/CoreVideo/issues](https://github.com/iamfatness/CoreVideo/issues)**.
+The bug report template walks through the same list:
 
-Please include:
-
-- **CoreVideo version** (shown in OBS log: `[obs-zoom-plugin] Loading plugin v...`)
+- **CoreVideo version** - the `[obs-zoom-plugin] Loading plugin v...` line
 - **OBS Studio version**
-- **Operating system** (Windows 10/11, macOS version, Linux distro)
-- **Zoom Meeting SDK version** (5.17.x or 7.x)
-- **Steps to reproduce** the issue
-- **OBS log file** - in OBS go to Help -> Log Files -> Upload Current Log File and paste the link
-- **Expected vs. actual behavior**
+- **Windows version**
+- **A support bundle** from the Zoom Diagnostics dock
+- **Steps to reproduce**, and expected versus actual behaviour
+- Whether the meeting used **breakout rooms**, a **waiting room**, or was joined
+  as a **Webinar / Zoom Events** session - each has its own failure modes
+
+For security vulnerabilities, **do not open a public issue**. See
+[SECURITY.md](https://github.com/iamfatness/CoreVideo/blob/main/SECURITY.md).
 
 ---
 
 ## Common Issues
 
-### Raw-data permission or stream-count error at runtime
+### Everything worked yesterday and now audio breaks up, or the engine will not start
 
-**Cause:** Raw data access is available through Zoom Meeting SDK apps, but the signed-in account and app entitlements still determine negotiated quality, bandwidth, and stream count. Standard accounts are typically limited to a 30 Mbps incoming video budget; Enhanced Media / HBM can raise that envelope to roughly 100 Mbps. Developers may also need an app-level entitlement flag to test more than a small number of concurrent raw streams.
+**Cause:** an orphaned `ZoomObsEngine.exe` from a previous OBS session. If OBS
+exited while the Zoom SDK was wedged, the engine can survive as an orphan -
+still in the meeting, still writing into shared memory under the names the next
+session wants to use. The new session then shares its audio transport with a
+ghost writer, which suppresses its audio wakeups (audio breaks up on every
+source), corrupts video regions, and holds the SDK singleton so the first engine
+start of the day fails.
 
-**Fix:** Verify the Meeting SDK app is approved or beta-enabled for the account joining the meeting, then confirm the expected bandwidth and developer/app entitlements with Zoom. Treat Enhanced Media / HBM as a production quality and bandwidth tier, not as a hard prerequisite for raw data.
+**Fix:** since v0.1.41 every engine start sweeps stale engine processes first and
+logs what it removed, so this should not happen. If it does, the plugin reports
+a shared-memory name collision as a visible error naming the cure: close OBS, end
+any `ZoomObsEngine.exe` in Task Manager, and start again.
+
+---
+
+### The plugin cannot launch or reach the engine
+
+**Cause:** a partial install. CoreVideo is two binaries and they must match -
+`obs-zoom-plugin.dll` **and** `zoom-runtime\ZoomObsEngine.exe`. Copying only the
+DLL is the most common self-inflicted failure with this plugin; roughly half the
+fixes in any release are engine-side.
+
+**Fix:**
+1. Reinstall from the official installer rather than copying files.
+2. Confirm the layout under your OBS install:
+   - `obs-plugins\64bit\obs-zoom-plugin.dll`
+   - `obs-plugins\64bit\zoom-runtime\ZoomObsEngine.exe`
+   - `obs-plugins\64bit\zoom-runtime\sdk.dll` and the rest of the Zoom SDK runtime
+   - `obs-plugins\64bit\plugins\platforms\qwindows.dll`
+   - `obs-plugins\64bit\plugins\tls\qschannelbackend.dll`
+3. The support bundle's `runtime-manifest.json` checks exactly these files and
+   says which are missing - it is faster than checking by hand.
+4. If you are upgrading from a build older than v0.1.30, delete any loose FFmpeg
+   DLLs left in `obs-plugins\64bit` by the old layout. The plugin logs a warning
+   naming them.
+
+---
+
+### The join sits on "joining" and never finishes
+
+**Two known causes, and they look identical from the dock.**
+
+**A waiting room.** This is normal and CoreVideo now waits it out - as of
+v0.1.44 the two-minute join watchdog holds its window open for as long as a
+legitimate waiting-room or waiting-for-host state lasts, rather than counting it
+as no progress and leaving. Before v0.1.44 a host who took longer than two
+minutes to admit got an auto-leave and a Failed attempt; if you are on an older
+build, upgrade.
+
+**Your own Zoom account is already hosting a meeting somewhere else.** Joining
+with a ZAK for an account that is hosting elsewhere - your own client in your
+own PMI, which is the ordinary way anyone tests - does not fail the join. The
+SDK silently asks whether to end the other meeting, and if nobody answers,
+`Join()` never resolves and no failure is ever reported. CoreVideo now answers
+"no" (it will never end your live show to join a meeting) and fails the join
+loudly instead, with reason `account_busy_elsewhere` and code `909001`. If you
+see that, leave the other meeting or use a different account.
+
+Note the join watchdog is armed by the dock's **Join** button only. A join
+issued through the TCP or OSC control API is not watched.
 
 ---
 
 ### OAuth sign-in or join authentication fails
 
-**Cause:** The local plugin, published broker, or Zoom Marketplace app environment is out of sync.
-
 **Fix:**
-1. Sign out and sign back in from **Tools -> Zoom Plugin Settings**.
-2. Confirm the published broker page is available at `https://corevideo.iamfatness.us/oauth/start`.
-3. Confirm the Zoom Marketplace app has Public Client OAuth enabled, the redirect URL is `https://corevideo.iamfatness.us/oauth/callback`, and Meeting SDK / Embed is enabled for the same environment.
-4. Check the OBS log for `[obs-zoom-plugin]` OAuth, ZAK, or Meeting SDK auth errors.
+1. Sign out and sign back in from **Tools -> Zoom Plugin Settings** - the
+   **Sign in with Zoom** and **Sign out** buttons are there, not on the Zoom
+   Control dock.
+2. Leave the join-token dropdown on the Zoom Control dock set to **Zoom
+   sign-in**. `User ZAK` and `App privilege token` are for tokens Zoom support
+   has given you specifically; a stale value there will fail every join.
+3. Confirm the broker page loads: `https://corevideo.iamfatness.us/oauth/start`.
+   That is the host compiled into published builds; the site itself is
+   corevideo.io, and both names route to the same worker.
+4. Check the OBS log for `[obs-zoom-plugin]` OAuth, ZAK, or Meeting SDK auth
+   errors.
+
+If you run your own Marketplace app rather than the published one, it needs
+Public Client OAuth with PKCE, Meeting SDK / Embed enabled in the same
+environment, and `/oauth/callback` on your broker host registered as the
+redirect URL. See
+[OAuth PKCE](https://corevideo.io/documentation/#flow-oauth).
 
 ---
 
-### Engine fails to start / IPC connection timeout
+### Every video source goes black after a breakout room
 
-**Cause:** `ZoomObsEngine` could not be launched or located.
+**Cause:** moving into or out of a breakout room does not disconnect you, so the
+engine believed raw recording was still running - while Zoom had quietly revoked
+the permission. Every source then failed to subscribe with
+`SDKERR_NO_PERMISSION` and stayed black.
 
-**Fix:**
-1. Confirm `ZoomObsEngine` (`.exe` on Windows) is in the same directory as the plugin.
-2. On macOS, remove quarantine: `xattr -d com.apple.quarantine ZoomObsEngine`
-3. On Linux, ensure execute permission: `chmod +x ZoomObsEngine`
-4. Check the OBS log for `[obs-zoom-plugin]` launch failure messages.
+**Fix:** fixed in v0.1.40 - re-entry now re-requests the recording privilege the
+same way the initial join does. On an older build, stop and start raw media from
+the Zoom Control dock. Note also that talkback reaches only the breakout room
+the engine is in.
 
 ---
 
 ### Blank / black video from a participant
 
-**Cause:** Participant camera is off, or the subscription was dropped.
+**Cause:** the participant's camera is off, or the subscription was dropped.
 
 **Fix:**
-1. Confirm the participant has their camera enabled in Zoom.
-2. Set **On video loss** -> **Hold last frame** in source properties to avoid going black on brief drops.
-3. Click **Refresh** in the participant list and re-subscribe.
+1. Confirm the participant has their camera enabled in Zoom. Someone with their
+   camera off cannot be routed to an output or a tile at all - the Output
+   Manager's **Hide participants without video** toggle filters them out of the
+   pickers, and never hides a participant who is already assigned.
+2. Set **On video loss** to **Hold last frame** in the source's properties so a
+   brief drop does not go black.
+3. Click **Refresh participant list** in the source's properties and re-select
+   the participant.
+4. Check the Zoom Diagnostics dock for requested versus observed resolution,
+   frame age, and stale/quality retry counters. That is the fastest way to tell
+   "waiting for a first frame" from "receiving a lower feed than requested"
+   from "being resubscribed by recovery".
 
 ---
 
-### No audio from a participant
+### No audio, or audio that breaks up
 
-**Cause:** Incorrect audio mode or participant is muted.
+**First, know which of the two audio paths you are on** - they have different
+guarantees and no code connects them.
+
+- The **dedicated** path is the audio-only sources: **CoreVideo Participant
+  Audio**, **CoreVideo Active Speaker Audio**. These drain an 8-slot ring, stamp
+  timestamps from a master clock derived from the sample count, count what they
+  lose, and honour the audio delay trim. **Route these to program for anything
+  that matters.**
+- The **embedded** path is the audio track published alongside a CoreVideo video
+  source's picture. It reads only the newest buffer, is stamped at arrival, and
+  has no loss accounting.
 
 **Fix:**
-1. Set **Audio Channels** to **Mono** or **Stereo** (not None) in source properties.
-2. Confirm the participant is unmuted in Zoom.
-3. If using **Isolate Audio**, confirm the correct participant ID is selected.
-4. Check the OBS audio mixer - the track may be muted or set to Monitor Only.
+1. For a video source, set **Audio Channels** to **Mono** or **Stereo** (not
+   None) in source properties, and confirm the participant is unmuted in Zoom.
+2. Check the OBS audio mixer - the track may be muted or monitoring-only.
+3. If you are using **Isolate selected participant's audio**, confirm the right
+   participant is selected.
+4. Gaps are often Zoom, not CoreVideo: Zoom only calls audio back for a
+   participant who is currently making sound. A silent stretch produces no
+   buffers at all. CoreVideo fills the gap and ramps in the resumption so it does
+   not click, but it cannot invent speech that was never sent.
+5. Continuous break-up on every source at once points at the ghost-engine case
+   above, or at the machine not keeping up - `list_audio_sources` over the TCP
+   API reports `overrun_slots` per source, which should stay at `0`, and
+   `audio_latency_us`, which should be sub-millisecond.
+
+---
+
+### Audio is ahead of the picture
+
+Video is the slower path in any software production chain, so audio arrives
+early and needs delaying to line back up. There is one control per audio path:
+
+- **Tools -> Zoom Plugin Settings -> Audio -> Audio delay (dedicated sources)** -
+  a single global trim, 0-500 ms, for every dedicated CoreVideo Audio source. It
+  takes effect on the next buffer, including on sources already running.
+- The Output Manager's per-row **Delay (embedded)** trims one video source's own
+  embedded track, and **A/V Offset (embedded)** is the measured number to trim it
+  against - positive means audio is early by that many milliseconds.
+
+Trim off air. Lowering a delay pushes the timestamp backward once and briefly
+glitches that source.
+
+---
+
+### Talkback: the key says live but nobody hears me
+
+The Zoom Talkback dock is new, and the failure modes are all silent in Zoom's
+own API.
+
+- **The banner reads "ON AIR - BOT MUTED".** Zoom refused to unmute CoreVideo's
+  microphone, and sends are accepted while delivering nothing. Ask the host to
+  unmute CoreVideo.
+- **A cell reads "not in channel".** They have a channel but are not in it -
+  most often because they are in a different breakout room. Talkback reaches only
+  the room the engine is in.
+- **A cell reads "no talkback".** Their Zoom client reported no talkback support,
+  or the channel budget could not cover them.
+- **A cell reads "no channel" or "assigning...".** Nobody is reachable until
+  channels are assigned. Open **Edit talent**, tick who you may need to talk to,
+  and press **Assign channels**. Zoom allows 16 channels and 10 people per
+  channel; the plan report names anyone the budget could not cover.
+- **Assigning takes a while.** Zoom rate-limits channel and invite calls, so
+  CoreVideo paces them at one every 600 ms. A large talent list can take around
+  20 seconds to fully provision. That cost is paid once, at assignment, and never
+  at key time.
+- **Nothing is keyable until you choose a talk source.** Pick the OBS audio
+  source you talk through in the dock's source combo, and check the line beneath
+  it: it tells you whether that source is also going out on a program track,
+  which the audience would hear.
 
 ---
 
 ### Auto-reconnect triggers but never succeeds
 
-**Cause:** The underlying error (auth failure, app entitlement issue, network) is permanent.
+**Cause:** the underlying error is permanent.
 
 **Fix:**
-1. Check the OBS log for the `RecoveryReason` and error codes.
-2. If the reason is `LicenseError`, see the raw-data permission or stream-count issue above.
-3. If the reason is `AuthFailure`, sign out and sign back in from **Tools -> Zoom Plugin Settings**.
-4. Click **Cancel Recovery** in the Zoom Control dock, resolve the root cause, then re-join manually.
+1. Check the OBS log for the line saying why recovery stopped - for example
+   `License error - reconnect not attempted`, `Auth failure - reconnect
+   suppressed by policy`, `Host ended meeting - not reconnecting`, or
+   `Engine crash - reconnect suppressed by policy`. Every path that declines to
+   reconnect logs its own reason.
+2. On a license error, see the raw-data entitlement note below.
+3. On an auth failure, sign out and back in from **Tools -> Zoom Plugin
+   Settings**.
+4. Click **Cancel Recovery** in the Zoom Control dock, fix the root cause, and
+   join again. Cancel stops the reconnect timers, stops the engine, and clears
+   the stored session so the retry loop cannot restart itself.
+
+---
+
+### Raw-data permission or stream-count error at runtime
+
+**Cause:** raw data access comes with Meeting SDK apps, but the signed-in account
+and app entitlements still determine negotiated quality, bandwidth, and stream
+count. Standard accounts are typically limited to a 30 Mbps incoming video
+budget; Enhanced Media / HBM can raise that to roughly 100 Mbps. Developers may
+also need an app-level entitlement flag to test more than a small number of
+concurrent raw streams.
+
+**Fix:** verify the Meeting SDK app is approved or beta-enabled for the account
+joining the meeting, then confirm the expected bandwidth and developer/app
+entitlements with Zoom. Treat Enhanced Media / HBM as a production quality and
+bandwidth tier, not as a hard prerequisite for raw data.
+
+---
+
+### ISO recording produces nothing, or a short file
+
+1. `ffmpeg` must be on `PATH`, or given explicitly as `ffmpeg_path`. The ISO
+   Recorder dock has a test button for it.
+2. Read the `.ffmpeg.log` beside the output files.
+3. The encoder demotion chain is NVENC -> QSV -> AMF -> libx264. If your machine
+   has no working QSV or AMF runtime, a source demoted off NVENC now walks the
+   chain all the way to libx264 rather than getting stuck (fixed in v0.1.42).
+4. Recording is blocked below 2 GB free on the output volume and warns below
+   10 GB.
+5. ISO durations that did not match real elapsed time, and WAVs that were double
+   or half length, were fixed in v0.1.42 and v0.1.43. If you see either, check
+   your version first.
 
 ---
 
 ### TCP or OSC control API not responding
 
-**Fix:**
-1. Confirm port numbers in **Tools -> Zoom Plugin Settings** match your client (defaults: TCP 19870, OSC 19871).
-2. Both servers bind to `127.0.0.1` (loopback) - external connections are not supported by default.
-3. Check for `TCP control server unavailable` or `OSC server unavailable` in the OBS log - another process may own the port.
+1. Confirm the ports in **Tools -> Zoom Plugin Settings** match your client.
+   Defaults are TCP `19870` and UDP OSC `19871`.
+2. Both servers bind to `127.0.0.1` only. A control surface on another machine
+   cannot reach them; put a local bridge on the OBS machine.
+3. Look for `TCP control server unavailable` or `OSC server unavailable` in the
+   OBS log - another process may already own the port. Neither failure stops the
+   plugin loading.
+4. If you set a token in settings, every TCP command line must carry a `"token"`
+   field. With no token set, authentication is disabled and the plugin logs a
+   warning saying so - the OSC server has no authentication at all either way.
+   Both are loopback-only, but any local process can drive them.
 
 ---
 
-## Feature Requests
+## Known limitations
 
-Feature requests are welcome as GitHub issues. Search existing issues first. Label your request `enhancement`.
+- **v0.1.43 was built and verified but never published.** Anyone tracking
+  releases goes from v0.1.42 straight to v0.1.44, which contains both.
+- **The installer is not code-signed**, so Windows SmartScreen flags it on first
+  run.
+- **The embedded audio track** on a video source has no loss accounting and is
+  stamped at arrival. Use the dedicated CoreVideo Audio sources for critical
+  audio.
+- **The intercom / talkback dock is newer than v0.1.44** and is not in a tagged
+  release yet. It is on `main` and ships next. Talkback has no OSC addresses,
+  no Companion actions, and no OBS hotkey yet - the dock and the TCP control API
+  are the only keying surfaces.
+- **macOS and Linux are source-build only.** There are no official packages, no
+  QA, and no supported upgrade path.
+- **`COREVIDEO_TALKBACK_LAYOUT_TEST`** is a developer instrument that fills the
+  Talkback dock with a fake cast and refuses every engine call. Never set it on a
+  show machine.
 
 ---
 
 ## Zoom Bandwidth and Enhanced Media / HBM
 
-CoreVideo does not require Enhanced Media / HBM simply to access Meeting SDK raw data. Quality and concurrency are still bounded by Zoom account and app entitlements:
+CoreVideo does not require Enhanced Media / HBM simply to access Meeting SDK raw
+data. Quality and concurrency are still bounded by Zoom account and app
+entitlements:
 
 - Standard accounts commonly operate within a 30 Mbps incoming video envelope.
 - Enhanced Media / HBM can raise the incoming video envelope to roughly 100 Mbps.
 - Standard 1080p feeds are typically about 4-6 Mbps each.
-- 100 Mbps can support roughly 16 standard 1080p feeds, or about 8 high-bitrate / 60 fps feeds.
-- Developers may need a separate app entitlement flag for testing more than a small number of raw streams; end users should not need that developer flag.
+- 100 Mbps can support roughly 16 standard 1080p feeds, or about 8 high-bitrate /
+  60 fps feeds.
+- Developers may need a separate app entitlement flag for testing more than a
+  small number of raw streams; end users should not need that developer flag.
 
 ---
 
-## Security
+## Feature Requests
 
-For security vulnerabilities, **do not open a public issue**. See [SECURITY.md](https://github.com/iamfatness/CoreVideo/blob/main/SECURITY.md) for the responsible disclosure process.
+Feature requests are welcome as GitHub issues. Search existing issues first, and
+label your request `enhancement`. What is already planned is in the
+[Roadmap](https://github.com/iamfatness/CoreVideo/blob/main/docs/ROADMAP.md).

--- a/wiki/Terms-of-Use.md
+++ b/wiki/Terms-of-Use.md
@@ -1,6 +1,6 @@
 # Terms of Use
 
-_Last updated: May 2026_
+_Last updated: September 2026_
 
 ## 1. Acceptance
 
@@ -10,7 +10,7 @@ By installing, configuring, or using CoreVideo ("the Plugin"), you agree to thes
 
 ## 2. License
 
-CoreVideo is released under the terms of its open-source license (see [LICENSE](https://github.com/iamfatness/CoreVideo/blob/main/LICENSE) in the repository). You are free to use, modify, and redistribute the Plugin in accordance with that license.
+CoreVideo is released under the **MIT License** (see [LICENSE](https://github.com/iamfatness/CoreVideo/blob/main/LICENSE) in the repository). You are free to use, modify, and redistribute the Plugin in accordance with that license.
 
 ---
 


### PR DESCRIPTION
`wiki/` was last touched 2026-08-02 and `docs/CORE_PLUGIN_FUNCTIONALITY.md` 2026-08-13. Five releases and a whole shipped feature had accumulated outside the docs. Everything here was verified against the code at `d99183d`, not from memory.

These files are both the GitHub wiki and the source of four corevideo.io pages (`/support/`, `/terms/`, `/privacy/`, `/core-plugin/`). `wiki/Home.md` is wiki-only — the site's home page is generated by `homeContent()` in the JS and ignores it.

## Instructions that were WRONG

These mattered more than the thin sections, because each one sends an operator to something that is not there.

| Where | Claim | Truth |
|---|---|---|
| `Support.md` | Linked `/documentation/#installation` | That anchor has never existed. The page has `#adding` and `#requirements`. |
| `OPERATOR_QUICKSTART.md` | "Open **Zoom Control**. Click **Sign in with Zoom**." | Sign in / Sign out are in `zoom-settings-dialog.cpp`, i.e. **Tools > Zoom Plugin Settings**. The dock has no sign-in button (`zoom-dock.cpp` registers Join, Leave, Start/Stop Engine, Open Output Manager, Cancel Recovery, Take, Release). |
| `CORE_PLUGIN_FUNCTIONALITY.md` | "Use **Auto Zoom sign-in** for the published broker-backed flow." | No such string exists anywhere in the tree. The real control is the join-token dropdown, whose default item is "Zoom sign-in". |
| `Support.md` | "Confirm `ZoomObsEngine` is in the same directory as the plugin." | `engine_executable_path()` looks in `zoom-runtime\` first. A DLL-only copy is this project's canonical mistake, so the step now names both binaries and points at the bundle's `runtime-manifest.json`. |
| `Home.md` | "macOS beta (Apple Silicon) + install guide" as a live quick link | The only macOS bundle ever published is `v0.1.32-beta.1`. README's own platform table says macOS is source-build-only, unsupported, no packages. |
| `Support.md` | Suggested `Refresh` "in the participant list" | The control is **Refresh participant list**, in the source's properties. |
| `CORE_PLUGIN_FUNCTIONALITY.md` | "In `v0.1.18` it is a persistent OBS dock" | Vestigial version-pinning; removed. |

## Talkback

Documented nowhere before this. Now covered in the plugin guide, the quickstart, and Support:

- Channels are created at **assignment** time; a key press only selects a standing one. Assignment takes ~20s for a large list because Zoom rate-limits membership calls and the ladder paces at one per 600ms — stated as a cost, since operators will otherwise think it hung.
- The 16-channel / 10-member budget, and that the plan report names anyone it could not cover.
- Every cell state (`ready` / `ON AIR` / `assigning...` / `no channel` / `not in channel` / `no talkback` / `some missed`) and what to do about each.
- The three delivery laws: sends are accepted-but-silent while CoreVideo's own mic is muted (hence the `ON AIR - BOT MUTED` banner), talkback reaches only the engine's own breakout room, and stereo sends succeed silently so everything is downmixed to mono.
- The `talkback_nominate` / `talkback_key` / `talkback_renew` / `talkback_status` / `talkback_probe` control API, including that dock keys do not renew and control-API keys must.
- That the probe plays an audible tone to a real participant.

**Marked throughout as newer than v0.1.44**, because it is: `1d1ff3e`, `429eba9` and `d99183d` all land after `7306809 chore: cut v0.1.44`, so it is on `main` and not in the shipped installer. Documenting it as available would have been its own wrong claim.

## Also brought current

The two audio paths and which one to route to program; the delay and A/V-offset controls; ISO video pacing / audio gap-fill and the `.ffmpeg.log` sidecar; the encoder demotion chain reaching libx264; the ghost-engine sweep; breakout-room permission revocation; the waiting-room watchdog; the same-account host collision (`account_busy_elsewhere` / `909001`); `CV_ZOOM_VERBOSE_LOG`; the Companion module and its by-name participant model; and where support bundles actually land, with what they do and do not redact.

## Legal pages — please review

Checked for factual drift only. No legal language was invented.

**Changed in `Privacy-Policy.md`:**
- **New "Talkback (Intercom) Audio" section.** This is a genuinely new *outward* data flow — the operator's chosen OBS audio source is sent to Zoom — and the policy previously said only that media is never transmitted anywhere. Worth a careful read. Note it describes a capability that is on `main` but not in v0.1.44; I erred toward over-disclosure.
- **New "GitHub (Update Check)" section.** CoreVideo makes one anonymous request per OBS session to `api.github.com/repos/iamfatness/CoreVideo/releases/latest`. This was already disclosed in `docs/policies/privacy-policy.md` §4.3 but had **never** been in the published policy. Wording is taken from that document.
- New "Recordings You Make": ISO output, FFmpeg logs, support bundles, and the Zoom SDK's own logging/dumps (`enableLogByDefault` / `enableGenerateDump` in `engine/src/main.cpp`) — all local, none uploaded, and a note that a bundle redacts credentials but **not** participant names or file paths.
- Credential storage locations corrected: settings live in OBS's global config under `[ZoomPlugin]`, not the plugin config directory. "TCP/OSC API clients" narrowed to TCP — the OSC server has no authentication at all.
- Last-updated date.

**Changed in `Terms-of-Use.md`:** named the MIT License, and the date. Nothing else.

**Not changed, needs a human decision:**
1. **Terms say nothing about talkback.** §5 covers consent to *capture*; talkback *transmits* into the meeting, and the probe plays audible audio to a named participant. That is a drafting decision, not a factual correction, so I left it alone.
2. **`build-site.mjs` describes `/terms/` as covering "the CoreVideo OBS Studio plugin and CoreVideo Pro"**, but the Terms body only ever says "the Plugin". Either the description or the document is wrong. I did not guess which — and I do not own that file.
3. **`docs/policies/*.md`** (CVP-0x, the Marketplace compliance set) carry the same talkback gap. They have Document IDs, version numbers, effective dates and an annual review cycle, so bumping them is a human call. Left untouched.

## Notes for whoever merges

- **`CHANGELOG.md` `[Unreleased]` is empty** — talkback has no changelog entry. I left it alone rather than write release notes for someone else's feature, but it should get one before the next tag.
- **`scripts/build-site.mjs`'s markdown renderer emits no heading `id`s**, so in-page anchors (`[X](#x)`) work on the GitHub wiki and are dead on the site. I avoided them; worth fixing in the renderer.
- **`docs/index.html` (`/documentation/#mac-beta`) still tells people to get "the latest `CoreVideo-…-macOS-arm64.zip`" from Releases.** There isn't one after `v0.1.32-beta.1`. Not a file I own.
- I ran `node scripts/build-site.mjs` to confirm every page renders and reverted the generated `public/` — no generated output is in this PR.
- Expect a rebase: a second agent is concurrently rewriting the JS-rendered pages in the same file I deliberately did not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usc57QDDr12JdNRRPc2spM