### PR TITLE
Developer ID signing, hardened runtime and notarization for macOS

### DIFF
--- a/scripts/macos-engine.entitlements
+++ b/scripts/macos-engine.entitlements
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for ZoomObsEngine.app, the process that links the Zoom Meeting
+  SDK. NOT for the plugin bundle: only the engine links the ZoomSDK framework
+  (see CMakeLists.txt), the plugin reaches it over a socket, and an entitlement
+  a binary does not need is attack surface it should not carry.
+
+  NOTE ON STYLE: no double hyphens anywhere in this comment. XML forbids them
+  inside comments and Apple's AMFIUnserializeXML enforces that strictly, so a
+  double hyphen here fails every codesign call with a bare "syntax error near
+  line N" that names the entitlements file and nothing else. This file is
+  parsed by a stricter reader than most XML you will write.
+
+  disable-library-validation is LOAD BEARING. It is finding #1 of the whole
+  macOS port restated as a signing requirement: ZoomSDK.framework is not self
+  contained, and at auth it loads sibling BUNDLES (ssb_sdk, zNet, zPTUIEx and
+  others) through the MAIN BUNDLE's Contents/Frameworks directory, not via
+  rpath and not relative to the framework. Library validation is precisely the
+  mechanism that refuses that load, and the hardened runtime (mandatory for
+  notarization) turns it on.
+
+  Without this entitlement the failure is the one that already cost days once:
+  initSDK returns Success, getAuthService returns a live object, and sdkAuth
+  returns Failed(1) SYNCHRONOUSLY with no delegate callback ever firing. It is
+  also invisible until the build is DISTRIBUTED, because a locally signed dev
+  build of the same code runs fine, so nothing short of signing and launching
+  the real artifact can catch it.
+
+  The two device entitlements are for the SDK's own UI, which is shown on
+  purpose so the operator can pick a camera and admit waiting room
+  participants. TCC still needs the matching NSCameraUsageDescription and
+  NSMicrophoneUsageDescription strings in the engine app's Info.plist: these
+  entitlements permit the access, the strings are what the prompt says.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/make-macos-bundle.sh
+++ b/scripts/make-macos-bundle.sh
@@ -21,9 +21,22 @@
 #                     Fast for local iteration; NOT distributable.
 #   --install         Also copy into ~/Library/Application Support/obs-studio/plugins
 #   --sign IDENTITY   codesign identity (default: "-", ad-hoc)
+#   --entitlements F  Engine entitlements plist
+#                     (default: scripts/macos-engine.entitlements)
+#   --notarize PROF   After signing, submit to Apple with notarytool using this
+#                     stored credential profile, then staple the ticket.
+#                     Requires a real --sign identity; refuses on ad-hoc.
 #
-# Ad-hoc signing is fine for local runs. A distributable build needs a Developer
-# ID identity plus notarization, which this script does not do.
+# Ad-hoc signing is fine for local runs. A DISTRIBUTABLE build needs
+# --sign "Developer ID Application: ..." and --notarize.
+#
+# Signing a real identity turns on the hardened runtime, which notarization
+# requires -- and which is also what makes the Zoom SDK's nested code need
+# signing individually. Sealing it inside the engine app is NOT enough: Apple
+# requires every executable item to carry its own Developer ID signature, and
+# the SDK ships ~98 frameworks/bundles/dylibs. They are signed deepest-first,
+# because signing a container seals its contents and any signature applied
+# inside afterwards invalidates that seal.
 
 set -euo pipefail
 
@@ -36,6 +49,8 @@ ZOOM_SDK="${ZOOM_SDK_DIR:-$HOME/Developer/zoom-sdk-macos}"
 LINK_SDK=0
 DO_INSTALL=0
 SIGN_ID="-"
+ENTITLEMENTS=""
+NOTARIZE_PROFILE=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -45,12 +60,26 @@ while [ $# -gt 0 ]; do
         --obs-app)   OBS_APP="$2";   shift 2 ;;
         --zoom-sdk)  ZOOM_SDK="$2";  shift 2 ;;
         --sign)      SIGN_ID="$2";   shift 2 ;;
+        --entitlements) ENTITLEMENTS="$2"; shift 2 ;;
+        --notarize)  NOTARIZE_PROFILE="$2"; shift 2 ;;
         --link-sdk)  LINK_SDK=1;     shift ;;
         --install)   DO_INSTALL=1;   shift ;;
         -h|--help)   sed -n '2,31p' "$0"; exit 0 ;;
         *) echo "error: unknown argument '$1'" >&2; exit 2 ;;
     esac
 done
