### PR TITLE
Bring two meta descriptions inside the SEO gate

### DIFF
--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CoreVideo Pro | CoreVideo</title>
-  <meta name="description" content="CoreVideo Pro is a standalone Windows and macOS studio for live Zoom production - scenes, participant management, recording, streaming, and AI auto-direct. In development; not yet released.">
+  <meta name="description" content="A standalone Windows studio for live Zoom production: scenes, participant management, recording, streaming and AI auto-direct. In development, not yet released.">
   <meta name="theme-color" content="#0a0b0c">
   <link rel="icon" href="/favicon.svg">
   <link rel="preload" href="/assets/fonts/SpaceGrotesk-var.woff2" as="font" type="font/woff2" crossorigin>
@@ -13,7 +13,7 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="CoreVideo">
   <meta property="og:title" content="CoreVideo Pro | CoreVideo">
-  <meta property="og:description" content="CoreVideo Pro is a standalone Windows and macOS studio for live Zoom production - scenes, participant management, recording, streaming, and AI auto-direct. In development; not yet released.">
+  <meta property="og:description" content="A standalone Windows studio for live Zoom production: scenes, participant management, recording, streaming and AI auto-direct. In development, not yet released.">
   <meta property="og:image" content="https://corevideo.io/assets/corevideo-share.jpg">
   <meta property="og:image:alt" content="CoreVideo - Zoom participant video and audio as native OBS Studio sources">
   <meta property="og:image:width" content="1200">
@@ -22,7 +22,7 @@
   <meta property="og:url" content="https://corevideo.io/pro/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="CoreVideo Pro | CoreVideo">
-  <meta name="twitter:description" content="CoreVideo Pro is a standalone Windows and macOS studio for live Zoom production - scenes, participant management, recording, streaming, and AI auto-direct. In development; not yet released.">
+  <meta name="twitter:description" content="A standalone Windows studio for live Zoom production: scenes, participant management, recording, streaming and AI auto-direct. In development, not yet released.">
   <meta name="twitter:image" content="https://corevideo.io/assets/corevideo-share.jpg">
   <meta name="twitter:image:alt" content="CoreVideo - Zoom participant video and audio as native OBS Studio sources">
   <link rel="stylesheet" href="/assets/site.css">

--- a/public/zcomms/index.html
+++ b/public/zcomms/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ZComms - Zoom Talkback &amp; Intercom Station for Live Production</title>
-  <meta name="description" content="ZComms is a standalone Windows talkback and IFB station for Zoom productions: named talk keys, 16 private talkback channels, extern feeds from a multichannel interface, and breakout-aware routing.">
+  <meta name="description" content="Standalone Windows talkback and IFB station for Zoom: named talk keys, 16 private channels, extern feeds from a multichannel interface, breakout-aware.">
   <meta name="theme-color" content="#0a0b0c">
   <link rel="icon" href="/favicon.svg">
   <link rel="preload" href="/assets/fonts/SpaceGrotesk-var.woff2" as="font" type="font/woff2" crossorigin>
@@ -13,7 +13,7 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="CoreVideo">
   <meta property="og:title" content="ZComms - Zoom Talkback &amp; Intercom Station for Live Production">
-  <meta property="og:description" content="ZComms is a standalone Windows talkback and IFB station for Zoom productions: named talk keys, 16 private talkback channels, extern feeds from a multichannel interface, and breakout-aware routing.">
+  <meta property="og:description" content="Standalone Windows talkback and IFB station for Zoom: named talk keys, 16 private channels, extern feeds from a multichannel interface, breakout-aware.">
   <meta property="og:image" content="https://corevideo.io/assets/corevideo-share.jpg">
   <meta property="og:image:alt" content="CoreVideo - Zoom participant video and audio as native OBS Studio sources">
   <meta property="og:image:width" content="1200">
@@ -22,7 +22,7 @@
   <meta property="og:url" content="https://corevideo.io/zcomms/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="ZComms - Zoom Talkback &amp; Intercom Station for Live Production">
-  <meta name="twitter:description" content="ZComms is a standalone Windows talkback and IFB station for Zoom productions: named talk keys, 16 private talkback channels, extern feeds from a multichannel interface, and breakout-aware routing.">
+  <meta name="twitter:description" content="Standalone Windows talkback and IFB station for Zoom: named talk keys, 16 private channels, extern feeds from a multichannel interface, breakout-aware.">
   <meta name="twitter:image" content="https://corevideo.io/assets/corevideo-share.jpg">
   <meta name="twitter:image:alt" content="CoreVideo - Zoom participant video and audio as native OBS Studio sources">
   <link rel="stylesheet" href="/assets/site.css">

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -988,7 +988,7 @@ writeText(
     {
       title: "CoreVideo Pro",
       description:
-        "CoreVideo Pro is a standalone Windows and macOS studio for live Zoom production - scenes, participant management, recording, streaming, and AI auto-direct. In development; not yet released.",
+        "A standalone Windows studio for live Zoom production: scenes, participant management, recording, streaming and AI auto-direct. In development, not yet released.",
     },
     proPageContent(),
     {
@@ -1028,7 +1028,7 @@ writeText(
       title: "ZComms",
       seoTitle: "ZComms - Zoom Talkback & Intercom Station for Live Production",
       description:
-        "ZComms is a standalone Windows talkback and IFB station for Zoom productions: named talk keys, 16 private talkback channels, extern feeds from a multichannel interface, and breakout-aware routing.",
+        "Standalone Windows talkback and IFB station for Zoom: named talk keys, 16 private channels, extern feeds from a multichannel interface, breakout-aware.",
     },
     zcommsPageContent(),
     {


### PR DESCRIPTION
#237's deploy failed at `check-site-seo.mjs` before publishing anything — meta descriptions are held to 50–165 chars and the new ZComms page came in at 196, Pro at 189.

The gate did its job: the site was never updated, which is why corevideo.io still says the Windows installer is signed.

Trimmed both without losing the load-bearing claims. Pro's also drops "and macOS" — macOS parity is one of the unverified Pro claims, and the last macOS asset published anywhere was v0.1.32-beta.1.

Local: `node scripts/build-site.mjs` then `check-site-seo.mjs` → **SEO check passed: 13 pages, 10 canonical URLs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usc57QDDr12JdNRRPc2spM