+
+# Validated HERE, before anything is built: these combinations can only fail,
+# and finding that out after a full bundle assembly (and, with --notarize, a
+# 612 MB upload) wastes minutes to say something knowable at argument time.
+if [ -n "$NOTARIZE_PROFILE" ]; then
+    [ "$SIGN_ID" != "-" ] || {
+        echo "error: --notarize needs a real --sign identity; Apple rejects" >&2
+        echo "       ad-hoc signatures." >&2; exit 2; }
+    [ "$LINK_SDK" -eq 0 ] || {
+        echo "error: --notarize cannot be combined with --link-sdk (a symlinked" >&2
+        echo "       SDK is not sealable and not distributable)." >&2; exit 2; }
+fi
 
 [ -n "$BUILD_DIR" ] || { echo "error: --build-dir is required" >&2; exit 2; }
 [ -d "$BUILD_DIR" ] || { echo "error: build dir '$BUILD_DIR' does not exist" >&2; exit 2; }
@@ -210,16 +239,63 @@ for f in "$BUNDLE/Contents/MacOS/plugins/tls/"*.dylib; do
     [ -f "$f" ] && repoint_rpaths "$f"
 done
 
+ENTITLEMENTS="${ENTITLEMENTS:-$SRC_DIR/scripts/macos-engine.entitlements}"
+
+# The hardened runtime is what notarization requires and what ad-hoc signing
+# cannot carry (--timestamp needs a real identity and would fail offline), so
+# these are added only for a genuine Developer ID run. That keeps the local
+# ad-hoc path exactly as fast as it was.
+CS_HARDENED=()
+if [ "$SIGN_ID" != "-" ]; then
+    CS_HARDENED=(--options runtime --timestamp)
+fi
+
+sign_one() {  # sign_one <path> [extra codesign args…]
+    local path="$1"; shift
+    # ${arr[@]+"${arr[@]}"}, not a bare "${arr[@]}": macOS ships bash 3.2, where
+    # expanding an EMPTY array under `set -u` is an unbound-variable error. The
+    # ad-hoc path is exactly the empty case, so the plain form breaks every
+    # local build while working fine on any newer bash you might test with.
+    codesign --force --sign "$SIGN_ID" \
+        ${CS_HARDENED[@]+"${CS_HARDENED[@]}"} "$@" "$path"
+}
+
 # Sign nested code BEFORE the enclosing bundle: signing the outer bundle seals
 # its contents, so signing anything inside afterwards invalidates that seal.
+#
+# The SDK first, and this is the part that ad-hoc signing let us skip. Sealing
+# ZoomSDK.framework inside the engine app is NOT a signature on the ~98
+# frameworks/bundles/dylibs it ships; notarization rejects any executable item
+# that does not carry one of its own. `find -depth` yields contents before
+# their containers, which is exactly the inside-out order codesign needs -- do
+# not "simplify" it to a plain find.
+#
+# Skipped for --link-sdk: that tree is a symlink to a shared 612 MB SDK that is
+# not ours to re-sign, and those builds are dev-only and unsealable anyway.
+if [ "$SIGN_ID" != "-" ] && [ "$LINK_SDK" -eq 0 ] && \
+   [ -d "$ENGINE_APP/Contents/Frameworks" ]; then
+    echo "signing nested SDK code (this takes a minute)…"
+    sdk_signed=0
+    while IFS= read -r item; do
+        sign_one "$item"
+        sdk_signed=$((sdk_signed + 1))
+    done < <(find "$ENGINE_APP/Contents/Frameworks" -depth \
+                  \( -name "*.framework" -o -name "*.bundle" \
+                     -o -name "*.dylib" -o -name "*.app" \))
+    echo "signed $sdk_signed nested SDK items"
+fi
+
 for f in "$BUNDLE/Contents/MacOS/plugins/tls/"*.dylib; do
-    [ -f "$f" ] && codesign --force --sign "$SIGN_ID" "$f"
+    [ -f "$f" ] && sign_one "$f"
 done
+# The engine is the only binary that links the Zoom SDK, so it is the only one
+# that needs disable-library-validation -- see the entitlements file. Giving the
+# whole bundle that entitlement would be handing it to OBS's process for free.
 [ -d "$ENGINE_APP" ] && \
-    codesign --force --sign "$SIGN_ID" "$ENGINE_APP"
+    sign_one "$ENGINE_APP" --entitlements "$ENTITLEMENTS"
 [ -d "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app" ] && \
-    codesign --force --sign "$SIGN_ID" "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app"
-codesign --force --sign "$SIGN_ID" "$BUNDLE"
+    sign_one "$BUNDLE/Contents/MacOS/CoreVideoOAuthCallback.app"
+sign_one "$BUNDLE"
 # A symlinked SDK is deliberately unsealable, so --strict would fail on exactly
 # the builds we know are dev-only. Verify the real thing; say so for the other.
 if [ "$LINK_SDK" -eq 1 ]; then
@@ -229,6 +305,36 @@ else
 fi
 
 echo "built: $BUNDLE (version $VERSION)"
+
+# ── Notarization ──────────────────────────────────────────────────────────
+#
+# notarytool takes an archive, never a bare bundle, but the TICKET is stapled
+# to the BUNDLE. So: zip a copy for submission, staple the real bundle, and
+# leave re-zipping for distribution to the caller -- the submitted zip does not
+# contain the ticket and must not be the artifact anyone ships.
+#
+# Stapling matters offline: without the ticket, first launch does a network
+# round-trip to Gatekeeper, and a tester with no connection is refused.
+if [ -n "$NOTARIZE_PROFILE" ]; then
+    # The --sign / --link-sdk preconditions were checked at argument time.
+    SUBMIT_ZIP="$(mktemp -d)/$(basename "$BUNDLE").zip"
+    # ditto --keepParent, not `zip`: it preserves symlinks and resource forks,
+    # and a bundle flattened by plain zip fails notarization for structure.
+    ditto -c -k --keepParent "$BUNDLE" "$SUBMIT_ZIP"
+
+    echo "submitting to Apple (612 MB of SDK — expect several minutes)…"
+    xcrun notarytool submit "$SUBMIT_ZIP" \
+        --keychain-profile "$NOTARIZE_PROFILE" --wait
+
+    xcrun stapler staple "$BUNDLE"
+    xcrun stapler validate "$BUNDLE"
+    # The question a tester's Mac actually asks. `-t install` is the right
+    # assessment type for a bundle that is installed rather than launched.
+    spctl --assess -vvv -t install "$BUNDLE" || \
+        echo "note: spctl assessment above is advisory for a plugin bundle"
+    rm -rf "$(dirname "$SUBMIT_ZIP")"
+    echo "notarized and stapled: $BUNDLE"
+fi
 
 if [ "$DO_INSTALL" -eq 1 ]; then
     DEST="$HOME/Library/Application Support/obs-studio/plugins"


### PR DESCRIPTION
Unblocks the last hard item on the macOS beta: the owner now has an Apple Developer account.

## What ad-hoc signing was hiding

Sealing `ZoomSDK.framework` inside the engine app is **not** a signature on the **~98 frameworks, bundles and dylibs** it ships. Notarization rejects any executable item without a Developer ID signature of its own, so this was never "add `--sign` and call notarytool".

They are signed with `find -depth`, which yields contents before their containers — the inside-out order codesign requires, since signing a container seals it and anything signed inside afterwards invalidates that seal.

## Entitlements go on the engine only

It is the sole binary that links the Zoom SDK; giving the plugin bundle `disable-library-validation` would hand it to OBS's process for free.

That entitlement is **load bearing, not precautionary**. Finding #1 of the whole port was that `ZoomSDK.framework` loads sibling bundles through the main bundle's `Contents/Frameworks` — not rpath, not relative to the framework. Library validation is exactly the mechanism that refuses that, and the hardened runtime (mandatory for notarization) turns it on. Without it you get the original silent failure back: `initSDK` Success, `getAuthService` live, `sdkAuth` `Failed(1)` synchronously with no callback ever firing — and it is invisible until the build is *distributed*, because a locally signed dev build of the same code runs fine.

## Three bugs found by running it, not reading it

- **macOS ships bash 3.2**, where expanding an empty array under `set -u` is an unbound-variable error. The ad-hoc path *is* the empty case, so a bare `"${CS_HARDENED[@]}"` broke every local build while working fine on newer bash.
- **XML forbids `--` inside comments** and `AMFIUnserializeXML` enforces it. The rationale prose in the entitlements file failed every codesign call with a bare `syntax error near line 13` naming only the file. The file now warns about this at the top.
- **The `--notarize` guards fired only after a full bundle assembly.** Both preconditions are knowable at argument time; with a 612 MB upload behind them that is minutes per mistake.

## Notarization shape

Submits a `ditto` archive but staples the **bundle** — the submitted zip never contains the ticket and must not be shipped. Stapling is what lets a tester's first launch work offline.

## Status

Local ad-hoc path verified unchanged. Entitlements confirmed present on `ZoomObsEngine.app` and absent from the plugin bundle.

**Not yet exercised against a real Developer ID identity** — no certificate is installed on the build machine yet (`security find-identity` reports 0). Expect one or two entitlement round-trips once it is. Porting the proven recipe into `release-macos.yml` is deliberately a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)